### PR TITLE
ci: fix the min version for semantic release

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -27,6 +27,9 @@ jobs:
         id: semantic-release
         with:
           # version numbers below can be in many forms: M, M.m, M.m.p
+          # version should be greater than the 22.0.1 (https://github.com/semantic-release/semantic-release/releases/tag/v22.0.1)
+          # because previous version had a bug in commit analyzer
+          semantic_version: 22.0.5
           extra_plugins: |
             conventional-changelog-conventionalcommits
             @semantic-release/changelog


### PR DESCRIPTION
 version should be greater than the 22.0.1 (https://github.com/semantic-release/semantic-release/releases/tag/v22.0.1)
