### PR TITLE
fix: initialized sdk from storage using context

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,4 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.customer.reactnative.sdk">
 
+    <application>
+        <service
+            android:name=".service.CustomerIOReactNativeFCMService"
+            android:exported="false">
+            <intent-filter android:priority="-1">
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+    </application>
 </manifest>

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeInstance.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeInstance.kt
@@ -1,6 +1,16 @@
 package io.customer.reactnative.sdk
 
+import android.app.Application
+import android.content.Context
+import io.customer.messaginginapp.ModuleMessagingInApp
+import io.customer.messagingpush.MessagingPushModuleConfig
+import io.customer.messagingpush.ModuleMessagingPushFCM
+import io.customer.reactnative.sdk.constant.Keys
+import io.customer.reactnative.sdk.extension.*
+import io.customer.reactnative.sdk.storage.PreferencesStorage
 import io.customer.reactnative.sdk.util.ReactNativeConsoleLogger
+import io.customer.sdk.CustomerIO
+import io.customer.sdk.data.store.Client
 import io.customer.sdk.util.CioLogLevel
 import io.customer.sdk.util.Logger
 
@@ -14,4 +24,87 @@ object CustomerIOReactNativeInstance {
     fun setLogLevel(logLevel: CioLogLevel) {
         (logger as ReactNativeConsoleLogger).logLevel = logLevel
     }
+
+    internal fun initializeSDKFromContext(context: Context) {
+        if (CustomerIO.instanceOrNull() != null) return
+
+        try {
+            val preferencesStorage = PreferencesStorage(context = context)
+            initialize(
+                context = context,
+                environment = preferencesStorage.loadEnvironmentSettings(),
+                configuration = preferencesStorage.loadConfigurationSettings(),
+                sdkVersion = preferencesStorage.loadSDKVersion(),
+            )
+            logger.info("Customer.io instance initialized successfully from preferences")
+        } catch (ex: Exception) {
+            logger.error("Failed to initialize Customer.io instance from preferences, ${ex.message}")
+        }
+    }
+
+    @Throws(IllegalArgumentException::class)
+    internal fun initialize(
+        context: Context,
+        environment: Map<String, Any?>,
+        configuration: Map<String, Any?>?,
+        sdkVersion: String?,
+    ): CustomerIO {
+        val siteId = environment.getString(Keys.Environment.SITE_ID)
+        val apiKey = environment.getString(Keys.Environment.API_KEY)
+        val region = environment.getProperty<String>(
+            Keys.Environment.REGION
+        )?.takeIfNotBlank().toRegion()
+        val organizationId = environment.getProperty<String>(
+            Keys.Environment.ORGANIZATION_ID
+        )?.takeIfNotBlank()
+
+        return CustomerIO.Builder(
+            siteId = siteId,
+            apiKey = apiKey,
+            region = region,
+            appContext = context.applicationContext as Application,
+        ).apply {
+            setClient(Client.ReactNative(sdkVersion = sdkVersion ?: "n/a"))
+            setupConfig(configuration)
+            addCustomerIOModule(module = configureModuleMessagingPushFCM(configuration))
+            if (!organizationId.isNullOrBlank()) {
+                addCustomerIOModule(module = configureModuleMessagingInApp(organizationId))
+            }
+        }.build()
+    }
+
+    private fun CustomerIO.Builder.setupConfig(config: Map<String, Any?>?): CustomerIO.Builder {
+        if (config == null) return this
+
+        val logLevel = config.getProperty<Double>(Keys.Config.LOG_LEVEL).toCIOLogLevel()
+        setLogLevel(logLevel = logLevel)
+        setLogLevel(level = logLevel)
+        config.getProperty<String>(Keys.Config.TRACKING_API_URL)?.takeIfNotBlank()?.let { value ->
+            setTrackingApiURL(value)
+        }
+        config.getProperty<Boolean>(Keys.Config.AUTO_TRACK_DEVICE_ATTRIBUTES)?.let { value ->
+            autoTrackDeviceAttributes(shouldTrackDeviceAttributes = value)
+        }
+        config.getProperty<Double>(Keys.Config.BACKGROUND_QUEUE_MIN_NUMBER_OF_TASKS)?.let { value ->
+            setBackgroundQueueMinNumberOfTasks(backgroundQueueMinNumberOfTasks = value.toInt())
+        }
+        config.getProperty<Double>(Keys.Config.BACKGROUND_QUEUE_SECONDS_DELAY)?.let { value ->
+            setBackgroundQueueSecondsDelay(backgroundQueueSecondsDelay = value)
+        }
+        return this
+    }
+
+    private fun configureModuleMessagingPushFCM(config: Map<String, Any?>?): ModuleMessagingPushFCM {
+        return ModuleMessagingPushFCM(
+            config = MessagingPushModuleConfig.Builder().apply {
+                config?.getProperty<Boolean>(Keys.Config.AUTO_TRACK_PUSH_EVENTS)?.let { value ->
+                    setAutoTrackPushEvents(autoTrackPushEvents = value)
+                }
+            }.build(),
+        )
+    }
+
+    private fun configureModuleMessagingInApp(organizationId: String) = ModuleMessagingInApp(
+        organizationId = organizationId,
+    )
 }

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
@@ -1,18 +1,13 @@
 package io.customer.reactnative.sdk
 
