### PR TITLE
fix: support for expo client

### DIFF
--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
@@ -39,7 +39,7 @@ class CustomerIOReactNativeModule(
     fun initialize(
         environment: ReadableMap,
         configuration: ReadableMap? = null,
-        sdkVersion: String? = null,
+        packageConfiguration: ReadableMap? = null,
     ) {
         if (isInstanceValid()) {
             logger.info("Customer.io instance already initialized, reinitializing")
@@ -47,18 +47,19 @@ class CustomerIOReactNativeModule(
 
         val env = environment.toMap()
         val config = configuration?.toMap()
+        val packageConfig = packageConfiguration?.toMap()
 
         preferencesStorage.saveSettings(
             environment = env,
             configuration = config,
-            sdkVersion = sdkVersion
+            packageConfig = packageConfig
         )
         try {
             customerIO = CustomerIOReactNativeInstance.initialize(
                 context = reactApplicationContext,
                 environment = env,
                 configuration = config,
-                sdkVersion = sdkVersion,
+                packageConfig = packageConfig,
             )
             logger.info("Customer.io instance initialized successfully from app")
         } catch (ex: Exception) {

--- a/android/src/main/java/io/customer/reactnative/sdk/constant/Keys.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/constant/Keys.kt
@@ -16,4 +16,10 @@ internal object Keys {
         const val BACKGROUND_QUEUE_MIN_NUMBER_OF_TASKS = "backgroundQueueMinNumberOfTasks"
         const val BACKGROUND_QUEUE_SECONDS_DELAY = "backgroundQueueSecondsDelay"
     }
+
+    object PackageConfig {
+        const val SOURCE_SDK = "source"
+        const val SOURCE_SDK_VERSION = "version"
+        const val SOURCE_SDK_VERSION_COMPAT = "sdkVersion"
+    }
 }

--- a/android/src/main/java/io/customer/reactnative/sdk/storage/PreferencesStorage.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/storage/PreferencesStorage.kt
@@ -23,6 +23,9 @@ class PreferencesStorage(context: Context) {
             BACKGROUND_QUEUE_SECONDS_DELAY,
         )
     }
+    private val packageConfigKeys = with(Keys.PackageConfig) {
+        arrayOf(SOURCE_SDK, SOURCE_SDK_VERSION)
+    }
 
     init {
         sharedPref = context.getSharedPreferences(
@@ -33,7 +36,7 @@ class PreferencesStorage(context: Context) {
     fun saveSettings(
         environment: Map<String, Any?>,
         configuration: Map<String, Any?>?,
-        sdkVersion: String?,
+        packageConfig: Map<String, Any?>?,
     ) = with(sharedPref.edit()) {
         for (key in environmentKeys) {
             putString(key, environment[key]?.toString()?.encodeToBase64())
@@ -43,7 +46,11 @@ class PreferencesStorage(context: Context) {
                 putString(key, configuration[key]?.toString()?.encodeToBase64())
             }
         }
-        putString(SDK_VERSION_KEY, sdkVersion?.encodeToBase64())
+        if (packageConfig != null) {
+            for (key in packageConfigKeys) {
+                putString(key, packageConfig[key]?.toString()?.encodeToBase64())
+            }
+        }
         apply()
     }
 
@@ -62,7 +69,10 @@ class PreferencesStorage(context: Context) {
         return map
     }
 
-    fun loadSDKVersion() = sharedPref.getString(SDK_VERSION_KEY, null)?.decodeFromBase64()
+    fun loadPackageConfigurations() = loadSettings(
+        keys = packageConfigKeys.plus(Keys.PackageConfig.SOURCE_SDK_VERSION_COMPAT),
+    )
+
     fun loadEnvironmentSettings() = loadSettings(environmentKeys)
     fun loadConfigurationSettings() = loadSettings(configKeys) { key, value ->
         with(Keys.Config) {
@@ -81,8 +91,6 @@ class PreferencesStorage(context: Context) {
     }
 
     companion object {
-        private const val SDK_VERSION_KEY = "sdkVersion"
-
         private fun String.encodeToBase64(): String {
             return Base64.encodeToString(toByteArray(Charsets.UTF_8), Base64.NO_WRAP)
         }

--- a/customerio-reactnative.podspec
+++ b/customerio-reactnative.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "CustomerIOTracking", '~> 1.2.0'
-  s.dependency "CustomerIOMessagingInApp", '~> 1.2.0'
+  s.dependency "CustomerIOTracking", '~> 1.2.1'
+  s.dependency "CustomerIOMessagingInApp", '~> 1.2.1'
 end

--- a/ios/CustomerioReactnative.m
+++ b/ios/CustomerioReactnative.m
@@ -4,7 +4,7 @@
 
 RCT_EXTERN_METHOD(initialize: (nonnull NSDictionary *) env
                   configData : (NSDictionary *) configData
-                  pversion: (nonnull NSString *) pversion)
+                  packageConfig: (nonnull NSDictionary *) packageConfig)
 
 RCT_EXTERN_METHOD(identify: (nonnull NSString *) identifier
                   body : (NSDictionary *) body)

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -13,13 +13,24 @@ class CustomerioReactnative: NSObject {
     /**
      Initialize the package before sending any calls to the package
      */
-    @objc(initialize:configData:pversion:)
-    func initialize(env: Dictionary<String, AnyHashable>, configData: Dictionary<String, AnyHashable>, pversion: String) -> Void {
+    @objc(initialize:configData:packageConfig:)
+    func initialize(env: Dictionary<String, AnyHashable>, configData: Dictionary<String, AnyHashable>, packageConfig: Dictionary<String, AnyHashable>) -> Void {
+        
         guard let siteId = env["siteId"] as? String, let apiKey = env["apiKey"] as? String, let region = env["region"] as? String, let organizationId = env["organizationId"] as? String else {
             return
         }
+        
+        guard let pversion = packageConfig["version"] as? String, let source = packageConfig["source"] as? String else {
+            return
+        }
+        
+        var sdkSource = SdkWrapperConfig.Source.reactNative
+        if source.lowercased() == "expo" {
+            sdkSource = SdkWrapperConfig.Source.expo
+        }
+        
         CustomerIO.initialize(siteId: siteId, apiKey: apiKey, region: Region.getLocation(from: region)) { config in
-            config._sdkWrapperConfig = SdkWrapperConfig(source: SdkWrapperConfig.Source.reactNative, version: pversion )
+            config._sdkWrapperConfig = SdkWrapperConfig(source: sdkSource, version: pversion )
             config.autoTrackDeviceAttributes = configData["autoTrackDeviceAttributes"] as! Bool
             config.logLevel = CioLogLevel.getLogValue(for: configData["logLevel"] as! Int)
             config.autoTrackPushEvents = configData["autoTrackPushEvents"] as! Bool

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "lib/typescript/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",
+  "expoVersion": "",
   "files": [
     "src",
     "lib",

--- a/src/CustomerioConfig.tsx
+++ b/src/CustomerioConfig.tsx
@@ -26,7 +26,13 @@ class CustomerIOEnv {
     organizationId: string = ""
 }
 
+class PackageConfig {
+    version: string = ""
+    source: string = ""
+}
+
 export {
     CustomerioConfig,
-    CustomerIOEnv
+    CustomerIOEnv,
+    PackageConfig
 }

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -5,7 +5,6 @@ import {
   PackageConfig,
 } from './CustomerioConfig';
 import { Region } from './CustomerioEnum';
-import fs from 'fs';
 var pjson = require('../package.json');
 
 const LINKING_ERROR =
@@ -14,11 +13,16 @@ const LINKING_ERROR =
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo managed workflow\n';
 
-const isNode =
-  typeof process !== 'undefined' &&
-  process.versions != null &&
-  process.versions.node != null;
+async function importModule(moduleName: string): Promise<any> {
+  console.log('importing ', moduleName);
+  const importedModule = await import(moduleName);
+  console.log('\timported ...');
+  return importedModule;
+}
 
+let moduleName = '../../customerio-expo-plugin/package.json';
+let importedModule = await importModule(moduleName);
+console.log('importedModule', importedModule);
 /**
  * Get CustomerioReactnative native module
  */
@@ -47,19 +51,14 @@ class CustomerIO {
     config: CustomerioConfig = new CustomerioConfig()
   ) {
     let pversion = pjson.version ?? '';
+    let expoVersion = pjson.expoVersion ?? '';
 
     const packageConfig = new PackageConfig();
     packageConfig.source = 'ReactNative';
     packageConfig.version = pversion;
-
-    if (isNode) {
-      if (fs.existsSync('node_modules/customerio-expo-plugin/package.json')) {
-        const expoPjson = require('../../node_modules/customerio-expo-plugin/package.json');
-        if (expoPjson) {
-          packageConfig.source = 'Expo';
-          packageConfig.version = expoPjson.version;
-        }
-      }
+    if (expoVersion != '') {
+      packageConfig.source = 'Expo';
+      packageConfig.version = expoVersion;
     }
 
     return CustomerioReactnative.initialize(env, config, packageConfig);

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -36,25 +36,20 @@ class CustomerIO {
    * @param config set config for the package eg trackApiUrl etc
    * @returns
    */
-  static async initialize(
+  static initialize(
     env: CustomerIOEnv,
     config: CustomerioConfig = new CustomerioConfig()
   ) {
     let pversion = pjson.version ?? '';
+    let expoVersion = pjson.expoVersion ?? '';
 
     const packageConfig = new PackageConfig();
     packageConfig.source = 'ReactNative';
     packageConfig.version = pversion;
-
-    try {
-      var m = require('../../customerio-expo-plugin/src/version.ts');
-      if (m && m.LIB_VERSION) {
-        packageConfig.source = 'Expo';
-        packageConfig.version = m.LIB_VERSION;
-        console.log(`Expo plugin detected: V: ${m.LIB_VERSION}`);
-      }
-      // do stuff
-    } catch (ex) {}
+    if (expoVersion != '') {
+      packageConfig.source = 'Expo';
+      packageConfig.version = expoVersion;
+    }
 
     return CustomerioReactnative.initialize(env, config, packageConfig);
   }

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -5,6 +5,7 @@ import {
   PackageConfig,
 } from './CustomerioConfig';
 import { Region } from './CustomerioEnum';
+var pjson = require('../package.json');
 
 const LINKING_ERROR =
   `The package 'customerio-reactnative' doesn't seem to be linked. Make sure: \n\n` +
@@ -39,10 +40,16 @@ class CustomerIO {
     env: CustomerIOEnv,
     config: CustomerioConfig = new CustomerioConfig()
   ) {
-    const packageConfig = new PackageConfig();
+    let pversion = pjson.version ?? '';
+    let expoVersion = pjson.expoVersion ?? '';
 
-    packageConfig.source = 'Expo';
-    packageConfig.version = '1.2.3';
+    const packageConfig = new PackageConfig();
+    packageConfig.source = 'ReactNative';
+    packageConfig.version = pversion;
+    if (expoVersion != '') {
+      packageConfig.source = 'Expo';
+      packageConfig.version = expoVersion;
+    }
 
     console.warn(packageConfig);
 

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -1,5 +1,9 @@
 import { NativeModules, Platform } from 'react-native';
-import { CustomerioConfig, CustomerIOEnv, PackageConfig } from './CustomerioConfig';
+import {
+  CustomerioConfig,
+  CustomerIOEnv,
+  PackageConfig,
+} from './CustomerioConfig';
 import { Region } from './CustomerioEnum';
 var pjson = require('../package.json');
 
@@ -8,7 +12,6 @@ const LINKING_ERROR =
   Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo managed workflow\n';
-
 
 /**
  * Get CustomerioReactnative native module
@@ -24,7 +27,6 @@ const CustomerioReactnative = NativeModules.CustomerioReactnative
       }
     );
 
-
 class CustomerIO {
   /**
    * To initialize the package using workspace credentials
@@ -34,90 +36,86 @@ class CustomerIO {
    * @param config set config for the package eg trackApiUrl etc
    * @returns
    */
-   static initialize(env: CustomerIOEnv, config: CustomerioConfig = new CustomerioConfig()) {
+  static initialize(
+    env: CustomerIOEnv,
+    config: CustomerioConfig = new CustomerioConfig()
+  ) {
+    let pversion = pjson.version ?? '';
+    let expoVersion = pjson.expoVersion ?? '1.2.3';
 
-    let pversion = pjson.version ?? ""
-    let expoVersion = pjson.expoVersion ?? "1.2.3"
+    const packageConfig = new PackageConfig();
 
-    const packageConfig = new PackageConfig()
-    packageConfig.source = "ReactNative"
-    packageConfig.version = pversion
-    if (expoVersion != "") {
-      packageConfig.source = "Expo"
-      packageConfig.version = expoVersion
-    }
+    packageConfig.source = 'Expo';
+    packageConfig.version = expoVersion;
 
     console.warn(packageConfig);
 
-    return CustomerioReactnative.initialize(env, config, packageConfig)
+    return CustomerioReactnative.initialize(env, config, packageConfig);
   }
 
-    /**
-     * Identify a person using a unique identifier, eg. email id.
-     * Note that you can identify only 1 profile at a time. In case, multiple
-     * identifiers are attempted to be identified, then the last identified profile
-     * will be removed automatically.
-     *
-     * @param identifier unique identifier for a profile
-     * @param body (Optional) data to identify a profile
-     */
-    static identify(identifier: string, body: Object) {
-      CustomerioReactnative.identify(identifier, body)
-    }
-
-    /**
-     * Call this function to stop identifying a person.
-     *
-     * If a profile exists, clearIdentify will stop identifying the profile.
-     * If no profile exists, request to clearIdentify will be ignored.
-     */
-    static clearIdentify() {
-      CustomerioReactnative.clearIdentify()
-    }
-
-    /**
-     * To track user events like loggedIn, addedItemToCart etc.
-     * You may also track events with additional yet optional data.
-     *
-     * @param name event name to be tracked
-     * @param data (Optional) data to be sent with event
-     */
-    static track(name: string, data : Object) {
-      CustomerioReactnative.track(name, data)
-    }
-
-    /**
-     * Use this function to send custom device attributes
-     * such as app preferences, timezone etc
-     *
-     * @param data device attributes data
-     */
-    static setDeviceAttributes(data : Object) {
-      CustomerioReactnative.setDeviceAttributes(data)
-    }
-
-    /**
-     * Set custom user profile information such as user preference, specific
-     * user actions etc
-     *
-     * @param data additional attributes for a user profile
-     */
-    static setProfileAttributes(data : Object) {
-      CustomerioReactnative.setProfileAttributes(data)
-    }
-
-    /**
-     * Track screen events to record the screens a user visits
-     *
-     * @param name name of the screen user visited
-     * @param data (Optional) any additional data to be sent
-     */
-    static screen(name : string, data : Object) {
-      CustomerioReactnative.screen(name, data)
-    }
+  /**
+   * Identify a person using a unique identifier, eg. email id.
+   * Note that you can identify only 1 profile at a time. In case, multiple
+   * identifiers are attempted to be identified, then the last identified profile
+   * will be removed automatically.
+   *
+   * @param identifier unique identifier for a profile
+   * @param body (Optional) data to identify a profile
+   */
+  static identify(identifier: string, body: Object) {
+    CustomerioReactnative.identify(identifier, body);
   }
 
-  export {
-    CustomerIO,
-    Region
+  /**
+   * Call this function to stop identifying a person.
+   *
+   * If a profile exists, clearIdentify will stop identifying the profile.
+   * If no profile exists, request to clearIdentify will be ignored.
+   */
+  static clearIdentify() {
+    CustomerioReactnative.clearIdentify();
   }
+
+  /**
+   * To track user events like loggedIn, addedItemToCart etc.
+   * You may also track events with additional yet optional data.
+   *
+   * @param name event name to be tracked
+   * @param data (Optional) data to be sent with event
+   */
+  static track(name: string, data: Object) {
+    CustomerioReactnative.track(name, data);
+  }
+
+  /**
+   * Use this function to send custom device attributes
+   * such as app preferences, timezone etc
+   *
+   * @param data device attributes data
+   */
+  static setDeviceAttributes(data: Object) {
+    CustomerioReactnative.setDeviceAttributes(data);
+  }
+
+  /**
+   * Set custom user profile information such as user preference, specific
+   * user actions etc
+   *
+   * @param data additional attributes for a user profile
+   */
+  static setProfileAttributes(data: Object) {
+    CustomerioReactnative.setProfileAttributes(data);
+  }
+
+  /**
+   * Track screen events to record the screens a user visits
+   *
+   * @param name name of the screen user visited
+   * @param data (Optional) any additional data to be sent
+   */
+  static screen(name: string, data: Object) {
+    CustomerioReactnative.screen(name, data);
+  }
+}
+
+export { CustomerIO, Region };

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -40,8 +40,8 @@ class CustomerIO {
     env: CustomerIOEnv,
     config: CustomerioConfig = new CustomerioConfig()
   ) {
-    let pversion = pjson.version ?? '';
-    let expoVersion = pjson.expoVersion ?? '';
+    let pversion = pjson.version || '';
+    let expoVersion = pjson.expoVersion || '';
 
     const packageConfig = new PackageConfig();
     packageConfig.source = 'ReactNative';

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -13,16 +13,6 @@ const LINKING_ERROR =
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo managed workflow\n';
 
-async function importModule(moduleName: string): Promise<any> {
-  console.log('importing ', moduleName);
-  const importedModule = await import(moduleName);
-  console.log('\timported ...');
-  return importedModule;
-}
-
-let moduleName = '../../customerio-expo-plugin/package.json';
-let importedModule = await importModule(moduleName);
-console.log('importedModule', importedModule);
 /**
  * Get CustomerioReactnative native module
  */
@@ -46,20 +36,25 @@ class CustomerIO {
    * @param config set config for the package eg trackApiUrl etc
    * @returns
    */
-  static initialize(
+  static async initialize(
     env: CustomerIOEnv,
     config: CustomerioConfig = new CustomerioConfig()
   ) {
     let pversion = pjson.version ?? '';
-    let expoVersion = pjson.expoVersion ?? '';
 
     const packageConfig = new PackageConfig();
     packageConfig.source = 'ReactNative';
     packageConfig.version = pversion;
-    if (expoVersion != '') {
-      packageConfig.source = 'Expo';
-      packageConfig.version = expoVersion;
-    }
+
+    try {
+      var m = require('../../customerio-expo-plugin/src/version.ts');
+      if (m && m.LIB_VERSION) {
+        packageConfig.source = 'Expo';
+        packageConfig.version = m.LIB_VERSION;
+        console.log(`Expo plugin detected: V: ${m.LIB_VERSION}`);
+      }
+      // do stuff
+    } catch (ex) {}
 
     return CustomerioReactnative.initialize(env, config, packageConfig);
   }

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -11,7 +11,7 @@ const LINKING_ERROR =
 
 
 /**
- * Get CustomerioReactnative native module 
+ * Get CustomerioReactnative native module
  */
 const CustomerioReactnative = NativeModules.CustomerioReactnative
   ? NativeModules.CustomerioReactnative
@@ -27,12 +27,12 @@ const CustomerioReactnative = NativeModules.CustomerioReactnative
 
 class CustomerIO {
   /**
-   * To initialize the package using workspace credentials 
-   * such as siteId, APIKey and region as optional. 
-   *   
-   * @param env use CustomerIOEnv class to set environment variables such as siteId, apiKey, region, org id  
+   * To initialize the package using workspace credentials
+   * such as siteId, APIKey and region as optional.
+   *
+   * @param env use CustomerIOEnv class to set environment variables such as siteId, apiKey, region, org id
    * @param config set config for the package eg trackApiUrl etc
-   * @returns 
+   * @returns
    */
    static initialize(env: CustomerIOEnv, config: CustomerioConfig = new CustomerioConfig()) {
 
@@ -46,7 +46,9 @@ class CustomerIO {
       packageConfig.source = "Expo"
       packageConfig.version = expoVersion
     }
-    
+
+    console.log(packageConfig);
+
     return CustomerioReactnative.initialize(env, config, packageConfig)
   }
 
@@ -54,8 +56,8 @@ class CustomerIO {
      * Identify a person using a unique identifier, eg. email id.
      * Note that you can identify only 1 profile at a time. In case, multiple
      * identifiers are attempted to be identified, then the last identified profile
-     * will be removed automatically. 
-     * 
+     * will be removed automatically.
+     *
      * @param identifier unique identifier for a profile
      * @param body (Optional) data to identify a profile
      */
@@ -65,9 +67,9 @@ class CustomerIO {
 
     /**
      * Call this function to stop identifying a person.
-     * 
+     *
      * If a profile exists, clearIdentify will stop identifying the profile.
-     * If no profile exists, request to clearIdentify will be ignored. 
+     * If no profile exists, request to clearIdentify will be ignored.
      */
     static clearIdentify() {
       CustomerioReactnative.clearIdentify()
@@ -76,7 +78,7 @@ class CustomerIO {
     /**
      * To track user events like loggedIn, addedItemToCart etc.
      * You may also track events with additional yet optional data.
-     * 
+     *
      * @param name event name to be tracked
      * @param data (Optional) data to be sent with event
      */
@@ -87,7 +89,7 @@ class CustomerIO {
     /**
      * Use this function to send custom device attributes
      * such as app preferences, timezone etc
-     * 
+     *
      * @param data device attributes data
      */
     static setDeviceAttributes(data : Object) {
@@ -97,7 +99,7 @@ class CustomerIO {
     /**
      * Set custom user profile information such as user preference, specific
      * user actions etc
-     *  
+     *
      * @param data additional attributes for a user profile
      */
     static setProfileAttributes(data : Object) {
@@ -106,9 +108,9 @@ class CustomerIO {
 
     /**
      * Track screen events to record the screens a user visits
-     * 
+     *
      * @param name name of the screen user visited
-     * @param data (Optional) any additional data to be sent 
+     * @param data (Optional) any additional data to be sent
      */
     static screen(name : string, data : Object) {
       CustomerioReactnative.screen(name, data)

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -44,11 +44,12 @@ class CustomerIO {
     let pversion = version || '';
 
     const packageConfig = new PackageConfig();
-    packageConfig.source = 'ReactNative';
-    packageConfig.version = pversion;
     if (expoVersion) {
       packageConfig.source = 'Expo';
       packageConfig.version = expoVersion || '';
+    } else {
+      packageConfig.source = 'ReactNative';
+      packageConfig.version = pversion;
     }
 
     console.warn(pjson);

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -47,7 +47,7 @@ class CustomerIO {
       packageConfig.version = expoVersion
     }
 
-    console.log(packageConfig);
+    console.warn(packageConfig);
 
     return CustomerioReactnative.initialize(env, config, packageConfig)
   }

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -40,12 +40,11 @@ class CustomerIO {
     env: CustomerIOEnv,
     config: CustomerioConfig = new CustomerioConfig()
   ) {
-    let expoVersion = pjson.expoVersion ?? '1.2.3';
 
     const packageConfig = new PackageConfig();
 
     packageConfig.source = 'Expo';
-    packageConfig.version = expoVersion;
+    packageConfig.version = '1.2.3';
 
     console.warn(packageConfig);
 

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -40,7 +40,6 @@ class CustomerIO {
     env: CustomerIOEnv,
     config: CustomerioConfig = new CustomerioConfig()
   ) {
-    let pversion = pjson.version ?? '';
     let expoVersion = pjson.expoVersion ?? '1.2.3';
 
     const packageConfig = new PackageConfig();

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -37,7 +37,7 @@ class CustomerIO {
    static initialize(env: CustomerIOEnv, config: CustomerioConfig = new CustomerioConfig()) {
 
     let pversion = pjson.version ?? ""
-    let expoVersion = pjson.expoVersion ?? ""
+    let expoVersion = pjson.expoVersion ?? "1.2.3"
 
     const packageConfig = new PackageConfig()
     packageConfig.source = "ReactNative"

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -5,7 +5,6 @@ import {
   PackageConfig,
 } from './CustomerioConfig';
 import { Region } from './CustomerioEnum';
-var pjson = require('../package.json');
 
 const LINKING_ERROR =
   `The package 'customerio-reactnative' doesn't seem to be linked. Make sure: \n\n` +
@@ -40,7 +39,6 @@ class CustomerIO {
     env: CustomerIOEnv,
     config: CustomerioConfig = new CustomerioConfig()
   ) {
-
     const packageConfig = new PackageConfig();
 
     packageConfig.source = 'Expo';

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -1,5 +1,5 @@
 import { NativeModules, Platform } from 'react-native';
-import { CustomerioConfig, CustomerIOEnv } from './CustomerioConfig';
+import { CustomerioConfig, CustomerIOEnv, PackageConfig } from './CustomerioConfig';
 import { Region } from './CustomerioEnum';
 var pjson = require('../package.json');
 
@@ -37,7 +37,17 @@ class CustomerIO {
    static initialize(env: CustomerIOEnv, config: CustomerioConfig = new CustomerioConfig()) {
 
     let pversion = pjson.version ?? ""
-    return CustomerioReactnative.initialize(env, config, pversion)
+    let expoVersion = pjson.expoVersion ?? ""
+
+    const packageConfig = new PackageConfig()
+    packageConfig.source = "ReactNative"
+    packageConfig.version = pversion
+    if (expoVersion != "") {
+      packageConfig.source = "Expo"
+      packageConfig.version = expoVersion
+    }
+    
+    return CustomerioReactnative.initialize(env, config, packageConfig)
   }
 
     /**

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -6,6 +6,7 @@ import {
 } from './CustomerioConfig';
 import { Region } from './CustomerioEnum';
 import { expoVersion, version } from '../package.json';
+var pjson = require('../package.json');
 
 const LINKING_ERROR =
   `The package 'customerio-reactnative' doesn't seem to be linked. Make sure: \n\n` +
@@ -50,6 +51,8 @@ class CustomerIO {
       packageConfig.version = expoVersion || '';
     }
 
+    console.warn(pjson);
+    console.warn(expoVersion);
     console.warn(packageConfig);
 
     return CustomerioReactnative.initialize(env, config, packageConfig);

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -5,7 +5,7 @@ import {
   PackageConfig,
 } from './CustomerioConfig';
 import { Region } from './CustomerioEnum';
-var pjson = require('../package.json');
+import { expoVersion, version } from '../package.json';
 
 const LINKING_ERROR =
   `The package 'customerio-reactnative' doesn't seem to be linked. Make sure: \n\n` +
@@ -40,15 +40,14 @@ class CustomerIO {
     env: CustomerIOEnv,
     config: CustomerioConfig = new CustomerioConfig()
   ) {
-    let pversion = pjson.version || '';
-    let expoVersion = pjson.expoVersion || '';
+    let pversion = version || '';
 
     const packageConfig = new PackageConfig();
     packageConfig.source = 'ReactNative';
     packageConfig.version = pversion;
-    if (expoVersion != '') {
+    if (expoVersion) {
       packageConfig.source = 'Expo';
-      packageConfig.version = expoVersion;
+      packageConfig.version = expoVersion || '';
     }
 
     console.warn(packageConfig);


### PR DESCRIPTION
### Changes

- Added support to differentiate between expo and react apps using `package.json`
- Added support for Expo client in iOS and Android SDK wrappers
- Updated iOS SDK to `1.2.1`
- Added `PackageConfig` to pass package configurations in a convenient way