### PR TITLE
fix: replace any data types with strongly typed objects

### DIFF
--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -4,12 +4,16 @@ import Common
 import CioMessagingInApp
 import UserNotifications
 
-enum PushPermissionStatus : String {
-    case denied = "Denied"
-    case notDetermined = "NotDetermined"
-    case unknown = "Unknown"
-    case granted = "Granted"
+enum PushPermissionStatus: String {
+    case denied
+    case notDetermined
+    case granted
+
+    var rawValue: String {
+        return self.capitalized
+    }
 }
+
 @objc(CustomerioReactnative)
 class CustomerioReactnative: NSObject {
 

--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -4,13 +4,13 @@ import Common
 import CioMessagingInApp
 import UserNotifications
 
-enum PushPermissionStatus: String {
+enum PushPermissionStatus: String, CaseIterable {
     case denied
     case notDetermined
     case granted
 
-    var rawValue: String {
-        return self.capitalized
+    var value: String {
+        return rawValue.capitalized
     }
 }
 
@@ -152,10 +152,10 @@ class CustomerioReactnative: NSObject {
                         reject("[CIO]", "Error requesting push notification permission.", permissionStatus as? Error)
                         return
                     }
-                    resolve(status ? PushPermissionStatus.granted.rawValue : PushPermissionStatus.denied.rawValue)
+                    resolve(status ? PushPermissionStatus.granted.value : PushPermissionStatus.denied.value)
                 }
             } else {
-                resolve(status.rawValue)
+                resolve(status.value)
             }
         }
     }
@@ -166,7 +166,7 @@ class CustomerioReactnative: NSObject {
     @objc(getPushPermissionStatus:rejecter:)
     func getPushPermissionStatus(resolver resolve: @escaping(RCTPromiseResolveBlock), rejecter reject: @escaping(RCTPromiseRejectBlock)) -> Void {
         getPushNotificationPermissionStatus { status in
-            resolve(status.rawValue)
+            resolve(status.value)
         }
     }
     

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -6,6 +6,7 @@ import {
 } from './CustomerioConfig';
 import { Region } from './CustomerioEnum';
 import { CustomerIOInAppMessaging } from './CustomerIOInAppMessaging';
+import type { PushPermissionOptions } from './types/PushPermissionOptions';
 var pjson = require("customerio-reactnative/package.json");
 
 const LINKING_ERROR =
@@ -151,18 +152,19 @@ class CustomerIO {
    * @param options
    * @returns Success & Failure promises
    */
-  static async showPromptForPushNotifications(options?: any) : Promise<any>{
-    let pushConfigurationOptions  = {
-      "ios": {
-        "badge" : true,
-        "sound" : true
-      }
-    }
-    if (typeof options !== 'undefined'){
-      pushConfigurationOptions = options
-    }
-  
-  return CustomerioReactnative.showPromptForPushNotifications(pushConfigurationOptions)
+  static async showPromptForPushNotifications(
+    options?: PushPermissionOptions
+  ): Promise<any> {
+    let defaultOptions: PushPermissionOptions = {
+      ios: {
+        badge: true,
+        sound: true,
+      },
+    };
+
+    return CustomerioReactnative.showPromptForPushNotifications(
+      options || defaultOptions
+    );
   }
 
   /**

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -6,7 +6,7 @@ import {
 } from './CustomerioConfig';
 import { Region } from './CustomerioEnum';
 import { CustomerIOInAppMessaging } from './CustomerIOInAppMessaging';
-import type { PushPermissionOptions } from './types/PushPermissionOptions';
+import type { PushPermissionStatus, PushPermissionOptions } from './types';
 var pjson = require("customerio-reactnative/package.json");
 
 const LINKING_ERROR =
@@ -154,7 +154,7 @@ class CustomerIO {
    */
   static async showPromptForPushNotifications(
     options?: PushPermissionOptions
-  ): Promise<any> {
+  ): Promise<PushPermissionStatus> {
     let defaultOptions: PushPermissionOptions = {
       ios: {
         badge: true,
@@ -171,7 +171,7 @@ class CustomerIO {
    * Get status of push permission for the app
    * @returns Promise with status of push permission as a string
    */
-  static getPushPermissionStatus() : Promise<any> {
+  static getPushPermissionStatus() : Promise<PushPermissionStatus> {
     return CustomerioReactnative.getPushPermissionStatus()
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,3 +18,5 @@ export {
   CustomerIOEnv,
   CioLogLevel
 };
+
+export * from "./types";

--- a/src/types/PushPermissionOptions.tsx
+++ b/src/types/PushPermissionOptions.tsx
@@ -1,0 +1,6 @@
+export interface PushPermissionOptions {
+  ios?: {
+    badge: boolean;
+    sound: boolean;
+  };
+}

--- a/src/types/PushPermissionStatus.tsx
+++ b/src/types/PushPermissionStatus.tsx
@@ -1,0 +1,5 @@
+export enum PushPermissionStatus {
+    Granted = "Granted",
+    Denied = "Denied",
+    NotDetermined = "NotDetermined"
+}

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -1,0 +1,1 @@
+export * from './PushPermissionOptions'

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -1,1 +1,2 @@
 export * from './PushPermissionOptions'
+export * from './PushPermissionStatus'


### PR DESCRIPTION
Add typescript definitions for a better development experience for typescript customers. 

PR needs tested in Ami app to confirm that the feature is working as intended. In particular, we need to test the new `PushPermissionStatus` type is populated on Android and iOS. 

The `PushPermissionStatus` is just a String. We have to test that both the Android and iOS ami apps result string when calling `getPushPermissionStatus` is one of the 3 hard-coded strings in `PushPermissionStatus`. 

Lastly for testing, we have to make sure that a RN app that uses Typescript will compile it's code while using this code change. With the branch `levi/typescript` of the Ami app, if you run `yarn tsc`, you will see that the only code that does not compile successfully is non-CIO SDK code. This makes me feel confident the typescript code will compile. 