### PR TITLE
Remove Lefthook in postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
     "bootstrap": "yarn example && yarn && yarn pods",
-    "postinstall": "node src/postInstall.js && npx lefthook install",
+    "postinstall": "node src/postInstall.js",
     "format": "npx prettier --write \"src/**/*.tsx\" && (npm run lint || true)"
   },
   "keywords": [


### PR DESCRIPTION
I believe it was maybe a mistake to keep lefthook in the post install command. Since for people who use yarn workspaces/eas, it will throw an error on trying to install. Another example: https://github.com/customerio/customerio-reactnative/issues/142

Example im using yarn workspaces and i get this error on install:
```
TypeError: workspaces config expects an Array
```
Since npm workspaces work different to yarn.

Here is a patch package file for a temp fix that works for me to get past install:
```
diff --git a/node_modules/customerio-reactnative/package.json b/node_modules/customerio-reactnative/package.json
index d22953d..d77a5d1 100644
--- a/node_modules/customerio-reactnative/package.json
+++ b/node_modules/customerio-reactnative/package.json
@@ -31,7 +31,7 @@
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
     "bootstrap": "yarn example && yarn && yarn pods",
-    "postinstall": "node src/postInstall.js && npx lefthook install",
+    "postinstall": "node src/postInstall.js",
     "format": "npx prettier --write \"src/**/*.tsx\" && (npm run lint || true)"
   },
   "keywords": [
   ```
   
It also creates a lefthook file on install.