### PR TITLE
refactor: update samples to reflect SDK docs changes

### DIFF
--- a/Apps/APN/ios/AppDelegate.mm
+++ b/Apps/APN/ios/AppDelegate.mm
@@ -69,8 +69,6 @@ MyAppPushNotificationsHandler* pnHandlerObj = [[MyAppPushNotificationsHandler al
   }
 
   [application registerForRemoteNotifications];
-  UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-  center.delegate = self;
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];
@@ -78,8 +76,7 @@ MyAppPushNotificationsHandler* pnHandlerObj = [[MyAppPushNotificationsHandler al
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   
-  // Workaround for an outstanding issue preventing the React Native SDK from capturing a device token while the app starts
-  [pnHandlerObj initializeCioSdk];
+  [pnHandlerObj setupCustomerIOClickHandling:self];
 
   return YES;
 }

--- a/Apps/APN/ios/MyAppPushNotificationsHandler.swift
+++ b/Apps/APN/ios/MyAppPushNotificationsHandler.swift
@@ -1,13 +1,26 @@
 import Foundation
 import CioMessagingPushAPN
-import CioTracking
 import UserNotifications
+import CioTracking
 
-// This class manages all function calls to CustomerIO SDK.
 @objc
 public class MyAppPushNotificationsHandler : NSObject {
 
   public override init() {}
+
+  @objc(setupCustomerIOClickHandling:)
+  public func setupCustomerIOClickHandling(withNotificationDelegate notificationDelegate: UNUserNotificationCenterDelegate) {
+    // This line of code is required in order for the Customer.io SDK to handle push notification click events.
+    // We are working on removing this requirement in a future release.
+    // Remember to modify the siteId and apiKey with your own values.
+    CustomerIO.initialize(siteId: Env.siteId, apiKey: Env.apiKey, region: .US) { config in
+      config.autoTrackDeviceAttributes = true
+      config.logLevel = .debug
+    }
+    
+    let center  = UNUserNotificationCenter.current()
+    center.delegate = notificationDelegate
+  }
 
   @objc(application:deviceToken:)
   public func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
@@ -28,14 +41,6 @@ public class MyAppPushNotificationsHandler : NSObject {
     // completion handler. If the SDK did handle it, it called the completion handler for you.
     if !handled {
       completionHandler()
-    }
-  }
-  
-  @objc(initializeCioSdk)
-  public func initializeCioSdk() {
-    CustomerIO.initialize(siteId: Env.siteId, apiKey: Env.apiKey, region: .US) { config in
-      config.autoTrackDeviceAttributes = true
-      config.logLevel = .debug
     }
   }
 }

--- a/Apps/APN/ios/Podfile.lock
+++ b/Apps/APN/ios/Podfile.lock
@@ -1,36 +1,36 @@
 PODS:
   - boost (1.76.0)
-  - customerio-reactnative (3.1.7):
-    - customerio-reactnative/nopush (= 3.1.7)
-    - CustomerIO/MessagingInApp (= 2.7.7)
-    - CustomerIO/Tracking (= 2.7.7)
+  - customerio-reactnative (3.1.5):
+    - customerio-reactnative/nopush (= 3.1.5)
+    - CustomerIO/MessagingInApp (= 2.7.4)
+    - CustomerIO/Tracking (= 2.7.4)
     - React-Core
-  - customerio-reactnative-richpush/apn (3.1.7):
-    - CustomerIO/MessagingPushAPN (= 2.7.7)
-  - customerio-reactnative/apn (3.1.7):
-    - CustomerIO/MessagingInApp (= 2.7.7)
-    - CustomerIO/MessagingPushAPN (= 2.7.7)
-    - CustomerIO/Tracking (= 2.7.7)
+  - customerio-reactnative-richpush/apn (3.1.5):
+    - CustomerIO/MessagingPushAPN (= 2.7.4)
+  - customerio-reactnative/apn (3.1.5):
+    - CustomerIO/MessagingInApp (= 2.7.4)
+    - CustomerIO/MessagingPushAPN (= 2.7.4)
+    - CustomerIO/Tracking (= 2.7.4)
     - React-Core
-  - customerio-reactnative/nopush (3.1.7):
-    - CustomerIO/MessagingInApp (= 2.7.7)
-    - CustomerIO/Tracking (= 2.7.7)
+  - customerio-reactnative/nopush (3.1.5):
+    - CustomerIO/MessagingInApp (= 2.7.4)
+    - CustomerIO/Tracking (= 2.7.4)
     - React-Core
-  - CustomerIO/MessagingInApp (2.7.7):
-    - CustomerIOMessagingInApp (= 2.7.7)
-  - CustomerIO/MessagingPushAPN (2.7.7):
-    - CustomerIOMessagingPushAPN (= 2.7.7)
-  - CustomerIO/Tracking (2.7.7):
-    - CustomerIOTracking (= 2.7.7)
-  - CustomerIOCommon (2.7.7)
-  - CustomerIOMessagingInApp (2.7.7):
-    - CustomerIOTracking (= 2.7.7)
-  - CustomerIOMessagingPush (2.7.7):
-    - CustomerIOTracking (= 2.7.7)
-  - CustomerIOMessagingPushAPN (2.7.7):
-    - CustomerIOMessagingPush (= 2.7.7)
-  - CustomerIOTracking (2.7.7):
-    - CustomerIOCommon (= 2.7.7)
+  - CustomerIO/MessagingInApp (2.7.4):
+    - CustomerIOMessagingInApp (= 2.7.4)
+  - CustomerIO/MessagingPushAPN (2.7.4):
+    - CustomerIOMessagingPushAPN (= 2.7.4)
+  - CustomerIO/Tracking (2.7.4):
+    - CustomerIOTracking (= 2.7.4)
+  - CustomerIOCommon (2.7.4)
+  - CustomerIOMessagingInApp (2.7.4):
+    - CustomerIOTracking (= 2.7.4)
+  - CustomerIOMessagingPush (2.7.4):
+    - CustomerIOTracking (= 2.7.4)
+  - CustomerIOMessagingPushAPN (2.7.4):
+    - CustomerIOMessagingPush (= 2.7.4)
+  - CustomerIOTracking (2.7.4):
+    - CustomerIOCommon (= 2.7.4)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.69.1)
   - FBReactNativeSpec (0.69.1):
