### PR TITLE
fix: expo users reported app crash on didFailToRegisterForRemoteNotificationsWithError

### DIFF
--- a/Apps/APN/ios/Podfile.lock
+++ b/Apps/APN/ios/Podfile.lock
@@ -1,39 +1,39 @@
 PODS:
   - boost (1.76.0)
-  - customerio-reactnative (3.5.0):
-    - customerio-reactnative/nopush (= 3.5.0)
-    - CustomerIO/MessagingInApp (= 2.12.2)
-    - CustomerIO/Tracking (= 2.12.2)
+  - customerio-reactnative (3.5.1):
+    - customerio-reactnative/nopush (= 3.5.1)
+    - CustomerIO/MessagingInApp (= 2.12.3)
+    - CustomerIO/Tracking (= 2.12.3)
     - React-Core
-  - customerio-reactnative-richpush/apn (3.5.0):
-    - CustomerIO/MessagingPushAPN (= 2.12.2)
-  - customerio-reactnative/apn (3.5.0):
-    - CustomerIO/MessagingInApp (= 2.12.2)
-    - CustomerIO/MessagingPushAPN (= 2.12.2)
-    - CustomerIO/Tracking (= 2.12.2)
+  - customerio-reactnative-richpush/apn (3.5.1):
+    - CustomerIO/MessagingPushAPN (= 2.12.3)
+  - customerio-reactnative/apn (3.5.1):
+    - CustomerIO/MessagingInApp (= 2.12.3)
+    - CustomerIO/MessagingPushAPN (= 2.12.3)
+    - CustomerIO/Tracking (= 2.12.3)
     - React-Core
-  - customerio-reactnative/nopush (3.5.0):
-    - CustomerIO/MessagingInApp (= 2.12.2)
-    - CustomerIO/MessagingPush (= 2.12.2)
-    - CustomerIO/Tracking (= 2.12.2)
+  - customerio-reactnative/nopush (3.5.1):
+    - CustomerIO/MessagingInApp (= 2.12.3)
+    - CustomerIO/MessagingPush (= 2.12.3)
+    - CustomerIO/Tracking (= 2.12.3)
     - React-Core
-  - CustomerIO/MessagingInApp (2.12.2):
-    - CustomerIOMessagingInApp (= 2.12.2)
-  - CustomerIO/MessagingPush (2.12.2):
-    - CustomerIOMessagingPush (= 2.12.2)
-  - CustomerIO/MessagingPushAPN (2.12.2):
-    - CustomerIOMessagingPushAPN (= 2.12.2)
-  - CustomerIO/Tracking (2.12.2):
-    - CustomerIOTracking (= 2.12.2)
-  - CustomerIOCommon (2.12.2)
-  - CustomerIOMessagingInApp (2.12.2):
-    - CustomerIOTracking (= 2.12.2)
-  - CustomerIOMessagingPush (2.12.2):
-    - CustomerIOTracking (= 2.12.2)
-  - CustomerIOMessagingPushAPN (2.12.2):
-    - CustomerIOMessagingPush (= 2.12.2)
-  - CustomerIOTracking (2.12.2):
-    - CustomerIOCommon (= 2.12.2)
+  - CustomerIO/MessagingInApp (2.12.3):
+    - CustomerIOMessagingInApp (= 2.12.3)
+  - CustomerIO/MessagingPush (2.12.3):
+    - CustomerIOMessagingPush (= 2.12.3)
+  - CustomerIO/MessagingPushAPN (2.12.3):
+    - CustomerIOMessagingPushAPN (= 2.12.3)
+  - CustomerIO/Tracking (2.12.3):
+    - CustomerIOTracking (= 2.12.3)
+  - CustomerIOCommon (2.12.3)
+  - CustomerIOMessagingInApp (2.12.3):
+    - CustomerIOTracking (= 2.12.3)
+  - CustomerIOMessagingPush (2.12.3):
+    - CustomerIOTracking (= 2.12.3)
+  - CustomerIOMessagingPushAPN (2.12.3):
+    - CustomerIOMessagingPush (= 2.12.3)
+  - CustomerIOTracking (2.12.3):
+    - CustomerIOCommon (= 2.12.3)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.72.4)
   - FBReactNativeSpec (0.72.4):
@@ -351,12 +351,8 @@ PODS:
     - glog
   - react-native-notifications (5.1.0):
     - React-Core
-  - react-native-safe-area-context (4.5.3):
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
+  - react-native-safe-area-context (4.8.2):
     - React-Core
-    - ReactCommon/turbomodule/core
   - React-NativeModulesApple (0.72.4):
     - hermes-engine
     - React-callinvoker
@@ -467,15 +463,16 @@ PODS:
     - React-jsi (= 0.72.4)
     - React-logger (= 0.72.4)
     - React-perflogger (= 0.72.4)
