### PR TITLE
fix: push permission status value as received from native modules

### DIFF
--- a/src/types/PushPermissionStatus.tsx
+++ b/src/types/PushPermissionStatus.tsx
@@ -1,5 +1,5 @@
 export enum PushPermissionStatus {
   Granted = 'Granted',
   Denied = 'Denied',
-  NotDetermined = 'NotDetermined',
+  NotDetermined = 'Notdetermined',
 }


### PR DESCRIPTION
Related to GH issue https://github.com/customerio/customerio-reactnative/issues/115

[PushPermissionStatus.NotDetermined](https://github.com/customerio/customerio-reactnative/blob/main/src/types/PushPermissionStatus.tsx) is `NotDetermined` but the package receives `Notdetermined` from native modules

This PR fixes the mismatch