### PR TITLE
ci: revert action that annotations eslint results to fix ci on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,9 @@ jobs:
       - run: yarn lint:report
 
       - name: Annotate Code Linting Results
-        uses: ataylorme/eslint-annotate-action@v3
+        uses: ataylorme/eslint-annotate-action@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           check-name: 'eslint results'
           only-pr-files: false 
           fail-on-warning: false 


### PR DESCRIPTION
Reverts https://github.com/customerio/customerio-reactnative/pull/240

The action that we use to parse eslint results had a major version release (`v3`) and then changed the release to `v3-beta`.

Until the project creates a git tag indicating more clearly that v3 is ready for prod, I think we should continue to use v2 to keep `main` CI checks passing.

commit-id:6e52990a