### PR TITLE
refactor: update sample apps with newer RN syntax

### DIFF
--- a/Apps/APN/App.js
+++ b/Apps/APN/App.js
@@ -11,6 +11,7 @@ import {
 import StorageService from './src/services/StorageService';
 import { CustomerIoSdkContext } from './src/state/customerIoSdkState';
 import { UserStateContext } from './src/state/userState';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 export default function App() {
   const [loading, setLoading] = useState(true);
@@ -104,13 +105,15 @@ export default function App() {
   }
 
   return (
-    <CustomerIoSdkContext.Provider value={customerIoSdkState}>
-      <UserStateContext.Provider value={userState}>
-        <SafeAreaView style={styles.container}>
-          <AppNavigator />
-        </SafeAreaView>
-      </UserStateContext.Provider>
-    </CustomerIoSdkContext.Provider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <CustomerIoSdkContext.Provider value={customerIoSdkState}>
+        <UserStateContext.Provider value={userState}>
+          <SafeAreaView style={styles.container}>
+            <AppNavigator />
+          </SafeAreaView>
+        </UserStateContext.Provider>
+      </CustomerIoSdkContext.Provider>
+    </GestureHandlerRootView>
   );
 }
 

--- a/Apps/APN/ios/AppDelegate.h
+++ b/Apps/APN/ios/AppDelegate.h
@@ -1,10 +1,7 @@
-#import <React/RCTBridgeDelegate.h>
+#import <RCTAppDelegate.h>
 #import <UIKit/UIKit.h>
-#import <UserNotifications/UNUserNotificationCenter.h>
 #import <UserNotifications/UserNotifications.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate, UNUserNotificationCenterDelegate>
-
-@property (nonatomic, strong) UIWindow *window;
+@interface AppDelegate: RCTAppDelegate<UNUserNotificationCenterDelegate>
 
 @end

--- a/Apps/APN/ios/Podfile.lock
+++ b/Apps/APN/ios/Podfile.lock
@@ -1,36 +1,39 @@
 PODS:
   - boost (1.76.0)
-  - customerio-reactnative (3.1.7):
-    - customerio-reactnative/nopush (= 3.1.7)
-    - CustomerIO/MessagingInApp (= 2.7.7)
-    - CustomerIO/Tracking (= 2.7.7)
+  - customerio-reactnative (3.2.0):
+    - customerio-reactnative/nopush (= 3.2.0)
+    - CustomerIO/MessagingInApp (= 2.8.4)
+    - CustomerIO/Tracking (= 2.8.4)
     - React-Core
-  - customerio-reactnative-richpush/apn (3.1.7):
-    - CustomerIO/MessagingPushAPN (= 2.7.7)
-  - customerio-reactnative/apn (3.1.7):
-    - CustomerIO/MessagingInApp (= 2.7.7)
-    - CustomerIO/MessagingPushAPN (= 2.7.7)
-    - CustomerIO/Tracking (= 2.7.7)
+  - customerio-reactnative-richpush/apn (3.2.0):
+    - CustomerIO/MessagingPushAPN (= 2.8.4)
+  - customerio-reactnative/apn (3.2.0):
+    - CustomerIO/MessagingInApp (= 2.8.4)
+    - CustomerIO/MessagingPushAPN (= 2.8.4)
+    - CustomerIO/Tracking (= 2.8.4)
     - React-Core
-  - customerio-reactnative/nopush (3.1.7):
-    - CustomerIO/MessagingInApp (= 2.7.7)
-    - CustomerIO/Tracking (= 2.7.7)
+  - customerio-reactnative/nopush (3.2.0):
+    - CustomerIO/MessagingInApp (= 2.8.4)
+    - CustomerIO/MessagingPush (= 2.8.4)
+    - CustomerIO/Tracking (= 2.8.4)
     - React-Core
-  - CustomerIO/MessagingInApp (2.7.7):
-    - CustomerIOMessagingInApp (= 2.7.7)
-  - CustomerIO/MessagingPushAPN (2.7.7):
-    - CustomerIOMessagingPushAPN (= 2.7.7)
-  - CustomerIO/Tracking (2.7.7):
-    - CustomerIOTracking (= 2.7.7)
-  - CustomerIOCommon (2.7.7)
-  - CustomerIOMessagingInApp (2.7.7):
-    - CustomerIOTracking (= 2.7.7)
-  - CustomerIOMessagingPush (2.7.7):
-    - CustomerIOTracking (= 2.7.7)
-  - CustomerIOMessagingPushAPN (2.7.7):
-    - CustomerIOMessagingPush (= 2.7.7)
-  - CustomerIOTracking (2.7.7):
-    - CustomerIOCommon (= 2.7.7)
+  - CustomerIO/MessagingInApp (2.8.4):
+    - CustomerIOMessagingInApp (= 2.8.4)
+  - CustomerIO/MessagingPush (2.8.4):
+    - CustomerIOMessagingPush (= 2.8.4)
+  - CustomerIO/MessagingPushAPN (2.8.4):
+    - CustomerIOMessagingPushAPN (= 2.8.4)
+  - CustomerIO/Tracking (2.8.4):
+    - CustomerIOTracking (= 2.8.4)
+  - CustomerIOCommon (2.8.4)
+  - CustomerIOMessagingInApp (2.8.4):
+    - CustomerIOTracking (= 2.8.4)
+  - CustomerIOMessagingPush (2.8.4):
+    - CustomerIOTracking (= 2.8.4)
+  - CustomerIOMessagingPushAPN (2.8.4):
+    - CustomerIOMessagingPush (= 2.8.4)
+  - CustomerIOTracking (2.8.4):
+    - CustomerIOCommon (= 2.8.4)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.72.4)
   - FBReactNativeSpec (0.72.4):