@@ -270,12 +270,8 @@ PODS:
   - React-jsinspector (0.69.1)
   - React-logger (0.69.1):
     - glog
-  - react-native-safe-area-context (4.5.3):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
+  - react-native-safe-area-context (4.7.1):
     - React-Core
-    - ReactCommon/turbomodule/core
   - React-perflogger (0.69.1)
   - React-RCTActionSheet (0.69.1):
     - React-Core/RCTActionSheetHeaders (= 0.69.1)
@@ -342,13 +338,13 @@ PODS:
     - React-jsi (= 0.69.1)
     - React-logger (= 0.69.1)
     - React-perflogger (= 0.69.1)
-  - RNCAsyncStorage (1.18.2):
+  - RNCAsyncStorage (1.19.1):
     - React-Core
   - RNCClipboard (1.11.2):
     - React-Core
   - RNCPushNotificationIOS (1.11.0):
     - React-Core
-  - RNDeviceInfo (10.7.0):
+  - RNDeviceInfo (10.8.0):
     - React-Core
   - RNGestureHandler (1.10.3):
     - React-Core
@@ -544,14 +540,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  CustomerIO: ad7274a7c0ab31c33516b9262dfc408bfc66efa7
-  customerio-reactnative: 65c07e888b3810ac21357af3ed08e456ba0321bc
-  customerio-reactnative-richpush: 1e2a44da4acfbabec0e9d9f75cb7ca09566242b7
-  CustomerIOCommon: 64985257333953ddf7f2ab4f314c74d6949c5216
-  CustomerIOMessagingInApp: 5a1325c5638171bfb3418a914a550393488fdad9
-  CustomerIOMessagingPush: 8e5b9692fc80d778a9ab3ef6b310f9160a7e00b6
-  CustomerIOMessagingPushAPN: 28dfe73ebb6bb9642dc878635a0515331c367786
-  CustomerIOTracking: 4b7d734466e4db0b7c41f3cbdb461c1fe272bf5b
+  CustomerIO: fc932c67b92a71cb25edc4699d1bbfcbd74aa960
+  customerio-reactnative: 8f3913c1251ecfb7e0c62ce235824a95a4ec8a51
+  customerio-reactnative-richpush: 5d991f0b018db8d098c29f2ccadf7585f45f04cf
+  CustomerIOCommon: d26701acf4ffa6e7dfff82d5a4902d9ab034fec5
+  CustomerIOMessagingInApp: 431a7033a25292c09f8adc8c8e65ddd482ad7932
+  CustomerIOMessagingPush: c24b9cc5babcd5a707c9d2c5f66deb236a976fe0
+  CustomerIOMessagingPushAPN: bf6038cd9e302c4439c689ee3e8e222f6fc84a1c
+  CustomerIOTracking: 51b99fb3d3e3b2433a13c53e0309834ae2a08540
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 068141206af867f72854753423d0117c4bf53419
   FBReactNativeSpec: 546a637adc797fa436dd51d1c63c580f820de31c
