### PR TITLE
fix: in-app messages not displaying for release builds on Android

### DIFF
--- a/Apps/APN/android/app/build.gradle
+++ b/Apps/APN/android/app/build.gradle
@@ -96,7 +96,7 @@ def enableSeparateBuildPerCPUArchitecture = false
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore.

--- a/Apps/APN/android/app/src/main/AndroidManifest.xml
+++ b/Apps/APN/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- network security config set to allow proxy tools to view HTTP communication for app debugging.
+    tools:replace is needed because SDK declares a network security config as well for automated tests.
+     -->
     <application
         android:name=".MainApplication"
         android:allowBackup="false"
@@ -14,6 +17,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/AppTheme"
+        android:networkSecurityConfig="@xml/network_security_config"
+        tools:replace="android:networkSecurityConfig"
         tools:ignore="UnusedAttribute">
 
         <activity

--- a/Apps/APN/android/app/src/main/res/xml/network_security_config.xml
+++ b/Apps/APN/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,17 @@
+<network-security-config>
+    <domain-config>
+        <!-- using * because user might be testing against non-production endpoint -->
+        <domain includeSubdomains="true">*</domain>
+        <trust-anchors>
+            <certificates src="user"/>
+            <certificates src="system"/>
+        </trust-anchors>
+    </domain-config>
+
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="user" />
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/Apps/APN/ios/Podfile.lock
+++ b/Apps/APN/ios/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
   - boost (1.76.0)
-  - customerio-reactnative (3.1.4):
-    - customerio-reactnative/nopush (= 3.1.4)
+  - customerio-reactnative (3.1.5):
+    - customerio-reactnative/nopush (= 3.1.5)
     - CustomerIO/MessagingInApp (= 2.7.4)
     - CustomerIO/Tracking (= 2.7.4)
     - React-Core
-  - customerio-reactnative-richpush/apn (3.1.4):
+  - customerio-reactnative-richpush/apn (3.1.5):
     - CustomerIO/MessagingPushAPN (= 2.7.4)
-  - customerio-reactnative/apn (3.1.4):
+  - customerio-reactnative/apn (3.1.5):
     - CustomerIO/MessagingInApp (= 2.7.4)
     - CustomerIO/MessagingPushAPN (= 2.7.4)
     - CustomerIO/Tracking (= 2.7.4)
     - React-Core
-  - customerio-reactnative/nopush (3.1.4):
+  - customerio-reactnative/nopush (3.1.5):
     - CustomerIO/MessagingInApp (= 2.7.4)
     - CustomerIO/Tracking (= 2.7.4)
     - React-Core
@@ -545,8 +545,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CustomerIO: fc932c67b92a71cb25edc4699d1bbfcbd74aa960
-  customerio-reactnative: f0cbd3e3a3ec595b3fa6583aa732ad8c30335603
-  customerio-reactnative-richpush: 247d10c35f5c11ac41c83b7ba9efb07d6bee3b08
+  customerio-reactnative: 8f3913c1251ecfb7e0c62ce235824a95a4ec8a51
+  customerio-reactnative-richpush: 5d991f0b018db8d098c29f2ccadf7585f45f04cf
   CustomerIOCommon: d26701acf4ffa6e7dfff82d5a4902d9ab034fec5
   CustomerIOMessagingInApp: 431a7033a25292c09f8adc8c8e65ddd482ad7932
   CustomerIOMessagingPush: c24b9cc5babcd5a707c9d2c5f66deb236a976fe0

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ customerio.reactnative.kotlinVersion=1.7.21
 customerio.reactnative.compileSdkVersion=30
 customerio.reactnative.targetSdkVersion=30
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=3.6.3
+customerio.reactnative.cioSDKVersionAndroid=3.6.4


### PR DESCRIPTION
Ships the latest Android SDK bug fix to RN customers. 

# Tasks left to complete before merging this PR. 

- [x] Enable proguard in sample apps. After enabling proguard, push commit to this PR to assert proguard is enabled in the future for sample app builds. 
- [x] QA test sample app builds (that are now using proguard). Send device an in-app message. In-app message should appear on the device. 