@@ -674,14 +677,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  CustomerIO: ad7274a7c0ab31c33516b9262dfc408bfc66efa7
-  customerio-reactnative: 65c07e888b3810ac21357af3ed08e456ba0321bc
-  customerio-reactnative-richpush: 1e2a44da4acfbabec0e9d9f75cb7ca09566242b7
-  CustomerIOCommon: 64985257333953ddf7f2ab4f314c74d6949c5216
-  CustomerIOMessagingInApp: 5a1325c5638171bfb3418a914a550393488fdad9
-  CustomerIOMessagingPush: 8e5b9692fc80d778a9ab3ef6b310f9160a7e00b6
-  CustomerIOMessagingPushAPN: 28dfe73ebb6bb9642dc878635a0515331c367786
-  CustomerIOTracking: 4b7d734466e4db0b7c41f3cbdb461c1fe272bf5b
+  CustomerIO: 4a04f63c9951bced3f2160397e811451cba0de36
+  customerio-reactnative: 57a15506e537c89802847b819442ab4426de68eb
+  customerio-reactnative-richpush: 3866204a12a94ce8eaa6630ab39f069dea970b36
+  CustomerIOCommon: 65752b4280cd24edf8091eba59cae04347999fe1
+  CustomerIOMessagingInApp: ce4944ec4c9d1dd0d30ea7a0c6aee7137609d7e3
+  CustomerIOMessagingPush: 6a21e2bd5bb4a6b483671e7703dc011a4deb8178
+  CustomerIOMessagingPushAPN: 93e371ee9e5208497320bec6325e715db0a8b3ab
+  CustomerIOTracking: 5eab210defdf8950e0708713f7d95b35b779e056
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
   FBReactNativeSpec: 3fc2d478e1c4b08276f9dd9128f80ec6d5d85c1f

--- a/Apps/FCM/ios/FCMSampleApp/AppDelegate.h
+++ b/Apps/FCM/ios/FCMSampleApp/AppDelegate.h
@@ -1,11 +1,7 @@
-#import <UIKit/UIKit.h>
 #import <RCTAppDelegate.h>
-#import <React/RCTLinkingManager.h>
-#import <React/RCTBundleURLProvider.h>
+#import <UIKit/UIKit.h>
 #import <UserNotifications/UserNotifications.h>
