### PR TITLE
fix: deinit cleanup repo bad memory access

### DIFF
--- a/Apps/APN/ios/Podfile
+++ b/Apps/APN/ios/Podfile
@@ -4,6 +4,10 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 platform :ios, '13.0'
 install! 'cocoapods', :deterministic_uuids => false
 
+require 'open-uri'
+IO.copy_stream(URI.open('https://raw.githubusercontent.com/customerio/customerio-ios/main/scripts/cocoapods_override_sdk.rb'), "/tmp/override_cio_sdk.rb")
+load "/tmp/override_cio_sdk.rb"
+
 target 'SampleApp' do
   config = use_native_modules!
 
@@ -11,6 +15,7 @@ target 'SampleApp' do
   flags = get_default_flags()
 
   pod 'customerio-reactnative/apn', :path => '../node_modules/customerio-reactnative'
+  # install_non_production_ios_sdk_git_branch(branch_name: 'main', is_app_extension: false, push_service: "apn")
 
   use_react_native!(
     :path => config[:reactNativePath],
@@ -30,4 +35,5 @@ end
 
 target 'NotificationServiceExtension' do
   pod 'customerio-reactnative-richpush/apn', :path => '../node_modules/customerio-reactnative'
+  # install_non_production_ios_sdk_git_branch(branch_name: 'main', is_app_extension: true, push_service: "apn")
 end

--- a/Apps/APN/ios/Podfile.lock
+++ b/Apps/APN/ios/Podfile.lock
@@ -1,36 +1,36 @@
 PODS:
   - boost (1.76.0)
-  - customerio-reactnative (3.1.2):
-    - customerio-reactnative/nopush (= 3.1.2)
-    - CustomerIO/MessagingInApp (= 2.7.2)
-    - CustomerIO/Tracking (= 2.7.2)
+  - customerio-reactnative (3.1.3):
+    - customerio-reactnative/nopush (= 3.1.3)
+    - CustomerIO/MessagingInApp (= 2.7.5)
+    - CustomerIO/Tracking (= 2.7.5)
     - React-Core
-  - customerio-reactnative-richpush/apn (3.1.2):
-    - CustomerIO/MessagingPushAPN (= 2.7.2)
-  - customerio-reactnative/apn (3.1.2):
-    - CustomerIO/MessagingInApp (= 2.7.2)
-    - CustomerIO/MessagingPushAPN (= 2.7.2)
-    - CustomerIO/Tracking (= 2.7.2)
+  - customerio-reactnative-richpush/apn (3.1.3):
+    - CustomerIO/MessagingPushAPN (= 2.7.5)
+  - customerio-reactnative/apn (3.1.3):
+    - CustomerIO/MessagingInApp (= 2.7.5)
+    - CustomerIO/MessagingPushAPN (= 2.7.5)
+    - CustomerIO/Tracking (= 2.7.5)
     - React-Core
-  - customerio-reactnative/nopush (3.1.2):
-    - CustomerIO/MessagingInApp (= 2.7.2)
-    - CustomerIO/Tracking (= 2.7.2)
+  - customerio-reactnative/nopush (3.1.3):
+    - CustomerIO/MessagingInApp (= 2.7.5)
+    - CustomerIO/Tracking (= 2.7.5)
     - React-Core
-  - CustomerIO/MessagingInApp (2.7.2):
-    - CustomerIOMessagingInApp (= 2.7.2)
-  - CustomerIO/MessagingPushAPN (2.7.2):
-    - CustomerIOMessagingPushAPN (= 2.7.2)
-  - CustomerIO/Tracking (2.7.2):
-    - CustomerIOTracking (= 2.7.2)
-  - CustomerIOCommon (2.7.2)
-  - CustomerIOMessagingInApp (2.7.2):
-    - CustomerIOTracking (= 2.7.2)
-  - CustomerIOMessagingPush (2.7.2):
-    - CustomerIOTracking (= 2.7.2)
-  - CustomerIOMessagingPushAPN (2.7.2):
-    - CustomerIOMessagingPush (= 2.7.2)
-  - CustomerIOTracking (2.7.2):
-    - CustomerIOCommon (= 2.7.2)
+  - CustomerIO/MessagingInApp (2.7.5):
+    - CustomerIOMessagingInApp (= 2.7.5)
+  - CustomerIO/MessagingPushAPN (2.7.5):
+    - CustomerIOMessagingPushAPN (= 2.7.5)
+  - CustomerIO/Tracking (2.7.5):
+    - CustomerIOTracking (= 2.7.5)
+  - CustomerIOCommon (2.7.5)
+  - CustomerIOMessagingInApp (2.7.5):
+    - CustomerIOTracking (= 2.7.5)
+  - CustomerIOMessagingPush (2.7.5):
+    - CustomerIOTracking (= 2.7.5)
+  - CustomerIOMessagingPushAPN (2.7.5):
+    - CustomerIOMessagingPush (= 2.7.5)
+  - CustomerIOTracking (2.7.5):
+    - CustomerIOCommon (= 2.7.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.69.1)
   - FBReactNativeSpec (0.69.1):
@@ -544,14 +544,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  CustomerIO: b40c7a1c344323c51b15a54f9e92cae75d966cc8
-  customerio-reactnative: 2f556ed23c053086721becdb0fcfeefeb02ee287
-  customerio-reactnative-richpush: 161d512b6aeb4bbdff06fbd2bb54d71c28fbf5a3
-  CustomerIOCommon: fca967a85f2325b704f3f843a5b97e4bf95e6e6d
-  CustomerIOMessagingInApp: 3eae83ad9951c7dec39b73fc2903bd4901e6eee9
-  CustomerIOMessagingPush: 6351b9e8dd76b00a1d4c61e4b31527170468d1cd
-  CustomerIOMessagingPushAPN: 5024e45bf94ba21e7383f8e5c826932eb1ce5e06
-  CustomerIOTracking: 96777d0d4a52c9602260e41c200d2f11c9472b02
+  CustomerIO: 2afc85f04da3b993f9e0122a050877ed798fcfab
+  customerio-reactnative: cab08d36e5724a715ba553b34b668406cdb321d0
+  customerio-reactnative-richpush: b107ae8fa7af30dadb04e70668a69f941b2103f6
+  CustomerIOCommon: 85329f16b0ef162b0e37dc4742b946031c1d0d10
+  CustomerIOMessagingInApp: 5de40d0aa40a4d8253c57420fc5a518b72583835
+  CustomerIOMessagingPush: a7bd43a280f29cf903b52e0a728603e90cec137d
+  CustomerIOMessagingPushAPN: a4300db441b6946c4bbae926bd44ccc9f52eb7b9
+  CustomerIOTracking: 87b789bc09ee7badbf61d5f95d952b1b30d87fc0
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 068141206af867f72854753423d0117c4bf53419
   FBReactNativeSpec: 546a637adc797fa436dd51d1c63c580f820de31c
@@ -597,6 +597,6 @@ SPEC CHECKSUMS:
   RNSnackbar: 3727b42bf6c4314a53c18185b5203e915a4ab020
   Yoga: 7ab6e3ee4ce47d7b789d1cb520163833e515f452
 
-PODFILE CHECKSUM: 750e7498cf15b335e62a4a5819cc1f256c2a1714
+PODFILE CHECKSUM: e3e8e50af22b0749a6da080a7a66bfc3360928e7
 
 COCOAPODS: 1.12.1

--- a/Apps/APN/ios/SampleApp.xcodeproj/project.pbxproj
+++ b/Apps/APN/ios/SampleApp.xcodeproj/project.pbxproj
@@ -9,9 +9,8 @@
 /* Begin PBXBuildFile section */
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
-		2AE8273DBA3C7F92EAE7CC08 /* libPods-NotificationServiceExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 670470EED4E51186CAC3B53E /* libPods-NotificationServiceExtension.a */; };
+		39854C74C84BE330EF912B1C /* libPods-SampleApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 69E78FF94E1C2B50F221C9B9 /* libPods-SampleApp.a */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
-		44747C538F1A078B75DD8B8D /* libPods-SampleApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D8A905D4C5EE3A71C1C08253 /* libPods-SampleApp.a */; };
 		4606A0C1296C7D6500B98CC8 /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4606A0C0296C7D6500B98CC8 /* AppDelegate.mm */; };
 		464F84BA296D5DD2005918DF /* main.jsbundle in Resources */ = {isa = PBXBuildFile; fileRef = 464F84B9296D5DD2005918DF /* main.jsbundle */; };
 		46C29DBB2965912D0099A118 /* MyAppPushNotificationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C29DBA2965912D0099A118 /* MyAppPushNotificationsHandler.swift */; };