@@ -574,7 +570,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 758e70947c232828a66b5ddc42d02b4d010fa26e
   React-jsinspector: 55605caf04e02f9b0e05842b786f1c12dde08f4b
   React-logger: ca970551cb7eea2fd814d0d5f6fc1a471eb53b76
-  react-native-safe-area-context: b8979f5eda6ed5903d4dbc885be3846ea3daa753
+  react-native-safe-area-context: 9697629f7b2cda43cf52169bb7e0767d330648c2
   React-perflogger: c9161ff0f1c769993cd11d2751e4331ff4ceb7cd
   React-RCTActionSheet: 2d885b0bea76a5254ef852939273edd8de116180
   React-RCTAnimation: 353fa4fc3c19060068832dd32e555182ec07be45
@@ -587,10 +583,10 @@ SPEC CHECKSUMS:
   React-RCTVibration: e8b7dd6635cc95689b5db643b5a3848f1e05b30b
   React-runtimeexecutor: 27f468c5576eaf05ffb7a907528e44c75a3fcbae
   ReactCommon: e30ec17dfb1d4c4f3419eac254350d6abca6d5a2
-  RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
+  RNCAsyncStorage: f47fe18526970a69c34b548883e1aeceb115e3e1
   RNCClipboard: 3f0451a8100393908bea5c5c5b16f96d45f30bfc
   RNCPushNotificationIOS: 64218f3c776c03d7408284a819b2abfda1834bc8
-  RNDeviceInfo: 25d818c85db769cc0e7083d39efaa01a6f450df3
+  RNDeviceInfo: 5795b418ed3451ebcaf39384e6cf51f60cb931c9
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: e2414d403cc8da634e44103c1ec7a13e87bd6333
   RNScreens: 21b73c94c9117e1110a79ee0ee80c93ccefed8ce

--- a/Apps/APN/ios/Podfile.lock
+++ b/Apps/APN/ios/Podfile.lock
@@ -1,36 +1,36 @@
 PODS:
   - boost (1.76.0)
-  - customerio-reactnative (3.1.5):
-    - customerio-reactnative/nopush (= 3.1.5)
-    - CustomerIO/MessagingInApp (= 2.7.4)
-    - CustomerIO/Tracking (= 2.7.4)
+  - customerio-reactnative (3.1.7):
+    - customerio-reactnative/nopush (= 3.1.7)
+    - CustomerIO/MessagingInApp (= 2.7.7)
+    - CustomerIO/Tracking (= 2.7.7)
     - React-Core
-  - customerio-reactnative-richpush/apn (3.1.5):
-    - CustomerIO/MessagingPushAPN (= 2.7.4)
-  - customerio-reactnative/apn (3.1.5):
-    - CustomerIO/MessagingInApp (= 2.7.4)
-    - CustomerIO/MessagingPushAPN (= 2.7.4)
-    - CustomerIO/Tracking (= 2.7.4)
+  - customerio-reactnative-richpush/apn (3.1.7):
+    - CustomerIO/MessagingPushAPN (= 2.7.7)
+  - customerio-reactnative/apn (3.1.7):
+    - CustomerIO/MessagingInApp (= 2.7.7)
+    - CustomerIO/MessagingPushAPN (= 2.7.7)
+    - CustomerIO/Tracking (= 2.7.7)
     - React-Core
