### PR TITLE
fix: push opened metrics tracked on Android 12

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,6 +49,7 @@ repositories {
   mavenCentral()
   google()
   maven { url 'https://maven.gist.build' }
+  maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
 
   def found = false
   def defaultDir = null

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,6 @@ repositories {
   mavenCentral()
   google()
   maven { url 'https://maven.gist.build' }
-  maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
 
   def found = false
   def defaultDir = null

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ customerio.reactnative.kotlinVersion=1.7.21
 customerio.reactnative.compileSdkVersion=30
 customerio.reactnative.targetSdkVersion=30
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=[3.3,4.0)
+customerio.reactnative.cioSDKVersionAndroid=fix-android-12-opened-metrics-SNAPSHOT

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ customerio.reactnative.kotlinVersion=1.7.21
 customerio.reactnative.compileSdkVersion=30
 customerio.reactnative.targetSdkVersion=30
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=fix-android-12-opened-metrics-SNAPSHOT
+customerio.reactnative.cioSDKVersionAndroid=[3.4.1,4.0)

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
@@ -39,8 +39,8 @@ class CustomerIOReactNativeModule(
         configuration: ReadableMap? = null,
         packageConfiguration: ReadableMap? = null,
     ) {
-        val isFirstInitialization = isNotInitialized()
-        if (isInstanceValid()) {
+        val isFirstInitialization = !isInstanceValid()
+        if (!isFirstInitialization) {
             logger.info("Customer.io instance already initialized, reinitializing")
         }
 
@@ -62,6 +62,7 @@ class CustomerIOReactNativeModule(
             // will already be attached in this case as they are registered to application object.
             if (isFirstInitialization) {
                 currentActivity?.let { activity ->
+                    logger.info("Requesting delayed activity lifecycle events")
                     val lifecycleCallbacks = customerIO.diGraph.activityLifecycleCallbacks
                     lifecycleCallbacks.postDelayedEventsForNonNativeActivity(activity)
                 }

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
@@ -17,8 +17,13 @@ class CustomerIOReactNativeModule(
     private lateinit var customerIO: CustomerIO
 
     init {
-        // If SDK is already initialized from CIO service using context, initialize the local
-        // reference with SDK instance
+        // If the SDK was already initialized from CIO service using context, initialize the local
+        // reference with SDK instance so it represents the actual state of SDK.
+        // SDK instance may only be initialized before when a notification was received while the
+        // app was in terminated state. Capturing the same instance helps us identify the initial
+        // state of SDK initialization.
+        // If the SDK was not initialized before, `CustomerIO.instance()` will throw an exception
+        // and local variable will also not be initialized.
         kotlin.runCatching {
             customerIO = CustomerIO.instance()
         }

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
@@ -39,8 +39,7 @@ class CustomerIOReactNativeModule(
         configuration: ReadableMap? = null,
         packageConfiguration: ReadableMap? = null,
     ) {
-        val isFirstInitialization = !isInstanceValid()
-        if (!isFirstInitialization) {
+        if (isInstanceValid()) {
             logger.info("Customer.io instance already initialized, reinitializing")
         }
 
@@ -57,16 +56,6 @@ class CustomerIOReactNativeModule(
                 inAppEventListener = inAppMessagingModule,
             )
             logger.info("Customer.io instance initialized successfully from app")
-            // Request lifecycle events for first initialization only as relaunching app
-            // in wrapper SDKs may result in reinitialization of SDK and lifecycle listener
-            // will already be attached in this case as they are registered to application object.
-            if (isFirstInitialization) {
-                currentActivity?.let { activity ->
-                    logger.info("Requesting delayed activity lifecycle events")
-                    val lifecycleCallbacks = customerIO.diGraph.activityLifecycleCallbacks
-                    lifecycleCallbacks.postDelayedEventsForNonNativeActivity(activity)
-                }
-            }
         } catch (ex: Exception) {
             logger.error("Failed to initialize Customer.io instance from app, ${ex.message}")
         }

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
@@ -39,6 +39,7 @@ class CustomerIOReactNativeModule(
         configuration: ReadableMap? = null,
         packageConfiguration: ReadableMap? = null,
     ) {
+        val isFirstInitialization = isNotInitialized()
         if (isInstanceValid()) {
             logger.info("Customer.io instance already initialized, reinitializing")
         }
@@ -56,6 +57,15 @@ class CustomerIOReactNativeModule(
                 inAppEventListener = inAppMessagingModule,
             )
             logger.info("Customer.io instance initialized successfully from app")
+            // Request lifecycle events for first initialization only as relaunching app
+            // in wrapper SDKs may result in reinitialization of SDK and lifecycle listener
+            // will already be attached in this case as they are registered to application object.
+            if (isFirstInitialization) {
+                currentActivity?.let { activity ->
+                    val lifecycleCallbacks = customerIO.diGraph.activityLifecycleCallbacks
+                    lifecycleCallbacks.postDelayedEventsForNonNativeActivity(activity)
+                }
+            }
         } catch (ex: Exception) {
             logger.error("Failed to initialize Customer.io instance from app, ${ex.message}")
         }


### PR DESCRIPTION
fixes: https://github.com/customerio/issues/issues/9483
android sdk changes: https://github.com/customerio/customerio-android/pull/184

### Changes

- Requested native SDK to trigger missed lifecycle events so messaging push listener can process notification payload