### PR TITLE
feat: push permission prompt [android]

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 customerio.reactnative.kotlinVersion=1.7.21
-customerio.reactnative.compileSdkVersion=33
-customerio.reactnative.targetSdkVersion=33
+customerio.reactnative.compileSdkVersion=30
+customerio.reactnative.targetSdkVersion=30
 customerio.reactnative.minSdkVersion=21
 customerio.reactnative.cioSDKVersionAndroid=[3.3,4.0)

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 customerio.reactnative.kotlinVersion=1.7.21
-customerio.reactnative.compileSdkVersion=30
-customerio.reactnative.targetSdkVersion=30
+customerio.reactnative.compileSdkVersion=33
+customerio.reactnative.targetSdkVersion=33
 customerio.reactnative.minSdkVersion=21
 customerio.reactnative.cioSDKVersionAndroid=[3.3,4.0)

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.customer.reactnative.sdk">
+    
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 </manifest>

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
@@ -1,16 +1,15 @@
 package io.customer.reactnative.sdk
 
-import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.ReactMethod
-import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.*
 import io.customer.reactnative.sdk.extension.toMap
+import io.customer.reactnative.sdk.messagingpush.RNCIOPushMessaging
 import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOShared
 import io.customer.sdk.util.Logger
 
 class CustomerIOReactNativeModule(
     reactContext: ReactApplicationContext,
+    private val pushMessagingModule: RNCIOPushMessaging,
     private val inAppMessagingModule: RNCIOInAppMessaging,
 ) : ReactContextBaseJavaModule(reactContext) {
     private val logger: Logger
@@ -109,6 +108,16 @@ class CustomerIOReactNativeModule(
         if (isNotInitialized()) return
 
         customerIO.registerDeviceToken(token)
+    }
+
+    @ReactMethod
+    fun getPushPermissionStatus(promise: Promise) {
+        pushMessagingModule.getPushPermissionStatus(promise)
+    }
+
+    @ReactMethod
+    fun showPromptForPushNotifications(pushConfigurationOptions: ReadableMap?, promise: Promise) {
+        pushMessagingModule.showPromptForPushNotifications(pushConfigurationOptions, promise)
     }
 
     companion object {

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
@@ -111,8 +111,8 @@ class CustomerIOReactNativeModule(
     }
 
     @ReactMethod
-    fun getPushPermissionStatus(promise: Promise) {
-        pushMessagingModule.getPushPermissionStatus(promise)
+    fun getPushPermissionStatus(callback: Callback) {
+        pushMessagingModule.getPushPermissionStatus(callback)
     }
 
     @ReactMethod

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
@@ -4,14 +4,17 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
+import io.customer.reactnative.sdk.messagingpush.RNCIOPushMessaging
 
 class CustomerIOReactNativePackage : ReactPackage {
     override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        val pushMessagingModule = RNCIOPushMessaging(reactContext)
         val inAppMessagingModule = RNCIOInAppMessaging(reactContext)
         return listOf(
             inAppMessagingModule,
             CustomerIOReactNativeModule(
                 reactContext = reactContext,
+                pushMessagingModule = pushMessagingModule,
                 inAppMessagingModule = inAppMessagingModule,
             ),
         )

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/PermissionStatus.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/PermissionStatus.kt
@@ -1,0 +1,9 @@
+package io.customer.reactnative.sdk.messagingpush
+
+/**
+ * Enum class for wrapping status of Android app permissions.
+ */
+enum class PermissionStatus {
+    Granted,
+    Denied,
+}

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -37,7 +37,7 @@ class RNCIOPushMessaging(
      */
     @ReactMethod
     fun showPromptForPushNotifications(pushConfigurationOptions: ReadableMap?, promise: Promise) {
-        // Skip requesting permissions for older version and when permission already granted
+        // Skip requesting permissions for older versions and when permission already granted
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || checkPushPermissionStatus() == PermissionStatus.Granted) {
             promise.resolve(PermissionStatus.Granted.toReactNativeResult)
             return

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -37,8 +37,8 @@ class RNCIOPushMessaging(
      */
     @ReactMethod
     fun showPromptForPushNotifications(pushConfigurationOptions: ReadableMap?, promise: Promise) {
-        // Skip requesting permissions for older versions and when permission already granted
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || checkPushPermissionStatus() == PermissionStatus.Granted) {
+        // Skip requesting permissions when already granted
+        if (checkPushPermissionStatus() == PermissionStatus.Granted) {
             promise.resolve(PermissionStatus.Granted.toReactNativeResult)
             return
         }
@@ -60,9 +60,9 @@ class RNCIOPushMessaging(
      * Checks current permission of push notification permission
      */
     private fun checkPushPermissionStatus(): PermissionStatus =
-        if (ContextCompat.checkSelfPermission(
-                reactContext,
-                Manifest.permission.POST_NOTIFICATIONS,
+        // Skip requesting permissions for older versions where not required
+        if (Build.VERSION.SDK_INT < BUILD_VERSION_CODE_TIRAMISU || ContextCompat.checkSelfPermission(
+                reactContext, POST_NOTIFICATIONS_PERMISSION_NAME,
             ) == PackageManager.PERMISSION_GRANTED
         ) PermissionStatus.Granted
         else PermissionStatus.Denied
@@ -105,6 +105,7 @@ class RNCIOPushMessaging(
          */
         private const val POST_NOTIFICATIONS_PERMISSION_NAME =
             "android.permission.POST_NOTIFICATIONS"
+        private const val BUILD_VERSION_CODE_TIRAMISU = 33
         private const val POST_NOTIFICATIONS_PERMISSION_REQUEST = 24676
     }
 }

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -85,7 +85,7 @@ class RNCIOPushMessaging(
             } else {
                 resolvePermissionPromise(PermissionStatus.Denied)
             }
-            true // as this permission can be removed now
+            true // as this permission listener can be removed now
         }
         else -> false // desired permission not yet granted, so we will keep the listener
     }

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -1,0 +1,103 @@
+package io.customer.reactnative.sdk.messagingpush
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+import com.facebook.react.bridge.*
+import com.facebook.react.modules.core.PermissionAwareActivity
+import com.facebook.react.modules.core.PermissionListener
+
+/**
+ * ReactNative module to hold in-app messages features in a single place to bridge with native code.
+ */
+class RNCIOPushMessaging(
+    private val reactContext: ReactApplicationContext,
+) : ReactContextBaseJavaModule(reactContext), PermissionListener {
+    /**
+     * Temporarily holds reference for notification request as the request is dependent on Android
+     * lifecycle and cannot be completed instantly.
+     */
+    private var notificationRequestPromise: Promise? = null
+
+    @ReactMethod
+    fun getPushPermissionStatus(promise: Promise) {
+        promise.resolve(checkPushPermissionStatus().toReactNativeResult)
+    }
+
+    /**
+     * To request push notification permissions using native apis. Push notifications doesn't
+     * require permissions for Android versions older than 13, so the results are returned instantly.
+     * For newer versions, the permission is requested and the promise is resolved after the request
+     * has been completed.
+     *
+     * @param pushConfigurationOptions configurations options for push notifications, required for
+     * iOS only, unused on Android.
+     * @param promise to resolve and return the results.
+     */
+    @ReactMethod
+    fun showPromptForPushNotifications(pushConfigurationOptions: ReadableMap?, promise: Promise) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            promise.resolve(checkPushPermissionStatus().toReactNativeResult)
+            return
+        }
+
+        try {
+            notificationRequestPromise = promise
+            (currentActivity as PermissionAwareActivity).requestPermissions(
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                POST_NOTIFICATIONS_PERMISSION_REQUEST,
+                this,
+            )
+        } catch (ex: Throwable) {
+            promise.reject(ex)
+            notificationRequestPromise = null
+        }
+    }
+
+    /**
+     * Checks current permission of push notification permission
+     */
+    private fun checkPushPermissionStatus(): PermissionStatus = if (
+        ContextCompat.checkSelfPermission(
+            reactContext,
+            Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
+    ) PermissionStatus.Granted
+    else PermissionStatus.Denied
+
+    /**
+     * Resolves and clears promise with the provided permission status
+     */
+    private fun resolvePermissionPromise(status: PermissionStatus) {
+        notificationRequestPromise?.resolve(status.toReactNativeResult)
+        notificationRequestPromise = null
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int, permissions: Array<String>, grantResults: IntArray,
+    ): Boolean = when (requestCode) {
+        POST_NOTIFICATIONS_PERMISSION_REQUEST -> {
+            // If request is cancelled, the result arrays are empty.
+            if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                resolvePermissionPromise(PermissionStatus.Granted)
+            } else {
+                resolvePermissionPromise(PermissionStatus.Denied)
+            }
+            true // as this permission can be removed now
+        }
+        else -> false // desired permission not yet granted, so we will keep the listener
+    }
+
+    override fun getName(): String = "CustomerioPushMessaging"
+
+    /**
+     * Maps native class to react native supported type so the result can be passed on to JS/TS classes.
+     */
+    private val PermissionStatus.toReactNativeResult: Any
+        get() = name
+
+    companion object {
+        private const val POST_NOTIFICATIONS_PERMISSION_REQUEST = 24676
+    }
+}

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -21,8 +21,8 @@ class RNCIOPushMessaging(
     private var notificationRequestPromise: Promise? = null
 
     @ReactMethod
-    fun getPushPermissionStatus(promise: Promise) {
-        promise.resolve(checkPushPermissionStatus().toReactNativeResult)
+    fun getPushPermissionStatus(callback: Callback) {
+        callback.invoke(checkPushPermissionStatus().toReactNativeResult)
     }
 
     /**

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -46,7 +46,7 @@ class RNCIOPushMessaging(
         try {
             notificationRequestPromise = promise
             (currentActivity as PermissionAwareActivity).requestPermissions(
-                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                arrayOf(POST_NOTIFICATIONS_PERMISSION_NAME),
                 POST_NOTIFICATIONS_PERMISSION_REQUEST,
                 this,
             )
@@ -96,9 +96,15 @@ class RNCIOPushMessaging(
      * Maps native class to react native supported type so the result can be passed on to JS/TS classes.
      */
     private val PermissionStatus.toReactNativeResult: Any
-        get() = name
+        get() = this.name
 
     companion object {
+        /**
+         * Copying value os [Manifest.permission.POST_NOTIFICATIONS] as constant so we don't have to
+         * force newer compile sdk versions
+         */
+        private const val POST_NOTIFICATIONS_PERMISSION_NAME =
+            "android.permission.POST_NOTIFICATIONS"
         private const val POST_NOTIFICATIONS_PERMISSION_REQUEST = 24676
     }
 }

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -9,7 +9,7 @@ import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
 
 /**
- * ReactNative module to hold in-app messages features in a single place to bridge with native code.
+ * ReactNative module to hold push messages features in a single place to bridge with native code.
  */
 class RNCIOPushMessaging(
     private val reactContext: ReactApplicationContext,
@@ -44,8 +44,18 @@ class RNCIOPushMessaging(
         }
 
         try {
+            val activity = currentActivity
+            val permissionAwareActivity = activity as? PermissionAwareActivity
+            if (permissionAwareActivity == null) {
+                promise.reject(
+                    "E_ACTIVITY_DOES_NOT_EXIST",
+                    "Permission cannot be requested because activity doesn't exist. Please make sure to request permission from UI components only"
+                )
+                return
+            }
+
             notificationRequestPromise = promise
-            (currentActivity as PermissionAwareActivity).requestPermissions(
+            permissionAwareActivity.requestPermissions(
                 arrayOf(POST_NOTIFICATIONS_PERMISSION_NAME),
                 POST_NOTIFICATIONS_PERMISSION_REQUEST,
                 this,

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -37,8 +37,9 @@ class RNCIOPushMessaging(
      */
     @ReactMethod
     fun showPromptForPushNotifications(pushConfigurationOptions: ReadableMap?, promise: Promise) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            promise.resolve(checkPushPermissionStatus().toReactNativeResult)
+        // Skip requesting permissions for older version and when permission already granted
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || checkPushPermissionStatus() == PermissionStatus.Granted) {
+            promise.resolve(PermissionStatus.Granted.toReactNativeResult)
             return
         }
 
@@ -58,13 +59,13 @@ class RNCIOPushMessaging(
     /**
      * Checks current permission of push notification permission
      */
-    private fun checkPushPermissionStatus(): PermissionStatus = if (
-        ContextCompat.checkSelfPermission(
-            reactContext,
-            Manifest.permission.POST_NOTIFICATIONS
-        ) == PackageManager.PERMISSION_GRANTED
-    ) PermissionStatus.Granted
-    else PermissionStatus.Denied
+    private fun checkPushPermissionStatus(): PermissionStatus =
+        if (ContextCompat.checkSelfPermission(
+                reactContext,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        ) PermissionStatus.Granted
+        else PermissionStatus.Denied
 
     /**
      * Resolves and clears promise with the provided permission status


### PR DESCRIPTION
helps: https://github.com/customerio/issues/issues/8746
helps: https://github.com/customerio/issues/issues/9493

This PR includes changes for Android platform only. See #101 for more details.

### Changes

- ~Updated target and compile SDK version to `33` as `POST_NOTIFICATIONS` permission is only available in SDK 33~ Replaced with permission constant
- Added `RNCIOPushMessaging` module to react package internally to keep all push related code separate from same module
- Added `PermissionStatus` for permission visibility and match with iOS
- Implemented method exposed in react native react native package for Android

**NOTE:** The expected results for methods exposed in react native should not change. If you notice anything that could create different results from changes in iOS, please point it out so we can match the results