### PR TITLE
fix: include required messagingpush dependency for no push configuration

### DIFF
--- a/customerio-reactnative.podspec
+++ b/customerio-reactnative.podspec
@@ -28,7 +28,9 @@ Pod::Spec.new do |s|
   s.default_subspec = "nopush"
 
   s.subspec 'nopush' do |ss|
-    # no dependencies. This is the default subspec designed to not install any push dependencies.
+    # This is the default subspec designed to not install any push dependencies. Customer should choose APN or FCM.
+    # The SDK at runtime currently requires the MessagingPush module so we do include it here. 
+    ss.dependency "CustomerIO/MessagingPush", package["cioNativeiOSSdkVersion"]
   end 
 
   # Note: Subspecs inherit all dependencies specified the parent spec (this file). 


### PR DESCRIPTION
The RN SDK today does require the messagingpush SDK module but the podspec that we ask customers to install does not include this module. This could mean compile-time errors. 

Yes, we do expect that customers setup rich push in their app and so we do not expect customers to encounter this problem. However, the idea that this PR also adds a comment to the podspec files specifying required dependencies is a good value add to the codebase. 

PR in draft mode and asks for review by team to get feedback if this is something we want to do or not. 

Note: Conversation that sparked this idea: https://github.com/customerio/docs/pull/1446#discussion_r1298239891