-  - RNCAsyncStorage (1.18.2):
+  - RNCAsyncStorage (1.21.0):
     - React-Core
-  - RNCClipboard (1.11.2):
+  - RNCClipboard (1.13.2):
     - React-Core
   - RNCPushNotificationIOS (1.11.0):
     - React-Core
-  - RNDeviceInfo (10.7.0):
+  - RNDeviceInfo (10.12.0):
     - React-Core
-  - RNGestureHandler (2.12.1):
+  - RNGestureHandler (2.14.1):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - RNReanimated (3.2.0):
     - DoubleConversion
@@ -686,14 +683,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  CustomerIO: f33dc74e27cf2463adeeec7050f43923d4813a0e
-  customerio-reactnative: fe3e6d146f76f3ee922f18c52d9d27d907a384d2
-  customerio-reactnative-richpush: 5af75a5fbaa27f9290ca371c533f9fa93219aa45
-  CustomerIOCommon: 05e7cecb7e668b495d932020bc89e0eef833cb10
-  CustomerIOMessagingInApp: 0737b9bb5fbbfc29d2d6bdd50803405d01b87563
-  CustomerIOMessagingPush: d5d97ecf1c608954e4475033e573a3ffc3d7af52
-  CustomerIOMessagingPushAPN: a5d65368d3e6211e792a66069a8b89fc3ce79f53
-  CustomerIOTracking: 9ad6f4ab65df9ee08f8cfd593abe85da966f04c9
+  CustomerIO: d00b5e1f44ab92200bb38dda75c52961fd2df86b
+  customerio-reactnative: 3ff398f4d906a973149c68a8927cc613f7d7cc06
+  customerio-reactnative-richpush: f33224df458384f99e2e13df28fb39a0007bdeb9
+  CustomerIOCommon: cf2aeb5216ddc625c1d6fe8bc35830630cc18b29
+  CustomerIOMessagingInApp: 3caefed25b3628c02ede950f064f89e5fc1dd44f
+  CustomerIOMessagingPush: 88b2bab4f44961d0fef5ea16260358cae464aa2f
+  CustomerIOMessagingPushAPN: d054e2549411630cf67b9f16be5115949e74ccae
+  CustomerIOTracking: 5bb93da2c9a41f327483152197fb39dbb255dd13
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
   FBReactNativeSpec: 3fc2d478e1c4b08276f9dd9128f80ec6d5d85c1f
@@ -717,7 +714,7 @@ SPEC CHECKSUMS:
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
   react-native-notifications: 4601a5a8db4ced6ae7cfc43b44d35fe437ac50c4
-  react-native-safe-area-context: b8979f5eda6ed5903d4dbc885be3846ea3daa753
+  react-native-safe-area-context: 0ee144a6170530ccc37a0fd9388e28d06f516a89
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
   React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00
@@ -735,11 +732,11 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 4941cc1b3cf08b792fbf666342c9fc95f1969035
   React-utils: b79f2411931f9d3ea5781404dcbb2fa8a837e13a
   ReactCommon: 4b2bdcb50a3543e1c2b2849ad44533686610826d
-  RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
-  RNCClipboard: 3f0451a8100393908bea5c5c5b16f96d45f30bfc
+  RNCAsyncStorage: 618d03a5f52fbccb3d7010076bc54712844c18ef
+  RNCClipboard: 60fed4b71560d7bfe40e9d35dea9762b024da86d
   RNCPushNotificationIOS: 64218f3c776c03d7408284a819b2abfda1834bc8
-  RNDeviceInfo: 25d818c85db769cc0e7083d39efaa01a6f450df3
-  RNGestureHandler: c0d04458598fcb26052494ae23dda8f8f5162b13
+  RNDeviceInfo: db5c64a060e66e5db3102d041ebe3ef307a85120
+  RNGestureHandler: fe2be3be5598dc74329b211c58c9f2d231461769
   RNReanimated: ede9ef73159ec1d4db04290f4ffc4a36c5fc1156
   RNScreens: b21dc57dfa2b710c30ec600786a3fc223b1b92e7
   RNSnackbar: 3727b42bf6c4314a53c18185b5203e915a4ab020
@@ -748,4 +745,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: dd15e298a538ff617275f2a8acfe9f2e3d78fbbf
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.15.2

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "react-native": "src/index",
   "source": "src/index",
   "expoVersion": "",
-  "cioNativeiOSSdkVersion": "= 2.12.2",
+  "cioNativeiOSSdkVersion": "= 2.12.3",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
part of: https://linear.app/customerio/issue/MBL-141/expo-50-with-version-100-beta15-crash-startup-app-on-ios

This PR is using iOS SDK's version `2.12.3` with the fix for this crash. Refer this [iOS PR](https://github.com/customerio/customerio-ios/pull/575) for more detail.

