### PR TITLE
fix: change in way to update config in ios

### DIFF
--- a/ios/CustomerioReactnative.m
+++ b/ios/CustomerioReactnative.m
@@ -5,7 +5,7 @@
 RCT_EXTERN_METHOD(initialize: (nonnull NSString *) siteId
                   apiKey : (nonnull NSString *) apiKey
                   region : (NSString *) region
-                  config : (NSDictionary *) configData)
+                  configData : (NSDictionary *) configData)
 
 RCT_EXTERN_METHOD(identify: (nonnull NSString *) identifier
                   body : (NSDictionary *) body)
@@ -16,8 +16,6 @@ RCT_EXTERN_METHOD(track: (nonnull NSString *) name
                   data : (NSDictionary *) data)
 
 RCT_EXTERN_METHOD(setDeviceAttributes : (nonnull NSDictionary *) data)
-
-RCT_EXTERN_METHOD(config : (nonnull NSDictionary *) data)
 
 RCT_EXTERN_METHOD(setProfileAttributes : (nonnull NSDictionary *) data)
 

--- a/ios/CustomerioReactnative.m
+++ b/ios/CustomerioReactnative.m
@@ -4,7 +4,8 @@
 
 RCT_EXTERN_METHOD(initialize: (nonnull NSString *) siteId
                   apiKey : (nonnull NSString *) apiKey
-                  region : (NSString *) region)
+                  region : (NSString *) region
+                  config : (NSDictionary *) configData)
 
 RCT_EXTERN_METHOD(identify: (nonnull NSString *) identifier
                   body : (NSDictionary *) body)

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -11,8 +11,9 @@ class CustomerioReactnative: NSObject {
     /**
      Initialize the package before sending any calls to the package
      */
-    @objc(initialize:apiKey:region:)
-    func initialize(siteId: String, apiKey: String, region :String) -> Void {
+    @objc(initialize:apiKey:region:configData:)
+    func initialize(siteId: String, apiKey: String, region :String, configData: Dictionary<String, AnyHashable>?) -> Void {
+        print(configData)
         CustomerIO.initialize(siteId: siteId, apiKey: apiKey, region: Region.getLocation(from: region))
     }
     

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -12,9 +12,9 @@ class CustomerioReactnative: NSObject {
      Initialize the package before sending any calls to the package
      */
     @objc(initialize:apiKey:region:configData:)
-    func initialize(siteId: String, apiKey: String, region :String, configData: Dictionary<String, AnyHashable>?) -> Void {
-        print(configData)
+    func initialize(siteId: String, apiKey: String, region :String, configData: Dictionary<String, AnyHashable>) -> Void {
         CustomerIO.initialize(siteId: siteId, apiKey: apiKey, region: Region.getLocation(from: region))
+        config(data: configData)
     }
     
     /**
@@ -67,8 +67,7 @@ class CustomerioReactnative: NSObject {
     /**
      Configure properties like autoTrackDeviceAttributes, logLevel etc
 f     */
-    @objc(config:)
-    func config(data : Dictionary<String, AnyHashable>) -> Void{
+    private func config(data : Dictionary<String, AnyHashable>) -> Void{
         if let trackingApiUrl = data["trackingApiUrl"] as? String, !trackingApiUrl.isEmpty {
             CustomerIO.config {
                 $0.trackingApiUrl = trackingApiUrl

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -34,7 +34,7 @@ class CustomerIO {
    * @param region (Optional) Specifies region where your workspace data center is located
    * @returns 
    */
-    static initialize(siteId: string, apiKey: string, region: Region = Region.US) {
+    static initialize(siteId: string, apiKey: string, region: Region = Region.US, config: CustomerioConfig = new CustomerioConfig()) {
       return CustomerioReactnative.initialize(siteId, apiKey, region)
     }
 

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -34,9 +34,9 @@ class CustomerIO {
    * @param region (Optional) Specifies region where your workspace data center is located
    * @returns 
    */
-    static initialize(siteId: string, apiKey: string, region: Region = Region.US, config: CustomerioConfig = new CustomerioConfig()) {
-      return CustomerioReactnative.initialize(siteId, apiKey, region)
-    }
+   static initialize(siteId: string, apiKey: string, region: Region = Region.US, config: CustomerioConfig = new CustomerioConfig()) {
+    return CustomerioReactnative.initialize(siteId, apiKey, region, config)
+  }
 
     /**
      * Identify a person using a unique identifier, eg. email id.
@@ -80,15 +80,6 @@ class CustomerIO {
      */
     static setDeviceAttributes(data : Object) {
       CustomerioReactnative.setDeviceAttributes(data)
-    }
-
-    /**
-     * Configure package by updating the default values
-     * 
-     * @param data Update CustomerioConfig as configuration option 
-     */
-    static config(data : CustomerioConfig = new CustomerioConfig()) {
-      CustomerioReactnative.config(data)
     }
 
     /**


### PR DESCRIPTION
closes https://github.com/customerio/issues/issues/7791

Android SDK allows setting up config only during initialisation, but iOS SDK allows config setup later on too. To maintain consistency on both the platforms, react native package now allows setting up config on initialisation which is same for both the platforms.