### PR TITLE
build: setup downloading code signing files for sample apps

### DIFF
--- a/Apps/.gitignore
+++ b/Apps/.gitignore
@@ -106,6 +106,7 @@ playground.xcworkspace
 **/fastlane/Preview.html
 **/fastlane/screenshots
 **/fastlane/test_output
+**/fastlane/README.md
 
 # Code Injection
 #

--- a/Apps/APN/fastlane/Appfile
+++ b/Apps/APN/fastlane/Appfile
@@ -1,0 +1,3 @@
+# Include all of the bundle identifiers for your iOS app and for your rich push target. 
+# You find the bundle identifier of each app inside of Xcode - https://stackoverflow.com/a/59131511
+app_identifier(["io.customer.ami", "io.customer.ami.richpush"])

--- a/Apps/APN/fastlane/Fastfile
+++ b/Apps/APN/fastlane/Fastfile
@@ -1,0 +1,1 @@
+import "../../fastlane/Fastfile" # imports shared Fastfile from "Apps/fastlane/Fastfile"

--- a/Apps/FCM/fastlane/Appfile
+++ b/Apps/FCM/fastlane/Appfile
@@ -1,0 +1,3 @@
+# Include all of the bundle identifiers for your iOS app and for your rich push target. 
+# You find the bundle identifier of each app inside of Xcode - https://stackoverflow.com/a/59131511
+app_identifier(["io.customer.rn-sample.fcm", "io.customer.rn-sample.fcm.richpush"])

--- a/Apps/FCM/fastlane/Fastfile
+++ b/Apps/FCM/fastlane/Fastfile
@@ -1,0 +1,1 @@
+import "../../fastlane/Fastfile" # imports shared Fastfile from "Apps/fastlane/Fastfile"

--- a/Apps/fastlane/Fastfile
+++ b/Apps/fastlane/Fastfile
@@ -1,0 +1,11 @@
+
+# Import functions for setting up code signing in development as well as CI server. 
+# See this README (https://github.com/customerio/apple-code-signing) for list of all fastlane functions that this imports and you can run. 
+import_from_git(
+  url: "https://github.com/customerio/apple-code-signing.git", 
+  branch: "main", 
+  path: "fastlane/Fastfile"
+)
+
+# That is all we have for now.  
+# See the iOS SDK fastlane files for more functionality that we could add to this project in the future. 


### PR DESCRIPTION
I realized recently that you cannot run `fastlane download_development_code_signing` in the sample apps here like you can in the iOS SDK. This commit adds fastlane functions into the project so you can run all `fastlane` commands that the apple-code-signing repository defines. Making local development a bit easier to do.

commit-id:4fef2365