### PR TITLE
fix: iOS bad memory access crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "react-native": "src/index",
   "source": "src/index",
   "expoVersion": "",
-  "cioNativeiOSSdkVersion": "= 2.7.0",
+  "cioNativeiOSSdkVersion": "= 2.7.1",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
Release targeting to iOS version [2.7.1](https://github.com/customerio/customerio-ios/releases/tag/2.7.1)