### PR TITLE
fix: ios and android sdk version update

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
 customerio.reactnative.kotlinVersion=1.5.31
 customerio.reactnative.compileSdkVersion=30
 customerio.reactnative.targetSdkVersion=30
-customerio.reactnative.cioSDKVersionAndroid=3.2.0-alpha.1
+customerio.reactnative.cioSDKVersionAndroid=3.2.0-alpha.2

--- a/customerio-reactnative.podspec
+++ b/customerio-reactnative.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "CustomerIOTracking", '~> 1.2.6'
-  s.dependency "CustomerIOMessagingInApp", '~> 1.2.6'
+  s.dependency "CustomerIOTracking", '~> 2.0.0-alpha.1'
+  s.dependency "CustomerIOMessagingInApp", '~> 2.0.0-alpha.1'
 end


### PR DESCRIPTION
 This PR has iOS and Android SDK version updates
iOS - 2.0.0-alpha.1
Android - 3.2.0-alpha.1


iOS has some breaking changes but doesn't seem to be affecting react native package as we are already using shared instances and new method to initialise the package. 