### PR TITLE
fix: remove BQ tasks register device with empty profile identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "react-native": "src/index",
   "source": "src/index",
   "expoVersion": "",
-  "cioNativeiOSSdkVersion": "= 2.8.1",
+  "cioNativeiOSSdkVersion": "= 2.8.3",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
Ship [iOS bug fix](https://github.com/customerio/customerio-ios/pull/392). 

# todo

- [x] wait to merge until [cocoapods deployment successful](https://github.com/customerio/customerio-ios/actions/runs/6483169734/job/17604174895)