### PR TITLE
fix: add messaging service for react native sdk

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,4 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.customer.reactnative.sdk">
 
+    <application>
+        <service
+            android:name=".messagingpush.CustomerIORNFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter android:priority="-1">
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+    </application>
 </manifest>

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/CustomerIORNFirebaseMessagingService.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/CustomerIORNFirebaseMessagingService.kt
@@ -1,0 +1,12 @@
+package io.customer.reactnative.sdk.messagingpush
+
+import android.annotation.SuppressLint
+import io.customer.messagingpush.CustomerIOFirebaseMessagingService
+
+/**
+ * Customer.io firebase messaging service class that inherits base messaging service from native
+ * Android SDK to get all basic functionality. This class can be used to include react native
+ * specific features e.g. triggering events to JS/TS, etc.
+ */
+@SuppressLint("MissingFirebaseInstanceTokenRefresh")
+open class CustomerIORNFirebaseMessagingService : CustomerIOFirebaseMessagingService()


### PR DESCRIPTION
Closes: https://github.com/customerio/issues/issues/9477

### Changes

- Added `CustomerIORNFirebaseMessagingService ` and registered it as default notification service for react native SDK

For anyone using multiple notification services, we can recommend them to add the following in `application` tag to their `android/app/src/main/AndroidManifest.xml`

```
<service
    android:name="io.customer.reactnative.sdk.messagingpush.CustomerIORNFirebaseMessagingService"
    android:exported="false">
    <intent-filter>
        <action android:name="com.google.firebase.MESSAGING_EVENT" />
    </intent-filter>
</service>
```