-#import <FirebaseCore.h>
 #import <FirebaseMessaging/FIRMessaging.h>
-#import <FCMSampleApp-Swift.h>
 
 @interface AppDelegate : RCTAppDelegate <UNUserNotificationCenterDelegate, FIRMessagingDelegate>
 

--- a/Apps/FCM/ios/FCMSampleApp/AppDelegate.mm
+++ b/Apps/FCM/ios/FCMSampleApp/AppDelegate.mm
@@ -1,4 +1,8 @@
 #import "AppDelegate.h"
+#import <FCMSampleApp-Swift.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTBundleURLProvider.h>
+#import <FirebaseCore.h>
 
 @implementation AppDelegate
 

--- a/Apps/FCM/ios/Podfile.lock
+++ b/Apps/FCM/ios/Podfile.lock
@@ -1,37 +1,40 @@
 PODS:
   - boost (1.76.0)
-  - customerio-reactnative (3.1.7):
-    - customerio-reactnative/nopush (= 3.1.7)
-    - CustomerIO/MessagingInApp (= 2.7.7)
-    - CustomerIO/Tracking (= 2.7.7)
+  - customerio-reactnative (3.2.0):
+    - customerio-reactnative/nopush (= 3.2.0)
+    - CustomerIO/MessagingInApp (= 2.8.4)
+    - CustomerIO/Tracking (= 2.8.4)
     - React-Core
-  - customerio-reactnative-richpush/fcm (3.1.7):
-    - CustomerIO/MessagingPushFCM (= 2.7.7)
-  - customerio-reactnative/fcm (3.1.7):
-    - CustomerIO/MessagingInApp (= 2.7.7)
-    - CustomerIO/MessagingPushFCM (= 2.7.7)
-    - CustomerIO/Tracking (= 2.7.7)
+  - customerio-reactnative-richpush/fcm (3.2.0):
+    - CustomerIO/MessagingPushFCM (= 2.8.4)
+  - customerio-reactnative/fcm (3.2.0):
+    - CustomerIO/MessagingInApp (= 2.8.4)
+    - CustomerIO/MessagingPushFCM (= 2.8.4)
+    - CustomerIO/Tracking (= 2.8.4)
     - React-Core
-  - customerio-reactnative/nopush (3.1.7):
-    - CustomerIO/MessagingInApp (= 2.7.7)
-    - CustomerIO/Tracking (= 2.7.7)
+  - customerio-reactnative/nopush (3.2.0):
+    - CustomerIO/MessagingInApp (= 2.8.4)
+    - CustomerIO/MessagingPush (= 2.8.4)
+    - CustomerIO/Tracking (= 2.8.4)
     - React-Core
-  - CustomerIO/MessagingInApp (2.7.7):
-    - CustomerIOMessagingInApp (= 2.7.7)
-  - CustomerIO/MessagingPushFCM (2.7.7):
-    - CustomerIOMessagingPushFCM (= 2.7.7)
-  - CustomerIO/Tracking (2.7.7):
-    - CustomerIOTracking (= 2.7.7)
-  - CustomerIOCommon (2.7.7)
-  - CustomerIOMessagingInApp (2.7.7):
-    - CustomerIOTracking (= 2.7.7)
-  - CustomerIOMessagingPush (2.7.7):
-    - CustomerIOTracking (= 2.7.7)
-  - CustomerIOMessagingPushFCM (2.7.7):
-    - CustomerIOMessagingPush (= 2.7.7)
+  - CustomerIO/MessagingInApp (2.8.4):
+    - CustomerIOMessagingInApp (= 2.8.4)
+  - CustomerIO/MessagingPush (2.8.4):
+    - CustomerIOMessagingPush (= 2.8.4)
+  - CustomerIO/MessagingPushFCM (2.8.4):
+    - CustomerIOMessagingPushFCM (= 2.8.4)
+  - CustomerIO/Tracking (2.8.4):
+    - CustomerIOTracking (= 2.8.4)
+  - CustomerIOCommon (2.8.4)
+  - CustomerIOMessagingInApp (2.8.4):
+    - CustomerIOTracking (= 2.8.4)
+  - CustomerIOMessagingPush (2.8.4):
+    - CustomerIOTracking (= 2.8.4)
+  - CustomerIOMessagingPushFCM (2.8.4):
+    - CustomerIOMessagingPush (= 2.8.4)
     - FirebaseMessaging (< 11, >= 8.7.0)
