### PR TITLE
feat: screen tracking and automatic screen tracking

### DIFF
--- a/ios/CustomerioReactnative.m
+++ b/ios/CustomerioReactnative.m
@@ -20,5 +20,7 @@ RCT_EXTERN_METHOD(config : (nonnull NSDictionary *) data)
 
 RCT_EXTERN_METHOD(setProfileAttributes : (nonnull NSDictionary *) data)
 
+RCT_EXTERN_METHOD(screen: (nonnull NSString *) name
+                  data : (NSDictionary *) data)
 
 @end

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -77,5 +77,15 @@ class CustomerioReactnative: NSObject {
     func setProfileAttributes(data: Dictionary<String, AnyHashable>) -> Void{
         CustomerIO.shared.profileAttributes = data
     }
+    
+    @objc(screen:data:)
+    func screen(name : String, data : Dictionary<String, AnyHashable>?) -> Void {
+        
+        guard let body = data else {
+            CustomerIO.shared.screen(name: name)
+            return
+        }
+        CustomerIO.shared.screen(name: name, data: body)
+    }
 }
 

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -48,6 +48,10 @@ class CustomerIO {
     static setProfileAttributes(data : Object) {
       CustomerioReactnative.setProfileAttributes(data)
     }
+
+    static screen(name : string, data : Object) {
+      CustomerioReactnative.screen(name, data)
+    }
   }
 
   export {


### PR DESCRIPTION
closes: https://github.com/customerio/issues/issues/7327

## About
This PR provides flexibility to the customer to send screen events both manually and automatically. The customer can send screen events with or without additional yet optional data.

## Use case
**Manually send screen events :**
`CustomerIO.screen('ProfileScreen`)

**Enable automatic screen events :**
<img width="555" alt="Screenshot 2022-06-08 at 7 38 38 PM" src="https://user-images.githubusercontent.com/91549653/172638048-e445bcd2-5eaa-45fa-844e-bf348fe77c25.png">

## Screenshots
<img width="745" alt="Screenshot 2022-06-08 at 7 41 07 PM" src="https://user-images.githubusercontent.com/91549653/172638388-7a74f17d-09f1-4924-b816-77c97e58a2d2.png">

**Note** : Screen tracking in react native package is not a configurable property like `autoTrackDeviceAttributes`. Instead, if the user adds the above code in their navigation stack then the screen events are sent automatically as the user moves around the screens, provided the user has been identified.