-  - customerio-reactnative/nopush (3.1.5):
-    - CustomerIO/MessagingInApp (= 2.7.4)
-    - CustomerIO/Tracking (= 2.7.4)
+  - customerio-reactnative/nopush (3.1.7):
+    - CustomerIO/MessagingInApp (= 2.7.7)
+    - CustomerIO/Tracking (= 2.7.7)
     - React-Core
-  - CustomerIO/MessagingInApp (2.7.4):
-    - CustomerIOMessagingInApp (= 2.7.4)
-  - CustomerIO/MessagingPushAPN (2.7.4):
-    - CustomerIOMessagingPushAPN (= 2.7.4)
-  - CustomerIO/Tracking (2.7.4):
-    - CustomerIOTracking (= 2.7.4)
-  - CustomerIOCommon (2.7.4)
-  - CustomerIOMessagingInApp (2.7.4):
-    - CustomerIOTracking (= 2.7.4)
-  - CustomerIOMessagingPush (2.7.4):
-    - CustomerIOTracking (= 2.7.4)
-  - CustomerIOMessagingPushAPN (2.7.4):
-    - CustomerIOMessagingPush (= 2.7.4)
-  - CustomerIOTracking (2.7.4):
-    - CustomerIOCommon (= 2.7.4)
+  - CustomerIO/MessagingInApp (2.7.7):
+    - CustomerIOMessagingInApp (= 2.7.7)
+  - CustomerIO/MessagingPushAPN (2.7.7):
+    - CustomerIOMessagingPushAPN (= 2.7.7)
+  - CustomerIO/Tracking (2.7.7):
+    - CustomerIOTracking (= 2.7.7)
+  - CustomerIOCommon (2.7.7)
+  - CustomerIOMessagingInApp (2.7.7):
+    - CustomerIOTracking (= 2.7.7)
+  - CustomerIOMessagingPush (2.7.7):
+    - CustomerIOTracking (= 2.7.7)
+  - CustomerIOMessagingPushAPN (2.7.7):
+    - CustomerIOMessagingPush (= 2.7.7)
+  - CustomerIOTracking (2.7.7):
+    - CustomerIOCommon (= 2.7.7)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.69.1)
   - FBReactNativeSpec (0.69.1):
@@ -270,8 +270,12 @@ PODS:
   - React-jsinspector (0.69.1)
   - React-logger (0.69.1):
     - glog
-  - react-native-safe-area-context (4.7.1):
+  - react-native-safe-area-context (4.5.3):
+    - RCT-Folly
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - ReactCommon/turbomodule/core
   - React-perflogger (0.69.1)
   - React-RCTActionSheet (0.69.1):
     - React-Core/RCTActionSheetHeaders (= 0.69.1)
@@ -338,13 +342,13 @@ PODS:
     - React-jsi (= 0.69.1)
     - React-logger (= 0.69.1)
     - React-perflogger (= 0.69.1)
-  - RNCAsyncStorage (1.19.1):
+  - RNCAsyncStorage (1.18.2):
     - React-Core
   - RNCClipboard (1.11.2):
     - React-Core
   - RNCPushNotificationIOS (1.11.0):
     - React-Core
-  - RNDeviceInfo (10.8.0):
+  - RNDeviceInfo (10.7.0):
     - React-Core
   - RNGestureHandler (1.10.3):
     - React-Core
