### PR TITLE
ci: push to npm dist-tag other then latest for pre-releases

### DIFF
--- a/.github/workflows/deploy_npm.yml
+++ b/.github/workflows/deploy_npm.yml
@@ -24,6 +24,7 @@ jobs:
         run: ./scripts/deploy-code.sh 
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }} # true or false boolean if a prerelease github release
 
       - name: Notify team of successful deployment 
         uses: slackapi/slack-github-action@v1.18.0        

--- a/scripts/deploy-code.sh
+++ b/scripts/deploy-code.sh
@@ -11,6 +11,14 @@ set -e
 # version in package.json has already been updated when the git tag was made. 
 # we just need to push. 
 
+if [[ "$IS_PRERELEASE" == "" ]]; then # makes sure it's determined if prerelease or not. 
+    echo "Forgot to set environment variable IS_PRERELEASE. Value is \"false\" if deploying to production. Otherwise, set to \"true\"."
+    echo "Set variable with command (yes, with the double quotes around the variable value): export NAME_OF_VAR=\"foo\""
+    exit 1
+fi
+
+echo "Deploying npm package. Is pre-release: $IS_PRERELEASE"
+
 if [[ "$NPM_TOKEN" == "" ]]; then # makes sure auth token is set. 
     echo "Forgot to set environment variable NPM_TOKEN (value found in 1password for Ami npm account). Set it, then try again."
     echo "Set variable with command (yes, with the double quotes around the variable value): export NAME_OF_VAR=\"foo\""
@@ -38,6 +46,15 @@ echo "Compiling typescript code so it's ready to be uploaded"
 yarn typescript
 echo "compiling code done"
 
-echo "Publishing npm package...."
-npm publish 
+# npmjs registry dist-tag for the release. 
+# "latest" is usually used for production. You can use whatever other value that you want for non-production builds. 
+# https://docs.npmjs.com/cli/v9/commands/npm-dist-tag
+PUBLISH_DIST_TAG="latest"
+if [[ "$IS_PRERELEASE" == "true" || "$IS_PRERELEASE" == true ]]; then 
+    PUBLISH_DIST_TAG="next" # common pattern to see for npm packages is to use next for non-production builds. 
+fi 
+
+echo "Publishing npm package... with tag: $PUBLISH_DIST_TAG"
+
+npm publish --tag $PUBLISH_DIST_TAG
 echo "Publishing npm package complete"


### PR DESCRIPTION
Closes: https://github.com/customerio/issues/issues/8747

There is an issue with the CI script that deploys to npmjs.com. 

The script today will push all deployments to "latest" tag which means that if we were to deploy an alpha or beta build of the RN SDK, that alpha or beta would be pushed to npmjs.com as "latest". This would not be good as that would easily allow customers to install alpha or beta by accident when they expected to use the "latest" production build. 

I modified the script to push to `next` npmjs tag for Alpha or beta builds. Otherwise, push to `latest`. 