### PR TITLE
chore: fcm app not compiling and throws error on debugging

### DIFF
--- a/Apps/FCM/ios/NotificationServiceExtension/Info.plist
+++ b/Apps/FCM/ios/NotificationServiceExtension/Info.plist
@@ -7,7 +7,7 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.usernotifications.service</string>
 		<key>NSExtensionPrincipalClass</key>
-		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+		<string>NotificationService</string>
 	</dict>
 </dict>
 </plist>

--- a/Apps/FCM/ios/Podfile.lock
+++ b/Apps/FCM/ios/Podfile.lock
@@ -1,40 +1,40 @@
 PODS:
   - boost (1.76.0)
-  - customerio-reactnative (3.5.0):
-    - customerio-reactnative/nopush (= 3.5.0)
-    - CustomerIO/MessagingInApp (= 2.12.2)
-    - CustomerIO/Tracking (= 2.12.2)
+  - customerio-reactnative (3.5.2):
+    - customerio-reactnative/nopush (= 3.5.2)
+    - CustomerIO/MessagingInApp (= 2.12.3)
+    - CustomerIO/Tracking (= 2.12.3)
     - React-Core
-  - customerio-reactnative-richpush/fcm (3.5.0):
-    - CustomerIO/MessagingPushFCM (= 2.12.2)
-  - customerio-reactnative/fcm (3.5.0):
-    - CustomerIO/MessagingInApp (= 2.12.2)
-    - CustomerIO/MessagingPushFCM (= 2.12.2)
-    - CustomerIO/Tracking (= 2.12.2)
+  - customerio-reactnative-richpush/fcm (3.5.2):
+    - CustomerIO/MessagingPushFCM (= 2.12.3)
+  - customerio-reactnative/fcm (3.5.2):
+    - CustomerIO/MessagingInApp (= 2.12.3)
+    - CustomerIO/MessagingPushFCM (= 2.12.3)
+    - CustomerIO/Tracking (= 2.12.3)
     - React-Core
-  - customerio-reactnative/nopush (3.5.0):
-    - CustomerIO/MessagingInApp (= 2.12.2)
-    - CustomerIO/MessagingPush (= 2.12.2)
-    - CustomerIO/Tracking (= 2.12.2)
+  - customerio-reactnative/nopush (3.5.2):
+    - CustomerIO/MessagingInApp (= 2.12.3)
+    - CustomerIO/MessagingPush (= 2.12.3)
+    - CustomerIO/Tracking (= 2.12.3)
     - React-Core
-  - CustomerIO/MessagingInApp (2.12.2):
-    - CustomerIOMessagingInApp (= 2.12.2)
-  - CustomerIO/MessagingPush (2.12.2):
-    - CustomerIOMessagingPush (= 2.12.2)
-  - CustomerIO/MessagingPushFCM (2.12.2):
-    - CustomerIOMessagingPushFCM (= 2.12.2)
-  - CustomerIO/Tracking (2.12.2):
-    - CustomerIOTracking (= 2.12.2)
-  - CustomerIOCommon (2.12.2)
-  - CustomerIOMessagingInApp (2.12.2):
-    - CustomerIOTracking (= 2.12.2)
-  - CustomerIOMessagingPush (2.12.2):
-    - CustomerIOTracking (= 2.12.2)
-  - CustomerIOMessagingPushFCM (2.12.2):
-    - CustomerIOMessagingPush (= 2.12.2)
+  - CustomerIO/MessagingInApp (2.12.3):
+    - CustomerIOMessagingInApp (= 2.12.3)
+  - CustomerIO/MessagingPush (2.12.3):
+    - CustomerIOMessagingPush (= 2.12.3)
+  - CustomerIO/MessagingPushFCM (2.12.3):
+    - CustomerIOMessagingPushFCM (= 2.12.3)
+  - CustomerIO/Tracking (2.12.3):
+    - CustomerIOTracking (= 2.12.3)
+  - CustomerIOCommon (2.12.3)
+  - CustomerIOMessagingInApp (2.12.3):
+    - CustomerIOTracking (= 2.12.3)
+  - CustomerIOMessagingPush (2.12.3):
+    - CustomerIOTracking (= 2.12.3)
+  - CustomerIOMessagingPushFCM (2.12.3):
+    - CustomerIOMessagingPush (= 2.12.3)
     - FirebaseMessaging (< 11, >= 8.7.0)
-  - CustomerIOTracking (2.12.2):
-    - CustomerIOCommon (= 2.12.2)
+  - CustomerIOTracking (2.12.3):
+    - CustomerIOCommon (= 2.12.3)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.72.4)
   - FBReactNativeSpec (0.72.4):