@@ -540,14 +544,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  CustomerIO: fc932c67b92a71cb25edc4699d1bbfcbd74aa960
-  customerio-reactnative: 8f3913c1251ecfb7e0c62ce235824a95a4ec8a51
-  customerio-reactnative-richpush: 5d991f0b018db8d098c29f2ccadf7585f45f04cf
-  CustomerIOCommon: d26701acf4ffa6e7dfff82d5a4902d9ab034fec5
-  CustomerIOMessagingInApp: 431a7033a25292c09f8adc8c8e65ddd482ad7932
-  CustomerIOMessagingPush: c24b9cc5babcd5a707c9d2c5f66deb236a976fe0
-  CustomerIOMessagingPushAPN: bf6038cd9e302c4439c689ee3e8e222f6fc84a1c
-  CustomerIOTracking: 51b99fb3d3e3b2433a13c53e0309834ae2a08540
+  CustomerIO: ad7274a7c0ab31c33516b9262dfc408bfc66efa7
+  customerio-reactnative: 65c07e888b3810ac21357af3ed08e456ba0321bc
+  customerio-reactnative-richpush: 1e2a44da4acfbabec0e9d9f75cb7ca09566242b7
+  CustomerIOCommon: 64985257333953ddf7f2ab4f314c74d6949c5216
+  CustomerIOMessagingInApp: 5a1325c5638171bfb3418a914a550393488fdad9
+  CustomerIOMessagingPush: 8e5b9692fc80d778a9ab3ef6b310f9160a7e00b6
+  CustomerIOMessagingPushAPN: 28dfe73ebb6bb9642dc878635a0515331c367786
+  CustomerIOTracking: 4b7d734466e4db0b7c41f3cbdb461c1fe272bf5b
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 068141206af867f72854753423d0117c4bf53419
   FBReactNativeSpec: 546a637adc797fa436dd51d1c63c580f820de31c
@@ -570,7 +574,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 758e70947c232828a66b5ddc42d02b4d010fa26e
   React-jsinspector: 55605caf04e02f9b0e05842b786f1c12dde08f4b
   React-logger: ca970551cb7eea2fd814d0d5f6fc1a471eb53b76
-  react-native-safe-area-context: 9697629f7b2cda43cf52169bb7e0767d330648c2
+  react-native-safe-area-context: b8979f5eda6ed5903d4dbc885be3846ea3daa753
   React-perflogger: c9161ff0f1c769993cd11d2751e4331ff4ceb7cd
   React-RCTActionSheet: 2d885b0bea76a5254ef852939273edd8de116180
   React-RCTAnimation: 353fa4fc3c19060068832dd32e555182ec07be45
@@ -583,10 +587,10 @@ SPEC CHECKSUMS:
   React-RCTVibration: e8b7dd6635cc95689b5db643b5a3848f1e05b30b
   React-runtimeexecutor: 27f468c5576eaf05ffb7a907528e44c75a3fcbae
   ReactCommon: e30ec17dfb1d4c4f3419eac254350d6abca6d5a2
-  RNCAsyncStorage: f47fe18526970a69c34b548883e1aeceb115e3e1
+  RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
   RNCClipboard: 3f0451a8100393908bea5c5c5b16f96d45f30bfc
   RNCPushNotificationIOS: 64218f3c776c03d7408284a819b2abfda1834bc8
-  RNDeviceInfo: 5795b418ed3451ebcaf39384e6cf51f60cb931c9
+  RNDeviceInfo: 25d818c85db769cc0e7083d39efaa01a6f450df3
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: e2414d403cc8da634e44103c1ec7a13e87bd6333
   RNScreens: 21b73c94c9117e1110a79ee0ee80c93ccefed8ce

--- a/Apps/FCM/ios/FCMSampleApp/AppDelegate.mm
+++ b/Apps/FCM/ios/FCMSampleApp/AppDelegate.mm
@@ -28,13 +28,8 @@ MyAppPushNotificationsHandler *pnHandlerObj = [[MyAppPushNotificationsHandler al
       }
     }
   }
-
-  // Initialize Customer.io SDK here
-  // This fixes an issue in which the React Native SDK identifies a profile, but an iOS device isn't added to the profile
-  [pnHandlerObj initializeCioSdk];
-
-  UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-  center.delegate = self;
+  
+  [pnHandlerObj setupCustomerIOClickHandling:self];
 
   return [super application:application didFinishLaunchingWithOptions:modifiedLaunchOptions];
 }