-import android.app.Application
 import android.content.pm.ApplicationInfo
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
-import io.customer.messaginginapp.ModuleMessagingInApp
-import io.customer.messagingpush.MessagingPushModuleConfig
-import io.customer.messagingpush.ModuleMessagingPushFCM
-import io.customer.reactnative.sdk.constant.Keys
-import io.customer.reactnative.sdk.extension.*
+import io.customer.reactnative.sdk.extension.toMap
+import io.customer.reactnative.sdk.storage.PreferencesStorage
 import io.customer.sdk.CustomerIO
-import io.customer.sdk.data.store.Client
 import io.customer.sdk.util.CioLogLevel
 import io.customer.sdk.util.Logger
 
@@ -20,6 +15,7 @@ class CustomerIOReactNativeModule(
     reactContext: ReactApplicationContext,
 ) : ReactContextBaseJavaModule(reactContext) {
     private val logger: Logger = CustomerIOReactNativeInstance.logger
+    private val preferencesStorage = PreferencesStorage(context = reactContext)
     private lateinit var customerIO: CustomerIO
 
     init {
@@ -61,66 +57,23 @@ class CustomerIOReactNativeModule(
         val env = environment.toMap()
         val config = configuration?.toMap()
 
+        preferencesStorage.saveSettings(
+            environment = env,
+            configuration = config,
+            sdkVersion = sdkVersion
+        )
         try {
-            val siteId = env.getString(Keys.Environment.SITE_ID)
-            val apiKey = env.getString(Keys.Environment.API_KEY)
-            val region = env.getProperty<String>(
-                Keys.Environment.REGION
-            )?.takeIfNotBlank().toRegion()
-            val organizationId = env.getProperty<String>(
-                Keys.Environment.ORGANIZATION_ID
-            )?.takeIfNotBlank()
-
-            customerIO = CustomerIO.Builder(
-                siteId = siteId,
-                apiKey = apiKey,
-                region = region,
-                appContext = reactApplicationContext.applicationContext as Application,
-            ).apply {
-                setClient(Client.ReactNative(sdkVersion = sdkVersion ?: "n/a"))
-                setupConfig(config)
-                addCustomerIOModule(module = configureModuleMessagingPushFCM(config))
-                if (!organizationId.isNullOrBlank()) {
-                    addCustomerIOModule(module = configureModuleMessagingInApp(organizationId))
-                }
-            }.build()
-        } catch (ex: IllegalArgumentException) {
-            logger.error(ex.message ?: "$MODULE_NAME -> initialize -> IllegalArgumentException")
+            customerIO = CustomerIOReactNativeInstance.initialize(
+                context = reactApplicationContext,
+                environment = env,
+                configuration = config,
+                sdkVersion = sdkVersion,
+            )
+            logger.info("Customer.io instance initialized successfully from app")
+        } catch (ex: Exception) {
+            logger.error("Failed to initialize Customer.io instance from app, ${ex.message}")
         }
     }
-
-    private fun CustomerIO.Builder.setupConfig(config: Map<String, Any>?): CustomerIO.Builder {
-        if (config == null) return this
-
-        val logLevel = config.getProperty<Double>(Keys.Config.LOG_LEVEL).toCIOLogLevel()
-        CustomerIOReactNativeInstance.setLogLevel(logLevel = logLevel)
-        setLogLevel(level = logLevel)
-        config.getProperty<String>(Keys.Config.TRACKING_API_URL)?.takeIfNotBlank()?.let { value ->
-            setTrackingApiURL(value)
-        }
-        config.getProperty<Boolean>(Keys.Config.AUTO_TRACK_DEVICE_ATTRIBUTES)?.let { value ->
-            autoTrackDeviceAttributes(shouldTrackDeviceAttributes = value)
-        }
-        config.getProperty<Double>(Keys.Config.BACKGROUND_QUEUE_MIN_NUMBER_OF_TASKS)?.let { value ->
-            setBackgroundQueueMinNumberOfTasks(backgroundQueueMinNumberOfTasks = value.toInt())
-        }
-        config.getProperty<Double>(Keys.Config.BACKGROUND_QUEUE_SECONDS_DELAY)?.let { value ->
-            setBackgroundQueueSecondsDelay(backgroundQueueSecondsDelay = value)
-        }
-        return this
-    }
-
-    private fun configureModuleMessagingPushFCM(config: Map<String, Any>?) = ModuleMessagingPushFCM(
-        config = MessagingPushModuleConfig.Builder().apply {
-            config?.getProperty<Boolean>(Keys.Config.AUTO_TRACK_PUSH_EVENTS)?.let { value ->
-                setAutoTrackPushEvents(autoTrackPushEvents = value)
-            }
-        }.build(),
-    )
-
-    private fun configureModuleMessagingInApp(organizationId: String) = ModuleMessagingInApp(
-        organizationId = organizationId,
-    )
 
     @ReactMethod
     fun clearIdentify() {

--- a/android/src/main/java/io/customer/reactnative/sdk/extension/ReactNativeExt.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/extension/ReactNativeExt.kt
@@ -3,7 +3,7 @@ package io.customer.reactnative.sdk.extension
 import io.customer.reactnative.sdk.CustomerIOReactNativeInstance
 
 @Throws(IllegalArgumentException::class)
-internal inline fun <reified T> Map<String, Any>.getPropertyUnsafe(key: String): T {
+internal inline fun <reified T> Map<String, Any?>.getPropertyUnsafe(key: String): T {
     val property = get(key)
 
     if (property !is T) {
@@ -14,7 +14,7 @@ internal inline fun <reified T> Map<String, Any>.getPropertyUnsafe(key: String):
     return property
 }
 
-internal inline fun <reified T> Map<String, Any>.getProperty(key: String): T? = try {
+internal inline fun <reified T> Map<String, Any?>.getProperty(key: String): T? = try {
     getPropertyUnsafe(key)
 } catch (ex: IllegalArgumentException) {
     CustomerIOReactNativeInstance.logger.error(
@@ -24,7 +24,7 @@ internal inline fun <reified T> Map<String, Any>.getProperty(key: String): T? = 
 }
 
 @Throws(IllegalArgumentException::class)
-internal fun Map<String, Any>.getString(key: String): String = try {
+internal fun Map<String, Any?>.getString(key: String): String = try {
     getPropertyUnsafe<String>(key).takeIfNotBlank() ?: throw IllegalArgumentException(
         "Invalid value provided for $key, must not be blank"
     )

--- a/android/src/main/java/io/customer/reactnative/sdk/service/CustomerIOReactNativeFCMService.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/service/CustomerIOReactNativeFCMService.kt
@@ -1,0 +1,17 @@
+package io.customer.reactnative.sdk.service
+
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import io.customer.messagingpush.CustomerIOFirebaseMessagingService
+import io.customer.reactnative.sdk.CustomerIOReactNativeInstance
+
+class CustomerIOReactNativeFCMService : FirebaseMessagingService() {
+    override fun onMessageReceived(message: RemoteMessage) {
+        CustomerIOReactNativeInstance.initializeSDKFromContext(context = applicationContext)
+        CustomerIOFirebaseMessagingService.onMessageReceived(message)
+    }
+
+    override fun onNewToken(token: String) {
+        CustomerIOFirebaseMessagingService.onNewToken(token)
+    }
+}

--- a/android/src/main/java/io/customer/reactnative/sdk/storage/PreferencesStorage.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/storage/PreferencesStorage.kt
@@ -1,0 +1,94 @@
+package io.customer.reactnative.sdk.storage
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Base64
+import io.customer.reactnative.sdk.constant.Keys
+
+class PreferencesStorage(context: Context) {
+    private val preferenceFileKeyPrefix = "${context.packageName}.cio.rn"
+    private val preferenceFileKey = "${preferenceFileKeyPrefix}.PREFERENCE_FILE_KEY"
+    private val sharedPref: SharedPreferences
+
+    private val environmentKeys = with(Keys.Environment) {
+        arrayOf(SITE_ID, API_KEY, REGION, ORGANIZATION_ID)
+    }
+    private val configKeys = with(Keys.Config) {
+        arrayOf(
+            LOG_LEVEL,
+            TRACKING_API_URL,
+            AUTO_TRACK_DEVICE_ATTRIBUTES,
+            AUTO_TRACK_PUSH_EVENTS,
+            BACKGROUND_QUEUE_MIN_NUMBER_OF_TASKS,
+            BACKGROUND_QUEUE_SECONDS_DELAY,
+        )
+    }
+
+    init {
+        sharedPref = context.getSharedPreferences(
+            preferenceFileKey, Context.MODE_PRIVATE,
+        )
+    }
+
+    fun saveSettings(
+        environment: Map<String, Any?>,
+        configuration: Map<String, Any?>?,
+        sdkVersion: String?,
+    ) = with(sharedPref.edit()) {
+        for (key in environmentKeys) {
+            putString(key, environment[key]?.toString()?.encodeToBase64())
+        }
+        if (configuration != null) {
+            for (key in configKeys) {
+                putString(key, configuration[key]?.toString()?.encodeToBase64())
+            }
+        }
+        putString(SDK_VERSION_KEY, sdkVersion?.encodeToBase64())
+        apply()
+    }
+
+    private fun loadSettings(
+        keys: Array<String>,
+        typeConverter: ((String, String?) -> Any?)? = null,
+    ): Map<String, Any?> {
+        val map = hashMapOf<String, Any?>()
+        with(sharedPref) {
+            for (key in keys) {
+                map[key] = getString(key, null)?.decodeFromBase64().let { property ->
+                    typeConverter?.invoke(key, property) ?: property
+                }
+            }
+        }
+        return map
+    }
+
+    fun loadSDKVersion() = sharedPref.getString(SDK_VERSION_KEY, null)?.decodeFromBase64()
+    fun loadEnvironmentSettings() = loadSettings(environmentKeys)
+    fun loadConfigurationSettings() = loadSettings(configKeys) { key, value ->
+        with(Keys.Config) {
+            return@with when (key) {
+                LOG_LEVEL,
+                BACKGROUND_QUEUE_MIN_NUMBER_OF_TASKS,
+                BACKGROUND_QUEUE_SECONDS_DELAY,
+                -> value?.toDoubleOrNull()
+                AUTO_TRACK_DEVICE_ATTRIBUTES,
+                AUTO_TRACK_PUSH_EVENTS,
+                -> value?.toBooleanStrictOrNull()
+                TRACKING_API_URL -> value
+                else -> value
+            }
+        }
+    }
+
+    companion object {
+        private const val SDK_VERSION_KEY = "sdkVersion"
+
+        private fun String.encodeToBase64(): String {
+            return Base64.encodeToString(toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
+        }
+
+        private fun String.decodeFromBase64(): String {
+            return Base64.decode(this, Base64.NO_WRAP).toString(Charsets.UTF_8)
+        }
+    }
+}


### PR DESCRIPTION
Closes: [8059](https://github.com/customerio/issues/issues/8059) 

### Changes

- Stored `siteId`, `apiKey`, `organizationId` and other configuration settings to storage (preferences) every time the SDK is initialized from the app
- Added option to allow initializing SDK from storage settings using `context` only
- Added wrapper `FirebaseMessagingService` in react native package to prevent SDK crash on late initialization
- Moved initialization and other configuration settings from module to object instance for reusability within react package