@@ -55,9 +55,9 @@ PODS:
     - GoogleUtilities/Logger (~> 7.12)
   - FirebaseCoreExtension (10.20.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.21.0):
+  - FirebaseCoreInternal (10.22.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseInstallations (10.21.0):
+  - FirebaseInstallations (10.22.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -73,27 +73,35 @@ PODS:
     - nanopb (< 2.30910.0, >= 2.30908.0)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - GoogleDataTransport (9.3.0):
+  - GoogleDataTransport (9.4.1):
     - GoogleUtilities/Environment (~> 7.7)
-    - nanopb (< 2.30910.0, >= 2.30908.0)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/AppDelegateSwizzler (7.12.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.13.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.12.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Environment (7.13.0):
+    - GoogleUtilities/Privacy
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.12.0):
+  - GoogleUtilities/Logger (7.13.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (7.12.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (7.13.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.12.0)"
-  - GoogleUtilities/Reachability (7.12.0):
+  - "GoogleUtilities/NSData+zlib (7.13.0)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (7.13.0)
+  - GoogleUtilities/Reachability (7.13.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.12.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/UserDefaults (7.13.0):
     - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
   - hermes-engine (0.72.4):
     - hermes-engine/Pre-built (= 0.72.4)
   - hermes-engine/Pre-built (0.72.4)
@@ -404,7 +412,7 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-safe-area-context (4.7.2):
+  - react-native-safe-area-context (4.7.4):
     - React-Core
   - React-NativeModulesApple (0.72.4):
     - hermes-engine
@@ -516,25 +524,26 @@ PODS:
     - React-jsi (= 0.72.4)
     - React-logger (= 0.72.4)
     - React-perflogger (= 0.72.4)
-  - RNCAsyncStorage (1.19.3):
+  - RNCAsyncStorage (1.19.6):
     - React-Core
-  - RNCClipboard (1.11.2):
+  - RNCClipboard (1.12.1):
     - React-Core
-  - RNDeviceInfo (10.9.0):
+  - RNDeviceInfo (10.11.0):
     - React-Core
-  - RNFBApp (18.9.0):
+  - RNFBApp (18.8.0):
     - Firebase/CoreOnly (= 10.20.0)
     - React-Core
-  - RNFBMessaging (18.9.0):
+  - RNFBMessaging (18.8.0):
     - Firebase/Messaging (= 10.20.0)
     - FirebaseCoreExtension (= 10.20.0)
     - React-Core
     - RNFBApp
-  - RNGestureHandler (2.12.1):
+  - RNGestureHandler (2.13.4):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - RNScreens (3.25.0):
+  - RNScreens (3.27.0):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
-    - React-RCTImage
   - RNSnackbar (2.6.2):
     - React-Core
   - SocketRocket (0.6.1)
@@ -722,27 +731,27 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  CustomerIO: f33dc74e27cf2463adeeec7050f43923d4813a0e
-  customerio-reactnative: fe3e6d146f76f3ee922f18c52d9d27d907a384d2
-  customerio-reactnative-richpush: 5af75a5fbaa27f9290ca371c533f9fa93219aa45
-  CustomerIOCommon: 05e7cecb7e668b495d932020bc89e0eef833cb10
-  CustomerIOMessagingInApp: 0737b9bb5fbbfc29d2d6bdd50803405d01b87563
-  CustomerIOMessagingPush: d5d97ecf1c608954e4475033e573a3ffc3d7af52
-  CustomerIOMessagingPushFCM: e25b1767a67f460b833ea6c37586d4362ae720bf
-  CustomerIOTracking: 9ad6f4ab65df9ee08f8cfd593abe85da966f04c9
+  CustomerIO: d00b5e1f44ab92200bb38dda75c52961fd2df86b
+  customerio-reactnative: dd29af7bb00cc5803022bfce65ce2f181f48afb8
+  customerio-reactnative-richpush: 16c55fe3ec6b073672fe769deeb1d2b17c86c6fa
+  CustomerIOCommon: cf2aeb5216ddc625c1d6fe8bc35830630cc18b29
+  CustomerIOMessagingInApp: 3caefed25b3628c02ede950f064f89e5fc1dd44f
+  CustomerIOMessagingPush: 88b2bab4f44961d0fef5ea16260358cae464aa2f
+  CustomerIOMessagingPushFCM: cb640797602c488fa5640f5aa10a51c54ccdfb59
+  CustomerIOTracking: 5bb93da2c9a41f327483152197fb39dbb255dd13
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
   FBReactNativeSpec: 3fc2d478e1c4b08276f9dd9128f80ec6d5d85c1f
   Firebase: 10c8cb12fb7ad2ae0c09ffc86cd9c1ab392a0031
   FirebaseCore: 28045c1560a2600d284b9c45a904fe322dc890b6
   FirebaseCoreExtension: 0659f035b88c5a7a15a9763c48c2e6ca8c0a2977
-  FirebaseCoreInternal: 43c1788eaeee9d1b97caaa751af567ce11010d00
-  FirebaseInstallations: 390ea1d10a4d02b20c965cbfd527ee9b3b412acb
+  FirebaseCoreInternal: bca337352024b18424a61e478460547d46c4c753
+  FirebaseInstallations: 763814908793c0da14c18b3dcffdec71e29ed55e
   FirebaseMessaging: 06c414a21b122396a26847c523d5c370f8325df5
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  GoogleDataTransport: 57c22343ab29bc686febbf7cbb13bad167c2d8fe
-  GoogleUtilities: 0759d1a57ebb953965c2dfe0ba4c82e95ccc2e34
+  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
+  GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152
   hermes-engine: 81191603c4eaa01f5e4ae5737a9efcf64756c7b2
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
@@ -762,7 +771,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-safe-area-context: 7aa8e6d9d0f3100a820efb1a98af68aa747f9284
+  react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
   React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00
@@ -780,13 +789,13 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 4941cc1b3cf08b792fbf666342c9fc95f1969035
   React-utils: b79f2411931f9d3ea5781404dcbb2fa8a837e13a
   ReactCommon: 4b2bdcb50a3543e1c2b2849ad44533686610826d
-  RNCAsyncStorage: c913ede1fa163a71cea118ed4670bbaaa4b511bb
-  RNCClipboard: 3f0451a8100393908bea5c5c5b16f96d45f30bfc
-  RNDeviceInfo: 02ea8b23e2280fa18e00a06d7e62804d74028579
-  RNFBApp: a3e139715386fe79a09c387f2dbeb6890eb05b39
-  RNFBMessaging: a65862d8eba03cb6c838241bd328166504996894
-  RNGestureHandler: c0d04458598fcb26052494ae23dda8f8f5162b13
-  RNScreens: 85d3880b52d34db7b8eeebe2f1a0e807c05e69fa
+  RNCAsyncStorage: 191a99459b4a6d174cfe51579d34b5267201bbf3
+  RNCClipboard: d77213bfa269013bf4b857b7a9ca37ee062d8ef1
+  RNDeviceInfo: bf8a32acbcb875f568217285d1793b0e8588c974
+  RNFBApp: 5810d39f89d38272f29d9908cb19ef641922c081
+  RNFBMessaging: 8863c0206cc1a5577678eac6c1ec2b2965bd8e52
+  RNGestureHandler: 6e46dde1f87e5f018a54fe5d40cd0e0b942b49ee
+  RNScreens: 3c2d122f5e08c192e254c510b212306da97d2581
   RNSnackbar: 3727b42bf6c4314a53c18185b5203e915a4ab020
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 3efc43e0d48686ce2e8c60f99d4e6bd349aff981


### PR DESCRIPTION
## Context
React native FCM sample app's NotificationServiceExtension does not compile. It was found that it throws an error in the console log on debugging the extension target. The error log is:

`__extensionPrincipalClass != nil - /Library/Caches/com.apple.xbs/Sources/ExtensionFoundation_Sim/ExtensionFoundation/Source/NSExtension/NSExtensionSupport/EXConcreteExtensionContextVendor.m:109: Unable to find NSExtensionPrincipalClass (NotificationServiceExtension.NotificationService) in extension bundle! Please verify that the extension links the required frameworks and that the value for NSExtensionPrincipalClass is prefixed with '$(PRODUCT_MODULE_NAME).' if the class is implemented in Swift.`

This is the same error that one of our customer experienced and the same that prevented the app to display rich push notifications on the device.  

For more context:
- See [Linear comment](https://linear.app/customerio/issue/MBL-86/test-and-find-gaps-in-rn-nse-integration-documentation#comment-3c4b2d6d) for ticket https://linear.app/customerio/issue/MBL-86/test-and-find-gaps-in-rn-nse-integration-documentation#comment-3c4b2d6d

## PR Summary
This PR fixes the error by removing the prefixed '$(PRODUCT_MODULE_NAME).' in Info.plist.

## Test plan
To reproduce the issue on `main` branch:
- Run the app and send a rich push notification
- Note that you'll receive a push notification but without an image

After the fix:
- Run the app and send a rich push notification
- Now you receive a push notification but _with_ an image