@@ -48,15 +43,13 @@ MyAppPushNotificationsHandler *pnHandlerObj = [[MyAppPushNotificationsHandler al
 }
 
 - (void)messaging:(FIRMessaging *)messaging didReceiveRegistrationToken:(NSString *)fcmToken {
-  [pnHandlerObj didReceiveRegistrationToken:messaging fcmToken:fcmToken];
+  [pnHandlerObj didReceiveRegistrationToken:messaging fcmToken: fcmToken];
 }
 
-// To capture push metrics and handle deep links
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center
-    didReceiveNotificationResponse:(UNNotificationResponse *)response
-             withCompletionHandler:(void (^)(void))completionHandler {
-  [pnHandlerObj userNotificationCenter:center response:response completionHandler:completionHandler];
-}
+// Send push notification click events to the Customer.IO SDK for processing
+ - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void(^)(void))completionHandler {
+   [pnHandlerObj userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
+ }
 
 // To show a notification when the app is in foreground
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center

--- a/Apps/FCM/ios/FCMSampleApp/MyAppPushNotificationsHandler.swift
+++ b/Apps/FCM/ios/FCMSampleApp/MyAppPushNotificationsHandler.swift
@@ -1,36 +1,42 @@
-import CioMessagingPushFCM
-import CioTracking
-import FirebaseMessaging
 import Foundation
+import CioMessagingPushFCM
+import UserNotifications
+import FirebaseMessaging
+import CioTracking
 
 @objc
-public class MyAppPushNotificationsHandler: NSObject {
+public class MyAppPushNotificationsHandler : NSObject {
 
   public override init() {}
 
+  @objc(setupCustomerIOClickHandling:)
+  public func setupCustomerIOClickHandling(withNotificationDelegate notificationDelegate: UNUserNotificationCenterDelegate) {
+    // This line of code is required in order for the Customer.io SDK to handle push notification click events.
+    // We are working on removing this requirement in a future release.
+    // Remember to modify the siteId and apiKey with your own values.
+    CustomerIO.initialize(siteId: Env.siteId, apiKey: Env.apiKey, region: Region.US) { config in
+      config.autoTrackDeviceAttributes = true
+    }
+    
+    let center  = UNUserNotificationCenter.current()
+    center.delegate = notificationDelegate
+  }
+
   // Register device on receiving a device token (FCM)
   @objc(didReceiveRegistrationToken:fcmToken:)
-  public func didReceiveRegistrationToken(
-    _ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?
-  ) {
+  public func didReceiveRegistrationToken(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
     MessagingPush.shared.messaging(messaging, didReceiveRegistrationToken: fcmToken)
   }
 
-  // To capture push metrics
-  @objc(userNotificationCenter:response:completionHandler:)
-  public func userNotificationCenter(
-    center: UNUserNotificationCenter, didReceive response: UNNotificationResponse,
-    completionHandler: @escaping () -> Void
-  ) {
-    let _ = MessagingPush.shared.userNotificationCenter(
-      center, didReceive: response, withCompletionHandler: completionHandler)
-  }
+  @objc(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)
+  public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+    let handled = MessagingPush.shared.userNotificationCenter(center, didReceive: response,
+  withCompletionHandler: completionHandler)
 
-  @objc(initializeCioSdk)
-  public func initializeCioSdk() {
-    CustomerIO.initialize(siteId: Env.siteId, apiKey: Env.apiKey, region: .US) {
-      config in config.autoTrackDeviceAttributes = true
-      config.logLevel = .debug
+    // If the Customer.io SDK does not handle the push, it's up to you to handle it and call the
+    // completion handler. If the SDK did handle it, it called the completion handler for you.
+    if !handled {
+      completionHandler()
     }
   }
 }

--- a/Apps/FCM/ios/FCMSampleApp/MyAppPushNotificationsHandler.swift
+++ b/Apps/FCM/ios/FCMSampleApp/MyAppPushNotificationsHandler.swift
@@ -16,6 +16,10 @@ public class MyAppPushNotificationsHandler : NSObject {
     // Remember to modify the siteId and apiKey with your own values.
     CustomerIO.initialize(siteId: Env.siteId, apiKey: Env.apiKey, region: Region.US) { config in
       config.autoTrackDeviceAttributes = true
+      
+      // Configuration settings below are convenient for internal Customer.io testing. 
+      // They are optional for your setup. 
+      config.logLevel = .debug
     }
     
     let center  = UNUserNotificationCenter.current()


### PR DESCRIPTION
I proposed [changes to our SDK docs](https://github.com/customerio/docs/pull/1447) to increase the stability of `opened` push metrics for customers installing the RN SDK. 

This PR modifies the sample apps code to reflect the code snippets in the SDK docs PR. 
