### PR TITLE
fix: autoupdate to latest major version of iOS SDK

### DIFF
--- a/customerio-reactnative.podspec
+++ b/customerio-reactnative.podspec
@@ -16,6 +16,9 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "CustomerIOTracking", '~> 2.1.0-beta.2'
-  s.dependency "CustomerIOMessagingInApp", '~> 2.1.0-beta.2'
+
+  # Syntax of native iOS pods allows for automatically upgrading to the latest major version of the iOS SDK. 
+  # Reference: https://guides.cocoapods.org/syntax/podfile.html#pod
+  s.dependency "CustomerIO/Tracking", '~> 2'
+  s.dependency "CustomerIO/MessagingInApp", '~> 2'
 end


### PR DESCRIPTION
This will need tested in Ami to confirm that our SDK is compatible with latest native iOS SDK. 

QA builds being created [over in the Ami RN github repo](https://github.com/customerio/amiapp-reactnative/pull/56)

# QA 

iOS Ami RN app build to QA test with: `levi/auto-update-ios (1682348352)`

## QA steps: 

This PR updates the native iOS SDK version that is used by the RN SDK. In order for this PR to pass QA, we need to run the smoke test suite to confirm the SDK functionality is stable. This PR does not add any new features or bug fixes to the RN SDK. We simply need to test existing SDK functionality to assert that there are not issues. 