### PR TITLE
fix: remove return from init

### DIFF
--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -60,7 +60,7 @@ class CustomerIO {
       }
     }
 
-    return CustomerioReactnative.initialize(env, config, packageConfig);
+    CustomerioReactnative.initialize(env, config, packageConfig);
   }
 
   /**


### PR DESCRIPTION
Closes: https://github.com/customerio/issues/issues/9340

### Changes

- Removed init method from SDK initialization to make it void