### PR TITLE
feat: deprecated organization id for in-app

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
 customerio.reactnative.kotlinVersion=1.5.31
 customerio.reactnative.compileSdkVersion=30
 customerio.reactnative.targetSdkVersion=30
-customerio.reactnative.cioSDKVersionAndroid=[3.1, 3.2[
+customerio.reactnative.cioSDKVersionAndroid=3.2.0

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
 customerio.reactnative.kotlinVersion=1.5.31
 customerio.reactnative.compileSdkVersion=30
 customerio.reactnative.targetSdkVersion=30
-customerio.reactnative.cioSDKVersionAndroid=3.2.0
+customerio.reactnative.cioSDKVersionAndroid=3.3.0-alpha.1

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
 customerio.reactnative.kotlinVersion=1.5.31
 customerio.reactnative.compileSdkVersion=30
 customerio.reactnative.targetSdkVersion=30
-customerio.reactnative.cioSDKVersionAndroid=3.2.0-alpha.2
+customerio.reactnative.cioSDKVersionAndroid=[3.1, 3.2[

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
 customerio.reactnative.kotlinVersion=1.5.31
 customerio.reactnative.compileSdkVersion=30
 customerio.reactnative.targetSdkVersion=30
-customerio.reactnative.cioSDKVersionAndroid=3.3.0-alpha.1
+customerio.reactnative.cioSDKVersionAndroid=3.3.0-beta.1

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeInstance.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeInstance.kt
@@ -27,9 +27,9 @@ object CustomerIOReactNativeInstance {
         val region = environment.getProperty<String>(
             Keys.Environment.REGION
         )?.takeIfNotBlank().toRegion()
-        val organizationId = environment.getProperty<String>(
-            Keys.Environment.ORGANIZATION_ID
-        )?.takeIfNotBlank()
+        val enableInApp = configuration?.getProperty<Boolean>(
+            Keys.Config.ENABLE_IN_APP
+        ) ?: false
 
         return CustomerIO.Builder(
             siteId = siteId,
@@ -40,8 +40,8 @@ object CustomerIOReactNativeInstance {
             setClient(client = getUserAgentClient(packageConfig = packageConfig))
             setupConfig(configuration)
             addCustomerIOModule(module = configureModuleMessagingPushFCM(configuration))
-            if (!organizationId.isNullOrBlank()) {
-                addCustomerIOModule(module = configureModuleMessagingInApp(organizationId))
+            if (enableInApp) {
+                addCustomerIOModule(module = configureModuleMessagingInApp())
             }
         }.build()
     }
@@ -93,7 +93,5 @@ object CustomerIOReactNativeInstance {
         )
     }
 
-    private fun configureModuleMessagingInApp(organizationId: String) = ModuleMessagingInApp(
-        organizationId = organizationId,
-    )
+    private fun configureModuleMessagingInApp() = ModuleMessagingInApp()
 }

--- a/android/src/main/java/io/customer/reactnative/sdk/constant/Keys.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/constant/Keys.kt
@@ -5,10 +5,10 @@ internal object Keys {
         const val SITE_ID = "siteId"
         const val API_KEY = "apiKey"
         const val REGION = "region"
-        const val ORGANIZATION_ID = "organizationId"
     }
 
     object Config {
+        const val ENABLE_IN_APP = "enableInApp"
         const val TRACKING_API_URL = "trackingApiUrl"
         const val AUTO_TRACK_DEVICE_ATTRIBUTES = "autoTrackDeviceAttributes"
         const val LOG_LEVEL = "logLevel"

--- a/customerio-reactnative.podspec
+++ b/customerio-reactnative.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "CustomerIOTracking", '~> 2.0.0'
-  s.dependency "CustomerIOMessagingInApp", '~> 2.0.0'
+  s.dependency "CustomerIOTracking", '~> 2.0.5-alpha.1'
+  s.dependency "CustomerIOMessagingInApp", '~> 2.0.5-alpha.1'
 end

--- a/customerio-reactnative.podspec
+++ b/customerio-reactnative.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "CustomerIOTracking", '~> 2.0.5-alpha.1'
-  s.dependency "CustomerIOMessagingInApp", '~> 2.0.5-alpha.1'
+  s.dependency "CustomerIOTracking", '~> 2.1.0-beta.1'
+  s.dependency "CustomerIOMessagingInApp", '~> 2.1.0-beta.1'
 end

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -126,6 +126,7 @@ class CustomerioReactnative: NSObject {
     /**
         Intialize in-app using customerio package
      */
+    @available(*, deprecated, message: "Enable in-app using SDK configuration")
     private func initializeInApp(organizationId: String) -> Void{
         DispatchQueue.main.async {
             MessagingInApp.shared.initialize(organizationId: organizationId)

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -116,7 +116,7 @@ class CustomerioReactnative: NSObject {
     /**
         Initialize in-app using customerio package
      */
-    private func initializeInApp(organizationId: String) -> Void{
+    private func initializeInApp() -> Void{
         DispatchQueue.main.async {
             MessagingInApp.shared.initialize()
         }

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -40,8 +40,7 @@ class CustomerioReactnative: NSObject {
                 config.trackingApiUrl = trackingApiUrl
             }
             if let isEnableInApp = configData["enableInApp"] as? Bool, isEnableInApp {
-                // TODO: - Uncomment the following code once iOS SDK has feature to enable in-app using siteId
-                // config.isEnableInApp = true
+                initializeInApp()
             }
         }
     }
@@ -113,5 +112,15 @@ class CustomerioReactnative: NSObject {
         }
         CustomerIO.shared.screen(name: name, data: body)
     }
+    
+    /**
+        Initialize in-app using customerio package
+     */
+    private func initializeInApp(organizationId: String) -> Void{
+        DispatchQueue.main.async {
+            MessagingInApp.shared.initialize()
+        }
+    }
+
 }
 

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -39,10 +39,20 @@ class CustomerioReactnative: NSObject {
             if let trackingApiUrl = configData["trackingApiUrl"] as? String, !trackingApiUrl.isEmpty {
                 config.trackingApiUrl = trackingApiUrl
             }
+            if let isEnableInApp = configData["enableInApp"] as? Bool, isEnableInApp {
+                // TODO: - Uncomment the following code once iOS SDK has feature to enable in-app using siteId
+                // config.isEnableInApp = true
+            }
         }
+        
+        /*
+         organizationId will be removed in future releases. To enable in-app use config option
+         config.isEnableInApp = true
+         */
         if organizationId != "" {
             initializeInApp(organizationId: organizationId)
         }
+        
     }
     
     /**

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -44,15 +44,6 @@ class CustomerioReactnative: NSObject {
                 // config.isEnableInApp = true
             }
         }
-        
-        /*
-         organizationId will be removed in future releases. To enable in-app use config option
-         config.isEnableInApp = true
-         */
-        if organizationId != "" {
-            initializeInApp(organizationId: organizationId)
-        }
-        
     }
     
     /**

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -39,9 +39,9 @@ class CustomerioReactnative: NSObject {
             if let trackingApiUrl = configData["trackingApiUrl"] as? String, !trackingApiUrl.isEmpty {
                 config.trackingApiUrl = trackingApiUrl
             }
-            if let isEnableInApp = configData["enableInApp"] as? Bool, isEnableInApp {
-                self.initializeInApp()
-            }
+        }
+        if let isEnableInApp = configData["enableInApp"] as? Bool, isEnableInApp {
+            initializeInApp()
         }
     }
     

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -40,7 +40,7 @@ class CustomerioReactnative: NSObject {
                 config.trackingApiUrl = trackingApiUrl
             }
             if let isEnableInApp = configData["enableInApp"] as? Bool, isEnableInApp {
-                initializeInApp()
+                self.initializeInApp()
             }
         }
     }

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -113,15 +113,5 @@ class CustomerioReactnative: NSObject {
         }
         CustomerIO.shared.screen(name: name, data: body)
     }
-    
-    /**
-        Intialize in-app using customerio package
-     */
-    @available(*, deprecated, message: "Enable in-app using SDK configuration")
-    private func initializeInApp(organizationId: String) -> Void{
-        DispatchQueue.main.async {
-            MessagingInApp.shared.initialize(organizationId: organizationId)
-        }
-    }
 }
 

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -121,6 +121,5 @@ class CustomerioReactnative: NSObject {
             MessagingInApp.shared.initialize()
         }
     }
-
 }
 

--- a/src/CustomerioConfig.tsx
+++ b/src/CustomerioConfig.tsx
@@ -25,7 +25,7 @@ class CustomerIOEnv {
     apiKey: string = ""
     region: Region = Region.US
     /**
-     * @deprecated since version 2.0.1
+     * @deprecated since version 2.0.2
      * 
      * organizationId is no longer needed and will be removed in future releases.
      * Please remove organizationId from code and enable in-app messaging using {CustomerioConfig.enableInApp}.

--- a/src/CustomerioConfig.tsx
+++ b/src/CustomerioConfig.tsx
@@ -13,6 +13,7 @@ import {CioLogLevel, Region} from './CustomerioEnum'
 class CustomerioConfig {
     logLevel : CioLogLevel = CioLogLevel.error
     autoTrackDeviceAttributes : boolean = true
+    enableInApp: boolean = false
     trackingApiUrl : string = ""
     autoTrackPushEvents : boolean = true
     backgroundQueueMinNumberOfTasks : number = 10
@@ -23,6 +24,12 @@ class CustomerIOEnv {
     siteId: string = ""
     apiKey: string = ""
     region: Region = Region.US
+    /**
+     * @deprecated since version 2.0.1
+     * 
+     * organizationId is no longer needed and will be removed in future releases.
+     * Please remove organizationId from code and enable in-app messaging using {CustomerioConfig.enableInApp}.
+     */
     organizationId: string = ""
 }
 

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -51,6 +51,12 @@ class CustomerIO {
       packageConfig.version = expoVersion;
     }
 
+    if (env.organizationId && env.organizationId != '') {
+      console.warn('{organizationId} is deprecated and will be removed in future releases, please remove {organizationId} and enable in-app messaging using {CustomerioConfig.enableInApp}');
+      config.enableInApp = true;
+      console.warn('{config.enableInApp} set to {true} because {organizationId} was added');
+    }
+
     return CustomerioReactnative.initialize(env, config, packageConfig);
   }
 

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -53,8 +53,10 @@ class CustomerIO {
 
     if (env.organizationId && env.organizationId != '') {
       console.warn('{organizationId} is deprecated and will be removed in future releases, please remove {organizationId} and enable in-app messaging using {CustomerioConfig.enableInApp}');
-      config.enableInApp = true;
-      console.warn('{config.enableInApp} set to {true} because {organizationId} was added');
+      if (config.enableInApp == false) {
+        config.enableInApp = true;
+        console.warn('{config.enableInApp} set to {true} because {organizationId} was added');
+      }
     }
 
     return CustomerioReactnative.initialize(env, config, packageConfig);


### PR DESCRIPTION
Fixes: https://github.com/customerio/issues/issues/8990

### Changes

- Removed `organizationId` from native wrappers
- Added `enableInApp` flag to enable/disable in-app messaging module
- Auto set `enableInApp` based on `organizationId` for existing customers
- Added appropriate warnings
- Updated native Android and iOS SDKs