### PR TITLE
fix: kotlin version in gradle props

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,11 +27,8 @@ def getExtOrIntegerDefault(name) {
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   defaultConfig {
-    minSdkVersion 21
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
-    versionCode 1
-    versionName "1.0"
-    
   }
   
   buildTypes {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,5 @@
-customerio.reactnative.kotlinVersion=1.5.31
+customerio.reactnative.kotlinVersion=1.7.21
 customerio.reactnative.compileSdkVersion=30
 customerio.reactnative.targetSdkVersion=30
+customerio.reactnative.minSdkVersion=21
 customerio.reactnative.cioSDKVersionAndroid=[3.3,4.0)


### PR DESCRIPTION
I created a new sample app with React Native version `0.71.3`. But the app could not compile because of lower Kotlin version set in gradle than expected. I updated our React Native SDK to match the values with our Android SDK. However, if we found any customer facing issues with this change, we can suggest them to override kotlin version by adding the following to their `android/gradle.properties`

```
kotlinVersion=1.5.31
```

### Changes

- Updated `kotlinVersion` in gradle props to [match with Android SDK](https://github.com/customerio/customerio-android/blob/beta/buildSrc/src/main/kotlin/io.customer/android/Versions.kt#L22)
- Updated `minSdkVersion` to [match with Android SDK](https://github.com/customerio/customerio-android/blob/beta/buildSrc/src/main/kotlin/io.customer/android/Configurations.kt#L4-L6)
- Removed `versionCode` and `versionName` as they aren't needed for SDK modules