@@ -20,6 +19,7 @@
 		46D41EE52A0944D60008DBA4 /* NotificationServicePushHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46D41EE42A0944D60008DBA4 /* NotificationServicePushHandler.swift */; };
 		46F118D6296C3764007E1D09 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 46FB06302965B4EC00001290 /* main.m */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+		E23B23BC6B8B6427CBD65FC5 /* libPods-NotificationServiceExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B96BF5148A10A016EE14B22 /* libPods-NotificationServiceExtension.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +51,7 @@
 		13B07FB21A68108700A75B9A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = SampleApp/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = SampleApp/Info.plist; sourceTree = "<group>"; };
+		3B96BF5148A10A016EE14B22 /* libPods-NotificationServiceExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NotificationServiceExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4606A0C0296C7D6500B98CC8 /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AppDelegate.mm; sourceTree = "<group>"; };
 		4632B4D3283E5D2200AF05BC /* libCustomerIOMessagingPushAPN.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libCustomerIOMessagingPushAPN.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4632B4D5283E5D2700AF05BC /* libCustomerIOTracking.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libCustomerIOTracking.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -83,7 +84,7 @@
 		46FB06302965B4EC00001290 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		573E80042AAC5A9AAE4540D4 /* Pods-NotificationServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.debug.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		5F5D8D25C4C55AFCC90581F4 /* Pods-Notification Service.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Notification Service.release.xcconfig"; path = "Target Support Files/Pods-Notification Service/Pods-Notification Service.release.xcconfig"; sourceTree = "<group>"; };
-		670470EED4E51186CAC3B53E /* libPods-NotificationServiceExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NotificationServiceExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		69E78FF94E1C2B50F221C9B9 /* libPods-SampleApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SampleApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7027D8F2719E14592AE8C5B1 /* Pods-SampleApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleApp.debug.xcconfig"; path = "Target Support Files/Pods-SampleApp/Pods-SampleApp.debug.xcconfig"; sourceTree = "<group>"; };
 		8DBA40A64D8C8FFF7B19B979 /* Pods-SampleApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SampleApp.release.xcconfig"; path = "Target Support Files/Pods-SampleApp/Pods-SampleApp.release.xcconfig"; sourceTree = "<group>"; };
 		9B38E507D4B6B34BF5926EB2 /* Pods-Notification Service.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Notification Service.debug.xcconfig"; path = "Target Support Files/Pods-Notification Service/Pods-Notification Service.debug.xcconfig"; sourceTree = "<group>"; };
@@ -91,7 +92,6 @@
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = SampleApp/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		C25D949EE45F275B7A559231 /* Pods-NotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
-		D8A905D4C5EE3A71C1C08253 /* libPods-SampleApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SampleApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
@@ -101,7 +101,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				44747C538F1A078B75DD8B8D /* libPods-SampleApp.a in Frameworks */,
+				39854C74C84BE330EF912B1C /* libPods-SampleApp.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -109,7 +109,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2AE8273DBA3C7F92EAE7CC08 /* libPods-NotificationServiceExtension.a in Frameworks */,
+				E23B23BC6B8B6427CBD65FC5 /* libPods-NotificationServiceExtension.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -158,9 +158,9 @@
 				4632B4D3283E5D2200AF05BC /* libCustomerIOMessagingPushAPN.a */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
