### PR TITLE
fix(ios): when queue cannot find task, expect queue runs next task

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "react-native": "src/index",
   "source": "src/index",
   "expoVersion": "",
-  "cioNativeiOSSdkVersion": "= 2.8.4",
+  "cioNativeiOSSdkVersion": "= 2.8.5",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
Ship iOS bug fix https://github.com/customerio/customerio-ios/pull/397

**Note:** PR blocked until 2.8.5 iOS deployed to cocoapods. 