### PR TITLE
fix: native push permission status match typescript enum value

### DIFF
--- a/ios/CustomerioReactnative.swift
+++ b/ios/CustomerioReactnative.swift
@@ -10,7 +10,7 @@ enum PushPermissionStatus: String, CaseIterable {
     case granted
 
     var value: String {
-        return rawValue.capitalized
+        return rawValue.firstUppercased
     }
 }
 

--- a/ios/CustomerioReactnative.xcodeproj/project.pbxproj
+++ b/ios/CustomerioReactnative.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		F4FF95D7245B92E800C19C63 /* CustomerioReactnative.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FF95D6245B92E800C19C63 /* CustomerioReactnative.swift */; };
+		F70A0C4829CB88AF00743116 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70A0C4729CB88AF00743116 /* StringExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -28,6 +29,7 @@
 		B3E7B5891CC2AC0600A0062D /* CustomerioReactnative.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomerioReactnative.m; sourceTree = "<group>"; };
 		F4FF95D5245B92E700C19C63 /* CustomerioReactnative-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CustomerioReactnative-Bridging-Header.h"; sourceTree = "<group>"; };
 		F4FF95D6245B92E800C19C63 /* CustomerioReactnative.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerioReactnative.swift; sourceTree = "<group>"; };
+		F70A0C4729CB88AF00743116 /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -52,6 +54,7 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				F70A0C4729CB88AF00743116 /* StringExtensions.swift */,
 				4641179D284117EC00FB9CA9 /* CustomerioUtils.swift */,
 				F4FF95D6245B92E800C19C63 /* CustomerioReactnative.swift */,
 				B3E7B5891CC2AC0600A0062D /* CustomerioReactnative.m */,
@@ -117,6 +120,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F70A0C4829CB88AF00743116 /* StringExtensions.swift in Sources */,
 				F4FF95D7245B92E800C19C63 /* CustomerioReactnative.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/StringExtensions.swift
+++ b/ios/StringExtensions.swift
@@ -1,0 +1,17 @@
+//
+//  StringExtensions.swift
+//  CustomerioReactnative
+//
+//  Created by Levi Bostian on 3/22/23.
+//  Copyright © 2023 Facebook. All rights reserved.
+//
+
+import Foundation
+
+internal extension StringProtocol {
+    // Uppercase the first character without modifying the rest of the string.
+    // "notDeteremined" -> "NotDetermined"
+    // "notdetermined" -> "Notdeteremined"
+    // "not determined" -> "Not determined"
+    var firstUppercased: String { return prefix(1).uppercased() + dropFirst() }
+}

--- a/ios/StringExtensions.swift
+++ b/ios/StringExtensions.swift
@@ -1,11 +1,3 @@
-//
-//  StringExtensions.swift
-//  CustomerioReactnative
-//
-//  Created by Levi Bostian on 3/22/23.
-//  Copyright © 2023 Facebook. All rights reserved.
-//
-
 import Foundation
 
 internal extension StringProtocol {


### PR DESCRIPTION
Closes: https://github.com/customerio/customerio-reactnative/issues/115

Alternative solution to [this pr](https://github.com/customerio/customerio-reactnative/pull/116). I decided to create a separate PR to demonstrate an idea that I had instead of modifying the branch in [this pr](https://github.com/customerio/customerio-reactnative/pull/116). 

It's recommended that only 1 PR is merged by the team. 