-				D8A905D4C5EE3A71C1C08253 /* libPods-SampleApp.a */,
 				A591060ADD68CA232C10D473 /* libPods-Notification Service.a */,
-				670470EED4E51186CAC3B53E /* libPods-NotificationServiceExtension.a */,
+				3B96BF5148A10A016EE14B22 /* libPods-NotificationServiceExtension.a */,
+				69E78FF94E1C2B50F221C9B9 /* libPods-SampleApp.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -252,8 +252,6 @@
 				46D41EDF2A0944BF0008DBA4 /* PBXTargetDependency */,
 			);
 			name = SampleApp;
-			packageProductDependencies = (
-			);
 			productName = SampleApp;
 			productReference = 13B07F961A680F5B00A75B9A /* SampleApp.app */;
 			productType = "com.apple.product-type.application";
@@ -307,8 +305,6 @@
 				Base,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
-			packageReferences = (
-			);
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";

--- a/Apps/APN/yarn.lock
+++ b/Apps/APN/yarn.lock
@@ -2678,7 +2678,7 @@ css-in-js-utils@^2.0.0:
     isobject "^3.0.1"
 
 customerio-reactnative@../..:
-  version "3.1.2"
+  version "3.1.3"
 
 dayjs@^1.8.15:
   version "1.11.8"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "react-native": "src/index",
   "source": "src/index",
   "expoVersion": "",
-  "cioNativeiOSSdkVersion": "= 2.7.2",
+  "cioNativeiOSSdkVersion": "= 2.7.5",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
This PR updates the RN SDK to point to the latest production version of iOS SDK. This is to install a bug fix release done today in the iOS SDK. 

No update to latest Android needed as we are already pointing at the latest version. 