-  - CustomerIOTracking (2.7.7):
-    - CustomerIOCommon (= 2.7.7)
+  - CustomerIOTracking (2.8.4):
+    - CustomerIOCommon (= 2.8.4)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.72.4)
   - FBReactNativeSpec (0.72.4):
@@ -41,18 +44,18 @@ PODS:
     - React-Core (= 0.72.4)
     - React-jsi (= 0.72.4)
     - ReactCommon/turbomodule/core (= 0.72.4)
-  - FirebaseCore (10.14.0):
+  - FirebaseCore (10.16.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.14.0):
+  - FirebaseCoreInternal (10.16.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseInstallations (10.14.0):
+  - FirebaseInstallations (10.16.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (10.14.0):
+  - FirebaseMessaging (10.16.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleDataTransport (~> 9.2)
@@ -696,21 +699,21 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  CustomerIO: ad7274a7c0ab31c33516b9262dfc408bfc66efa7
-  customerio-reactnative: 65c07e888b3810ac21357af3ed08e456ba0321bc
-  customerio-reactnative-richpush: 1e2a44da4acfbabec0e9d9f75cb7ca09566242b7
-  CustomerIOCommon: 64985257333953ddf7f2ab4f314c74d6949c5216
-  CustomerIOMessagingInApp: 5a1325c5638171bfb3418a914a550393488fdad9
-  CustomerIOMessagingPush: 8e5b9692fc80d778a9ab3ef6b310f9160a7e00b6
-  CustomerIOMessagingPushFCM: 9f893b00272d66bbd57cfe991fa007489f5c816b
-  CustomerIOTracking: 4b7d734466e4db0b7c41f3cbdb461c1fe272bf5b
+  CustomerIO: 4a04f63c9951bced3f2160397e811451cba0de36
+  customerio-reactnative: 57a15506e537c89802847b819442ab4426de68eb
+  customerio-reactnative-richpush: 3866204a12a94ce8eaa6630ab39f069dea970b36
+  CustomerIOCommon: 65752b4280cd24edf8091eba59cae04347999fe1
+  CustomerIOMessagingInApp: ce4944ec4c9d1dd0d30ea7a0c6aee7137609d7e3
+  CustomerIOMessagingPush: 6a21e2bd5bb4a6b483671e7703dc011a4deb8178
+  CustomerIOMessagingPushFCM: 447bf98322bb4cedf42ed2ee0698391cd81cc986
+  CustomerIOTracking: 5eab210defdf8950e0708713f7d95b35b779e056
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
   FBReactNativeSpec: 3fc2d478e1c4b08276f9dd9128f80ec6d5d85c1f
-  FirebaseCore: 6fc17ac9f03509d51c131298aacb3ee5698b4f02
-  FirebaseCoreInternal: d558159ee6cc4b823c2296ecc193de9f6d9a5bb3
-  FirebaseInstallations: f672b1eda64e6381c21d424a2f680a943fd83f3b
-  FirebaseMessaging: 1077a4499f0c0a140b9a2e34fe08a1acc806b36d
+  FirebaseCore: 65a801af84cca84361ef9eac3fd868656968a53b
+  FirebaseCoreInternal: 26233f705cc4531236818a07ac84d20c333e505a
+  FirebaseInstallations: b822f91a61f7d1ba763e5ccc9d4f2e6f2ed3b3ee
+  FirebaseMessaging: 80b4a086d20ed4fd385a702f4bfa920e14f5064d
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2


### PR DESCRIPTION
* Update the syntax of sample apps to align with [docs changes](https://github.com/customerio/docs/pull/1627). 
* APN app had an error at runtime. I fixed it with App.js changes. 
* Rest of files are caused because of running `pod update` in sample apps. 
