### PR TITLE
feat: process push notifications received outside CIO SDK

### DIFF
--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
@@ -12,6 +12,7 @@ class CustomerIOReactNativePackage : ReactPackage {
         val inAppMessagingModule = RNCIOInAppMessaging(reactContext)
         return listOf(
             inAppMessagingModule,
+            pushMessagingModule,
             CustomerIOReactNativeModule(
                 reactContext = reactContext,
                 pushMessagingModule = pushMessagingModule,

--- a/android/src/main/java/io/customer/reactnative/sdk/extension/StringExt.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/extension/StringExt.kt
@@ -1,3 +1,8 @@
 package io.customer.reactnative.sdk.extension
 
 internal fun String.takeIfNotBlank(): String? = takeIf { it.isNotBlank() }
+
+internal fun String.camelToSnakeCase() = fold(StringBuilder(length)) { acc, c ->
+    if (c in 'A'..'Z') (if (acc.isNotEmpty()) acc.append('_') else acc).append(c + ('a' - 'A'))
+    else acc.append(c)
+}.toString()

--- a/android/src/main/java/io/customer/reactnative/sdk/extension/StringExt.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/extension/StringExt.kt
@@ -1,8 +1,3 @@
 package io.customer.reactnative.sdk.extension
 
 internal fun String.takeIfNotBlank(): String? = takeIf { it.isNotBlank() }
-
-internal fun String.camelToSnakeCase() = fold(StringBuilder(length)) { acc, c ->
-    if (c in 'A'..'Z') (if (acc.isNotEmpty()) acc.append('_') else acc).append(c + ('a' - 'A'))
-    else acc.append(c)
-}.toString()

--- a/android/src/main/java/io/customer/reactnative/sdk/extension/TypeConversion.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/extension/TypeConversion.kt
@@ -10,7 +10,7 @@ internal fun ReadableMap?.toMap(): Map<String, Any> {
 }
 
 internal fun ReadableMap.toMutableStringMap(): MutableMap<String, String?> {
-    return this.toHashMap().mapValues { toString() }.toMutableMap()
+    return this.toHashMap().mapValues { (_, value) -> value?.toString() }.toMutableMap()
 }
 
 internal fun String?.toRegion(fallback: Region = Region.US): Region {

--- a/android/src/main/java/io/customer/reactnative/sdk/extension/TypeConversion.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/extension/TypeConversion.kt
@@ -23,18 +23,25 @@ internal fun Double?.toCIOLogLevel(fallback: CioLogLevel = CioLogLevel.NONE): Ci
     else CioLogLevel.values().getOrNull(index = toInt() - 1) ?: fallback
 }
 
+/**
+ * Extensions function to build FCM [RemoteMessage] using RN map. This should be independent from
+ * the sender and should handle all scenarios to build a valid [RemoteMessage] for our native SDK.
+ */
 internal fun ReadableMap.toFCMRemoteMessage(): RemoteMessage {
     val cioParams = mutableListOf<Pair<String, Any>>()
     val googleParams = mutableListOf<Pair<String, Any>>()
     for ((key, value) in this.entryIterator) {
         when (key) {
             "data" -> {
+                // data params need to be added as flat params to match FCM expectations
                 val dataMap = value as ReadableMap
                 for (dataMapEntry in dataMap.entryIterator) {
                     cioParams.add(dataMapEntry.key to dataMapEntry.value)
                 }
             }
+            // params to be added without the prefix
             "from" -> googleParams.add(key to value)
+            // params to be added with the prefix and snake case to match FCM expectations
             else -> googleParams.add(key.asGoogleParamKey() to value)
         }
     }
@@ -42,4 +49,7 @@ internal fun ReadableMap.toFCMRemoteMessage(): RemoteMessage {
     return RemoteMessage(bundle)
 }
 
+/**
+ * Adds appropriate prefix and converts to snake case to match FCM expectations.
+ */
 private fun String.asGoogleParamKey(): String = "google.${this.camelToSnakeCase()}"

--- a/android/src/main/java/io/customer/reactnative/sdk/extension/TypeConversion.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/extension/TypeConversion.kt
@@ -9,10 +9,6 @@ internal fun ReadableMap?.toMap(): Map<String, Any> {
     return this?.toHashMap() ?: emptyMap()
 }
 
-internal fun ReadableMap.toMutableStringMap(): MutableMap<String, String?> {
-    return this.toHashMap().mapValues { (_, value) -> value?.toString() }.toMutableMap()
-}
-
 internal fun String?.toRegion(fallback: Region = Region.US): Region {
     return if (this.isNullOrBlank()) fallback
     else listOf(
@@ -36,7 +32,13 @@ internal fun Double?.toCIOLogLevel(fallback: CioLogLevel = CioLogLevel.NONE): Ci
  */
 internal fun ReadableMap.toFCMRemoteMessage(destination: String): RemoteMessage {
     return with(RemoteMessage.Builder(destination)) {
-        getMap("data")?.toMutableStringMap()?.let { data -> setData(data) }
+        getMap("data")?.let { messageData ->
+            val messageDataIterator = messageData.keySetIterator()
+            while (messageDataIterator.hasNextKey()) {
+                val key = messageDataIterator.nextKey()
+                addData(key, messageData.getString(key))
+            }
+        }
         getString("messageId")?.let { id -> setMessageId(id) }
         getString("messageType")?.let { type -> setMessageType(type) }
         getString("collapseKey")?.let { key -> setCollapseKey(key) }

--- a/android/src/main/java/io/customer/reactnative/sdk/extension/TypeConversion.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/extension/TypeConversion.kt
@@ -34,7 +34,7 @@ private fun Any.toStringOrNull(): String? = try {
 }
 
 /**
- * Extensions function to build FCM [RemoteMessage] using RN map. This should be independent from
+ * Extension function to build FCM [RemoteMessage] using RN map. This should be independent from
  * the sender source and should be able to build a valid [RemoteMessage] for our native SDK.
  *
  * @param destination receiver of the message. It is mainly required for sending upstream messages,

--- a/android/src/main/java/io/customer/reactnative/sdk/extension/TypeConversion.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/extension/TypeConversion.kt
@@ -23,6 +23,17 @@ internal fun Double?.toCIOLogLevel(fallback: CioLogLevel = CioLogLevel.NONE): Ci
 }
 
 /**
+ * Safely transforms any value to string
+ */
+private fun Any.toStringOrNull(): String? = try {
+    toString()
+} catch (ex: Exception) {
+    // We don't need to print any error here as this is expected for some values and doesn't
+    // break anything
+    null
+}
+
+/**
  * Extensions function to build FCM [RemoteMessage] using RN map. This should be independent from
  * the sender source and should be able to build a valid [RemoteMessage] for our native SDK.
  *
@@ -31,12 +42,21 @@ internal fun Double?.toCIOLogLevel(fallback: CioLogLevel = CioLogLevel.NONE): Ci
  * string for it.
  */
 internal fun ReadableMap.toFCMRemoteMessage(destination: String): RemoteMessage {
+    val messageParams = buildMap {
+        putAll(getMap("notification").toMap())
+        // Adding `data` after `notification` so `data` params take more value as we mainly use
+        // `data` in rich push
+        putAll(getMap("data").toMap())
+    }
     return with(RemoteMessage.Builder(destination)) {
-        getMap("data")?.let { messageData ->
-            val messageDataIterator = messageData.keySetIterator()
-            while (messageDataIterator.hasNextKey()) {
-                val key = messageDataIterator.nextKey()
-                addData(key, messageData.getString(key))
+        messageParams.let { params ->
+            val paramsIterator = params.iterator()
+            while (paramsIterator.hasNext()) {
+                val (key, value) = paramsIterator.next()
+                // Some values in notification object can be another object and may not support
+                // mapping to string values, transforming these values in a try-catch so the code
+                // doesn't break due to one bad value
+                value.toStringOrNull()?.let { v -> addData(key, v) }
             }
         }
         getString("messageId")?.let { id -> setMessageId(id) }

--- a/android/src/main/java/io/customer/reactnative/sdk/extension/TypeConversion.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/extension/TypeConversion.kt
@@ -10,11 +10,7 @@ internal fun ReadableMap?.toMap(): Map<String, Any> {
 }
 
 internal fun ReadableMap.toMutableStringMap(): MutableMap<String, String?> {
-    val map = mutableMapOf<String, String?>()
-    for ((key, value) in this.entryIterator) {
-        map[key] = value?.toString()
-    }
-    return map
+    return this.toHashMap().mapValues { toString() }.toMutableMap()
 }
 
 internal fun String?.toRegion(fallback: Region = Region.US): Region {

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -8,9 +8,12 @@ import com.facebook.react.bridge.*
 import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
 import io.customer.messagingpush.CustomerIOFirebaseMessagingService
+import io.customer.reactnative.sdk.extension.takeIfNotBlank
 import io.customer.reactnative.sdk.extension.toFCMRemoteMessage
+import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOShared
 import io.customer.sdk.util.Logger
+import java.util.*
 
 /**
  * ReactNative module to hold push messages features in a single place to bridge with native code.
@@ -87,9 +90,13 @@ class RNCIOPushMessaging(
                 return
             }
 
+            // Generate destination string, see docs on receiver method for more details
+            val destination = message.getString("to")?.takeIfNotBlank()
+                ?: CustomerIO.instanceOrNull(reactContext)?.diGraph?.sitePreferenceRepository?.getIdentifier()
+                ?: UUID.randomUUID().toString()
             val isNotificationHandled = CustomerIOFirebaseMessagingService.onMessageReceived(
                 context = reactContext,
-                remoteMessage = message.toFCMRemoteMessage(),
+                remoteMessage = message.toFCMRemoteMessage(destination = destination),
                 handleNotificationTrigger = true,
             )
             promise.resolve(isNotificationHandled)

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -70,6 +70,12 @@ class RNCIOPushMessaging(
         }
     }
 
+    /**
+     * Handles push notification received. This can be helpful in processing push notifications
+     * received outside the CIO SDK.
+     *
+     * @param message push payload received from FCM.
+     */
     @ReactMethod
     fun handleMessage(message: ReadableMap?, promise: Promise) {
         try {

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -4,9 +4,13 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
 import com.facebook.react.bridge.*
 import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
+import com.google.firebase.messaging.RemoteMessage
+import io.customer.messagingpush.CustomerIOFirebaseMessagingService
+import io.customer.reactnative.sdk.extension.toMap
 
 /**
  * ReactNative module to hold push messages features in a single place to bridge with native code.
@@ -63,6 +67,21 @@ class RNCIOPushMessaging(
         } catch (ex: Throwable) {
             promise.reject(ex)
             notificationRequestPromise = null
+        }
+    }
+
+    @ReactMethod
+    fun handleMessage(message: ReadableMap?, promise: Promise) {
+        try {
+            val remoteMessageBundle = bundleOf(*message.toMap().toList().toTypedArray())
+            val isNotificationHandled = CustomerIOFirebaseMessagingService.onMessageReceived(
+                context = reactContext,
+                remoteMessage = RemoteMessage(remoteMessageBundle),
+                handleNotificationTrigger = true,
+            )
+            promise.resolve(isNotificationHandled)
+        } catch (ex: Throwable) {
+            promise.reject(ex)
         }
     }
 

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -4,13 +4,11 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
-import androidx.core.os.bundleOf
 import com.facebook.react.bridge.*
 import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
-import com.google.firebase.messaging.RemoteMessage
 import io.customer.messagingpush.CustomerIOFirebaseMessagingService
-import io.customer.reactnative.sdk.extension.toMap
+import io.customer.reactnative.sdk.extension.toFCMRemoteMessage
 
 /**
  * ReactNative module to hold push messages features in a single place to bridge with native code.
@@ -79,14 +77,19 @@ class RNCIOPushMessaging(
     @ReactMethod
     fun handleMessage(message: ReadableMap?, promise: Promise) {
         try {
-            val remoteMessageBundle = bundleOf(*message.toMap().toList().toTypedArray())
+            if (message == null) {
+                promise.reject(IllegalArgumentException("Remote message cannot be null"))
+                return
+            }
+
             val isNotificationHandled = CustomerIOFirebaseMessagingService.onMessageReceived(
                 context = reactContext,
-                remoteMessage = RemoteMessage(remoteMessageBundle),
+                remoteMessage = message.toFCMRemoteMessage(),
                 handleNotificationTrigger = true,
             )
             promise.resolve(isNotificationHandled)
         } catch (ex: Throwable) {
+            ex.printStackTrace()
             promise.reject(ex)
         }
     }

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -9,6 +9,8 @@ import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
 import io.customer.messagingpush.CustomerIOFirebaseMessagingService
 import io.customer.reactnative.sdk.extension.toFCMRemoteMessage
+import io.customer.sdk.CustomerIOShared
+import io.customer.sdk.util.Logger
 
 /**
  * ReactNative module to hold push messages features in a single place to bridge with native code.
@@ -16,6 +18,9 @@ import io.customer.reactnative.sdk.extension.toFCMRemoteMessage
 class RNCIOPushMessaging(
     private val reactContext: ReactApplicationContext,
 ) : ReactContextBaseJavaModule(reactContext), PermissionListener {
+    private val logger: Logger
+        get() = CustomerIOShared.instance().diStaticGraph.logger
+
     /**
      * Temporarily holds reference for notification request as the request is dependent on Android
      * lifecycle and cannot be completed instantly.
@@ -89,7 +94,7 @@ class RNCIOPushMessaging(
             )
             promise.resolve(isNotificationHandled)
         } catch (ex: Throwable) {
-            ex.printStackTrace()
+            logger.error("Unable to handle push notification, reason: ${ex.message}")
             promise.reject(ex)
         }
     }

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -77,13 +77,14 @@ class RNCIOPushMessaging(
     }
 
     /**
-     * Handles push notification received. This can be helpful in processing push notifications
+     * Handles push notification received. This is helpful in processing push notifications
      * received outside the CIO SDK.
      *
      * @param message push payload received from FCM.
+     * @param handleNotificationTrigger indicating if the local notification should be triggered.
      */
     @ReactMethod
-    fun handleMessage(message: ReadableMap?, promise: Promise) {
+    fun handleMessage(message: ReadableMap?, handleNotificationTrigger: Boolean, promise: Promise) {
         try {
             if (message == null) {
                 promise.reject(IllegalArgumentException("Remote message cannot be null"))
@@ -97,7 +98,7 @@ class RNCIOPushMessaging(
             val isNotificationHandled = CustomerIOFirebaseMessagingService.onMessageReceived(
                 context = reactContext,
                 remoteMessage = message.toFCMRemoteMessage(destination = destination),
-                handleNotificationTrigger = true,
+                handleNotificationTrigger = handleNotificationTrigger,
             )
             promise.resolve(isNotificationHandled)
         } catch (ex: Throwable) {

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -10,7 +10,6 @@ import com.facebook.react.modules.core.PermissionListener
 import io.customer.messagingpush.CustomerIOFirebaseMessagingService
 import io.customer.reactnative.sdk.extension.takeIfNotBlank
 import io.customer.reactnative.sdk.extension.toFCMRemoteMessage
-import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOShared
 import io.customer.sdk.util.Logger
 import java.util.*
@@ -92,9 +91,8 @@ class RNCIOPushMessaging(
             }
 
             // Generate destination string, see docs on receiver method for more details
-            val destination = message.getString("to")?.takeIfNotBlank()
-                ?: CustomerIO.instanceOrNull(reactContext)?.diGraph?.sitePreferenceRepository?.getIdentifier()
-                ?: UUID.randomUUID().toString()
+            val destination =
+                message.getString("to")?.takeIfNotBlank() ?: UUID.randomUUID().toString()
             val isNotificationHandled = CustomerIOFirebaseMessagingService.onMessageReceived(
                 context = reactContext,
                 remoteMessage = message.toFCMRemoteMessage(destination = destination),

--- a/src/CustomerIOPushMessaging.tsx
+++ b/src/CustomerIOPushMessaging.tsx
@@ -1,0 +1,29 @@
+import { NativeModules, Platform } from 'react-native';
+
+const LINKING_ERROR =
+  `The package 'customerio-reactnative' doesn't seem to be linked. Make sure: \n\n` +
+  Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
+  '- You rebuilt the app after installing the package\n' +
+  '- You are not using Expo managed workflow\n';
+
+/**
+ * Get CustomerIOPushMessaging native module
+ */
+const PushMessagingNative = NativeModules.CustomerioPushMessaging
+  ? NativeModules.CustomerioPushMessaging
+  : new Proxy(
+      {},
+      {
+        get() {
+          throw new Error(LINKING_ERROR);
+        },
+      }
+    );
+
+class CustomerIOPushMessaging {
+  onMessageReceived(message: any): Promise<boolean> {
+    return PushMessagingNative.handleMessage(message);
+  }
+}
+
+export { CustomerIOPushMessaging };

--- a/src/CustomerIOPushMessaging.tsx
+++ b/src/CustomerIOPushMessaging.tsx
@@ -22,11 +22,15 @@ const PushMessagingNative = NativeModules.CustomerioPushMessaging
 
 class CustomerIOPushMessaging {
   /**
-   * Handles push notification received to help processing push notifications received outside the CIO SDK.
+   * Processes push notification received outside the CIO SDK. The method displays notification on
+   * device and tracks CIO metrics for push notification.
    *
-   * @param message push payload received from FCM.
-   * @param handleNotificationTrigger indicating if the local notification should be triggered.
-   * @return promise that resolves to boolean indicating whether this was handled by CustomerIO or not.
+   * @param message push payload received from FCM. The payload must contain data payload received in push
+   * notification.
+   * @param handleNotificationTrigger indicates whether it should display the notification or not.
+   * true (default): The SDK will display the notification and track associated metrics.
+   * false: The SDK will only process the notification to track metrics but will not display any notification.
+   * @return promise that resolves to boolean indicating if the notification was handled by the SDK or not.
    */
   onMessageReceived(
     message: any,
@@ -44,6 +48,17 @@ class CustomerIOPushMessaging {
         handleNotificationTrigger
       );
     }
+  }
+
+  /**
+   * Handles push notification received when app is background. Since FCM itself displays the notification
+   * when app is background, this method makes it easier to determine whether the notification should be
+   * displayed or not.
+   *
+   * @see [onMessageReceived] for more details
+   */
+  onBackgroundMessageReceived(message: any): Promise<boolean> {
+    return this.onMessageReceived(message, !message.notification);
   }
 }
 

--- a/src/CustomerIOPushMessaging.tsx
+++ b/src/CustomerIOPushMessaging.tsx
@@ -22,7 +22,11 @@ const PushMessagingNative = NativeModules.CustomerioPushMessaging
 
 class CustomerIOPushMessaging {
   onMessageReceived(message: any): Promise<boolean> {
-    return PushMessagingNative.handleMessage(message);
+    if (Platform.OS === 'ios') {
+      return Promise.resolve(true);
+    } else {
+      return PushMessagingNative.handleMessage(message);
+    }
   }
 }
 

--- a/src/CustomerIOPushMessaging.tsx
+++ b/src/CustomerIOPushMessaging.tsx
@@ -23,6 +23,10 @@ const PushMessagingNative = NativeModules.CustomerioPushMessaging
 class CustomerIOPushMessaging {
   onMessageReceived(message: any): Promise<boolean> {
     if (Platform.OS === 'ios') {
+      // Since push notifications on iOS work fine with multiple notification services,
+      // We don't need to process them on iOS for now.
+      // Resolving promise to true makes it easier for callers to avoid adding
+      // unnecessary platform specific checks.
       return Promise.resolve(true);
     } else {
       return PushMessagingNative.handleMessage(message);

--- a/src/CustomerIOPushMessaging.tsx
+++ b/src/CustomerIOPushMessaging.tsx
@@ -30,7 +30,7 @@ class CustomerIOPushMessaging {
    */
   onMessageReceived(
     message: any,
-    handleNotificationTrigger: boolean
+    handleNotificationTrigger: boolean = true
   ): Promise<boolean> {
     if (Platform.OS === 'ios') {
       // Since push notifications on iOS work fine with multiple notification services,

--- a/src/CustomerIOPushMessaging.tsx
+++ b/src/CustomerIOPushMessaging.tsx
@@ -21,7 +21,17 @@ const PushMessagingNative = NativeModules.CustomerioPushMessaging
     );
 
 class CustomerIOPushMessaging {
-  onMessageReceived(message: any): Promise<boolean> {
+  /**
+   * Handles push notification received to help processing push notifications received outside the CIO SDK.
+   *
+   * @param message push payload received from FCM.
+   * @param handleNotificationTrigger indicating if the local notification should be triggered.
+   * @return promise that resolves to boolean indicating whether this was handled by CustomerIO or not.
+   */
+  onMessageReceived(
+    message: any,
+    handleNotificationTrigger: boolean
+  ): Promise<boolean> {
     if (Platform.OS === 'ios') {
       // Since push notifications on iOS work fine with multiple notification services,
       // We don't need to process them on iOS for now.
@@ -29,7 +39,10 @@ class CustomerIOPushMessaging {
       // unnecessary platform specific checks.
       return Promise.resolve(true);
     } else {
-      return PushMessagingNative.handleMessage(message);
+      return PushMessagingNative.handleMessage(
+        message,
+        handleNotificationTrigger
+      );
     }
   }
 }

--- a/src/CustomerioTracking.tsx
+++ b/src/CustomerioTracking.tsx
@@ -6,6 +6,7 @@ import {
 } from './CustomerioConfig';
 import { Region } from './CustomerioEnum';
 import { CustomerIOInAppMessaging } from './CustomerIOInAppMessaging';
+import { CustomerIOPushMessaging } from './CustomerIOPushMessaging';
 import type { PushPermissionStatus, PushPermissionOptions } from './types';
 var pjson = require('customerio-reactnative/package.json');
 
@@ -134,6 +135,10 @@ class CustomerIO {
 
   static inAppMessaging(): CustomerIOInAppMessaging {
     return new CustomerIOInAppMessaging();
+  }
+
+  static pushMessaging(): CustomerIOPushMessaging {
+    return new CustomerIOPushMessaging();
   }
 
   /**


### PR DESCRIPTION
Closes: https://github.com/customerio/issues/issues/9591

### Changes

- Added `CustomerIOPushMessaging ` in react native to keep push messaging features in a single class
- Registered `RNCIOPushMessaging ` as react native android module
- Added support to generate notification locally using `RemoteMessage` for FCM

> iOS currently doesn't implement `CustomerioPushMessaging` and resolves promise to `true` by default

For anyone receiving notifications outside Customer.io SDK, they can generate notifications locally using the following code snippet:

```
CustomerIO.pushMessaging().onMessageReceived(message).then(handled => {
  // handled is true if notification was handled by Customer.io SDK; false otherwise
});
```

where `message` contains payload received using FCM.

An example using React Native Firebase library would look like:

```
useEffect(() => {
  const unsubscribe = messaging().onMessage(async remoteMessage => {
    CustomerIO.pushMessaging().onMessageReceived(remoteMessage).then(handled => {
      // handled is true if notification was handled by Customer.io SDK; false otherwise
    });
  });

  return unsubscribe;
}, []);
```

Similarly, they can implement `messaging().setBackgroundMessageHandler` to handle notifications in the background