### PR TITLE
ci: fix eslint result processing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,10 @@ jobs:
       - name: Annotate Code Linting Results
         uses: ataylorme/eslint-annotate-action@v3
         with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           check-name: 'eslint results'
           only-pr-files: false 
           fail-on-warning: false 
           fail-on-error: true 
           markdown-report-on-step-summary: true 
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           report-json: "eslint_report.json"


### PR DESCRIPTION
The github action that is used to process eslint results had a major version bump recently. They changed the way that you provide a github token used to create the CI status check.

For reference, here are docs for the latest version of this action:
https://github.com/ataylorme/eslint-annotate-action/tree/v3