### PR TITLE
feat: increase opened metrics reliability and 3rd party push SDK compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "react-native": "src/index",
   "source": "src/index",
   "expoVersion": "",
-  "cioNativeiOSSdkVersion": "= 2.9.2",
+  "cioNativeiOSSdkVersion": "= 2.11.0",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
Install the latest iOS SDK version which includes automatic push click handling. Which gives the RN SDK great benefits such as: increased opened push metrics reliability and better compatibility with 3rd party RN push SDKs.

# Blocked until 

* [iOS feature deployed to production](https://github.com/customerio/customerio-ios/pull/403)
