### PR TITLE
ci: fix github ref in npm publish step of deploy action

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -16,6 +16,7 @@ jobs:
     name: Deploy git tag
     runs-on: ubuntu-latest
     outputs:
+      new_release_git_head: ${{ steps.semantic-release.outputs.new_release_git_head }}
       new_release_published: ${{ steps.semantic-release.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic-release.outputs.new_release_version }}
     steps:
@@ -114,10 +115,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.deploy-git-tag.outputs.new_release_git_head }}
+
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'yarn'
+
       - run: yarn install --frozen-lockfile
 
       - name: Deploy to npm


### PR DESCRIPTION
The deploy-sdk action has two jobs. In the first, semantic-release will create a commit that bumps package.json, and then pushes to the `main` branch.

The second job will checkout the code and publish to npm. However, since it relies on $GITHUB_REF, it was checking out the original hash which didn't include the package.json bump.