### PR TITLE
refactor: APN sample app uses local SDK instead of production

### DIFF
--- a/Apps/APN/package.json
+++ b/Apps/APN/package.json
@@ -16,7 +16,7 @@
     "@react-native-community/push-notification-ios": "^1.10.1",
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
-    "customerio-reactnative": "^2.2.0",
+    "customerio-reactnative": "../..",
     "expo": "~42.0.1",
     "expo-splash-screen": "~0.11.2",
     "expo-status-bar": "~1.0.4",

--- a/Apps/APN/yarn.lock
+++ b/Apps/APN/yarn.lock
@@ -2537,10 +2537,8 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
-customerio-reactnative@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/customerio-reactnative/-/customerio-reactnative-2.2.0.tgz#27d3ea800efcaa438fd9584e55679ad9b28bc169"
-  integrity sha512-wwzG4kQkcqFe0DiOa9udkyEqYn039qqeWduikM6loKFuAMYASkJqq19yLeec7eyjcz1OWROQ/IsjPLubtiH7Uw==
+customerio-reactnative@../..:
+  version "2.4.2"
 
 dayjs@^1.8.15:
   version "1.11.3"


### PR DESCRIPTION
Change to allow our APN sample app to use local version of SDK instead of production version.