### PR TITLE
feat: privacy manifest files

### DIFF
--- a/Apps/APN/ios/Podfile.lock
+++ b/Apps/APN/ios/Podfile.lock
@@ -1,39 +1,39 @@
 PODS:
   - boost (1.76.0)
-  - customerio-reactnative (3.5.2):
-    - customerio-reactnative/nopush (= 3.5.2)
-    - CustomerIO/MessagingInApp (= 2.12.5)
-    - CustomerIO/Tracking (= 2.12.5)
+  - customerio-reactnative (3.5.4):
+    - customerio-reactnative/nopush (= 3.5.4)
+    - CustomerIO/MessagingInApp (= 2.13.0)
+    - CustomerIO/Tracking (= 2.13.0)
     - React-Core
-  - customerio-reactnative-richpush/apn (3.5.2):
-    - CustomerIO/MessagingPushAPN (= 2.12.5)
-  - customerio-reactnative/apn (3.5.2):
-    - CustomerIO/MessagingInApp (= 2.12.5)
-    - CustomerIO/MessagingPushAPN (= 2.12.5)
-    - CustomerIO/Tracking (= 2.12.5)
+  - customerio-reactnative-richpush/apn (3.5.4):
+    - CustomerIO/MessagingPushAPN (= 2.13.0)
+  - customerio-reactnative/apn (3.5.4):
+    - CustomerIO/MessagingInApp (= 2.13.0)
+    - CustomerIO/MessagingPushAPN (= 2.13.0)
+    - CustomerIO/Tracking (= 2.13.0)
     - React-Core
-  - customerio-reactnative/nopush (3.5.2):
-    - CustomerIO/MessagingInApp (= 2.12.5)
-    - CustomerIO/MessagingPush (= 2.12.5)
-    - CustomerIO/Tracking (= 2.12.5)
+  - customerio-reactnative/nopush (3.5.4):
+    - CustomerIO/MessagingInApp (= 2.13.0)
+    - CustomerIO/MessagingPush (= 2.13.0)
+    - CustomerIO/Tracking (= 2.13.0)
     - React-Core
-  - CustomerIO/MessagingInApp (2.12.5):
-    - CustomerIOMessagingInApp (= 2.12.5)
-  - CustomerIO/MessagingPush (2.12.5):
-    - CustomerIOMessagingPush (= 2.12.5)
-  - CustomerIO/MessagingPushAPN (2.12.5):
-    - CustomerIOMessagingPushAPN (= 2.12.5)
-  - CustomerIO/Tracking (2.12.5):
-    - CustomerIOTracking (= 2.12.5)
-  - CustomerIOCommon (2.12.5)
-  - CustomerIOMessagingInApp (2.12.5):
-    - CustomerIOTracking (= 2.12.5)
-  - CustomerIOMessagingPush (2.12.5):
-    - CustomerIOTracking (= 2.12.5)
-  - CustomerIOMessagingPushAPN (2.12.5):
-    - CustomerIOMessagingPush (= 2.12.5)
-  - CustomerIOTracking (2.12.5):
-    - CustomerIOCommon (= 2.12.5)
+  - CustomerIO/MessagingInApp (2.13.0):
+    - CustomerIOMessagingInApp (= 2.13.0)
+  - CustomerIO/MessagingPush (2.13.0):
+    - CustomerIOMessagingPush (= 2.13.0)
+  - CustomerIO/MessagingPushAPN (2.13.0):
+    - CustomerIOMessagingPushAPN (= 2.13.0)
+  - CustomerIO/Tracking (2.13.0):
+    - CustomerIOTracking (= 2.13.0)
+  - CustomerIOCommon (2.13.0)
+  - CustomerIOMessagingInApp (2.13.0):
+    - CustomerIOTracking (= 2.13.0)
+  - CustomerIOMessagingPush (2.13.0):
+    - CustomerIOTracking (= 2.13.0)
+  - CustomerIOMessagingPushAPN (2.13.0):
+    - CustomerIOMessagingPush (= 2.13.0)
+  - CustomerIOTracking (2.13.0):
+    - CustomerIOCommon (= 2.13.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.72.4)
   - FBReactNativeSpec (0.72.4):
@@ -683,14 +683,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  CustomerIO: 23b20c362c2824492147e50120c3da78dbd2d5a7
-  customerio-reactnative: 78f40eca3ed428d499b6710ac3cd8b070500b953
-  customerio-reactnative-richpush: 85255d203ab27e75e40893144342dc18f5815b12
-  CustomerIOCommon: 823ae9cec9fe1e3427e86ed01ff037f6b2fd225c
-  CustomerIOMessagingInApp: 193d5991459623b3657ea135ef143db48a1b127b
-  CustomerIOMessagingPush: cd27ef2331ed31891de651fa2327c300d7420dcf
-  CustomerIOMessagingPushAPN: d4aae8b04c030eb39ca71d1f16fe60a3bb29111d
-  CustomerIOTracking: 058bcae5ae2678de47f45c71066ac9eafafb7cd5
+  CustomerIO: 55adb7377dff7afaf38c533c5bddaabfdd4203ac
+  customerio-reactnative: ac88b4a499afc7ea6b5360c355cdb329762232bc
+  customerio-reactnative-richpush: c8ffb0981d330fdb6faaee3313f71a01a0a76904
+  CustomerIOCommon: 5c4c2d0ca81dd802dd3bab368c96fb3ee5ab7fe6
+  CustomerIOMessagingInApp: abe108b80c8deecac70741fa2c9928289fda5814
+  CustomerIOMessagingPush: c4a9a57de9e7ff1ab65e9b73cf49c7b4b155248e
+  CustomerIOMessagingPushAPN: 7bb31a9f6357c047475a6b27728c243a4090c2b1
+  CustomerIOTracking: d209e341d3732a8aa23858faed2565f4c6ee5ef7
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
   FBReactNativeSpec: 3fc2d478e1c4b08276f9dd9128f80ec6d5d85c1f

--- a/Apps/APN/ios/SampleApp.xcodeproj/project.pbxproj
+++ b/Apps/APN/ios/SampleApp.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 				46D41ED42A0944BF0008DBA4 /* Sources */,
 				46D41ED52A0944BF0008DBA4 /* Frameworks */,
 				46D41ED62A0944BF0008DBA4 /* Resources */,
+				6C1A9415C2D81E3D11DD832C /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -356,6 +357,26 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh\n../node_modules/expo-constants/scripts/get-app-config-ios.sh\n../node_modules/expo-updates/scripts/create-manifest-ios.sh\n";
 		};
+		6C1A9415C2D81E3D11DD832C /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/CustomerIOMessagingPushAPN/CustomerIOMessagingPushAPN_Privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/CustomerIOTracking/CustomerIOTracking_Privacy.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/CustomerIOMessagingPushAPN_Privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/CustomerIOTracking_Privacy.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		74A960915E932AA283D380B5 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -403,10 +424,16 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-SampleApp/Pods-SampleApp-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/CustomerIOMessagingInApp/CustomerIOMessagingInApp_Privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/CustomerIOMessagingPushAPN/CustomerIOMessagingPushAPN_Privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/CustomerIOTracking/CustomerIOTracking_Privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/CustomerIOMessagingInApp_Privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/CustomerIOMessagingPushAPN_Privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/CustomerIOTracking_Privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Apps/FCM/ios/Podfile.lock
+++ b/Apps/FCM/ios/Podfile.lock
@@ -1,40 +1,40 @@
 PODS:
   - boost (1.76.0)
-  - customerio-reactnative (3.5.3):
-    - customerio-reactnative/nopush (= 3.5.3)
-    - CustomerIO/MessagingInApp (= 2.12.5)
-    - CustomerIO/Tracking (= 2.12.5)
+  - customerio-reactnative (3.5.4):
+    - customerio-reactnative/nopush (= 3.5.4)
+    - CustomerIO/MessagingInApp (= 2.13.0)
+    - CustomerIO/Tracking (= 2.13.0)
     - React-Core
-  - customerio-reactnative-richpush/fcm (3.5.3):
-    - CustomerIO/MessagingPushFCM (= 2.12.5)
-  - customerio-reactnative/fcm (3.5.3):
-    - CustomerIO/MessagingInApp (= 2.12.5)
-    - CustomerIO/MessagingPushFCM (= 2.12.5)
-    - CustomerIO/Tracking (= 2.12.5)
+  - customerio-reactnative-richpush/fcm (3.5.4):
+    - CustomerIO/MessagingPushFCM (= 2.13.0)
+  - customerio-reactnative/fcm (3.5.4):
+    - CustomerIO/MessagingInApp (= 2.13.0)
+    - CustomerIO/MessagingPushFCM (= 2.13.0)
+    - CustomerIO/Tracking (= 2.13.0)
     - React-Core
-  - customerio-reactnative/nopush (3.5.3):
-    - CustomerIO/MessagingInApp (= 2.12.5)
-    - CustomerIO/MessagingPush (= 2.12.5)
-    - CustomerIO/Tracking (= 2.12.5)
+  - customerio-reactnative/nopush (3.5.4):
+    - CustomerIO/MessagingInApp (= 2.13.0)
+    - CustomerIO/MessagingPush (= 2.13.0)
+    - CustomerIO/Tracking (= 2.13.0)
     - React-Core
-  - CustomerIO/MessagingInApp (2.12.5):
-    - CustomerIOMessagingInApp (= 2.12.5)
-  - CustomerIO/MessagingPush (2.12.5):
-    - CustomerIOMessagingPush (= 2.12.5)
-  - CustomerIO/MessagingPushFCM (2.12.5):
-    - CustomerIOMessagingPushFCM (= 2.12.5)
-  - CustomerIO/Tracking (2.12.5):
-    - CustomerIOTracking (= 2.12.5)
-  - CustomerIOCommon (2.12.5)
-  - CustomerIOMessagingInApp (2.12.5):
-    - CustomerIOTracking (= 2.12.5)
-  - CustomerIOMessagingPush (2.12.5):
-    - CustomerIOTracking (= 2.12.5)
-  - CustomerIOMessagingPushFCM (2.12.5):
-    - CustomerIOMessagingPush (= 2.12.5)
+  - CustomerIO/MessagingInApp (2.13.0):
+    - CustomerIOMessagingInApp (= 2.13.0)
+  - CustomerIO/MessagingPush (2.13.0):
+    - CustomerIOMessagingPush (= 2.13.0)
+  - CustomerIO/MessagingPushFCM (2.13.0):
+    - CustomerIOMessagingPushFCM (= 2.13.0)
+  - CustomerIO/Tracking (2.13.0):
+    - CustomerIOTracking (= 2.13.0)
+  - CustomerIOCommon (2.13.0)
+  - CustomerIOMessagingInApp (2.13.0):
+    - CustomerIOTracking (= 2.13.0)
+  - CustomerIOMessagingPush (2.13.0):
+    - CustomerIOTracking (= 2.13.0)
+  - CustomerIOMessagingPushFCM (2.13.0):
+    - CustomerIOMessagingPush (= 2.13.0)
     - FirebaseMessaging (< 11, >= 8.7.0)
-  - CustomerIOTracking (2.12.5):
-    - CustomerIOCommon (= 2.12.5)
+  - CustomerIOTracking (2.13.0):
+    - CustomerIOCommon (= 2.13.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.72.4)
   - FBReactNativeSpec (0.72.4):
@@ -55,9 +55,9 @@ PODS:
     - GoogleUtilities/Logger (~> 7.12)
   - FirebaseCoreExtension (10.20.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.23.0):
+  - FirebaseCoreInternal (10.24.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseInstallations (10.23.0):
+  - FirebaseInstallations (10.24.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -412,7 +412,7 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-safe-area-context (4.7.2):
+  - react-native-safe-area-context (4.9.0):
     - React-Core
   - React-NativeModulesApple (0.72.4):
     - hermes-engine
@@ -526,9 +526,9 @@ PODS:
     - React-perflogger (= 0.72.4)
   - RNCAsyncStorage (1.22.3):
     - React-Core
-  - RNCClipboard (1.11.2):
+  - RNCClipboard (1.13.2):
     - React-Core
-  - RNDeviceInfo (10.9.0):
+  - RNDeviceInfo (10.13.1):
     - React-Core
   - RNFBApp (18.9.0):
     - Firebase/CoreOnly (= 10.20.0)
@@ -538,11 +538,12 @@ PODS:
     - FirebaseCoreExtension (= 10.20.0)
     - React-Core
     - RNFBApp
-  - RNGestureHandler (2.12.1):
+  - RNGestureHandler (2.15.0):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - RNScreens (3.25.0):
+  - RNScreens (3.29.0):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
-    - React-RCTImage
   - RNSnackbar (2.6.2):
     - React-Core
   - SocketRocket (0.6.1)
@@ -730,22 +731,22 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  CustomerIO: 23b20c362c2824492147e50120c3da78dbd2d5a7
-  customerio-reactnative: cbce2fea6c4d76e8e5ff92947b2dc5964f819f55
-  customerio-reactnative-richpush: 1b789a7a28185db57787a1d5ac0fc7805d72fc7c
-  CustomerIOCommon: 823ae9cec9fe1e3427e86ed01ff037f6b2fd225c
-  CustomerIOMessagingInApp: 193d5991459623b3657ea135ef143db48a1b127b
-  CustomerIOMessagingPush: cd27ef2331ed31891de651fa2327c300d7420dcf
-  CustomerIOMessagingPushFCM: b419b4b6bfe259754186f246098fbd11cd02cb82
-  CustomerIOTracking: 058bcae5ae2678de47f45c71066ac9eafafb7cd5
+  CustomerIO: 55adb7377dff7afaf38c533c5bddaabfdd4203ac
+  customerio-reactnative: ac88b4a499afc7ea6b5360c355cdb329762232bc
+  customerio-reactnative-richpush: c8ffb0981d330fdb6faaee3313f71a01a0a76904
+  CustomerIOCommon: 5c4c2d0ca81dd802dd3bab368c96fb3ee5ab7fe6
+  CustomerIOMessagingInApp: abe108b80c8deecac70741fa2c9928289fda5814
+  CustomerIOMessagingPush: c4a9a57de9e7ff1ab65e9b73cf49c7b4b155248e
+  CustomerIOMessagingPushFCM: 3de31ee43590a26ce753e64df5305cea1b9db583
+  CustomerIOTracking: d209e341d3732a8aa23858faed2565f4c6ee5ef7
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
   FBReactNativeSpec: 3fc2d478e1c4b08276f9dd9128f80ec6d5d85c1f
   Firebase: 10c8cb12fb7ad2ae0c09ffc86cd9c1ab392a0031
   FirebaseCore: 28045c1560a2600d284b9c45a904fe322dc890b6
   FirebaseCoreExtension: 0659f035b88c5a7a15a9763c48c2e6ca8c0a2977
-  FirebaseCoreInternal: 6a292e6f0bece1243a737e81556e56e5e19282e3
-  FirebaseInstallations: 42d6ead4605d6eafb3b6683674e80e18eb6f2c35
+  FirebaseCoreInternal: bcb5acffd4ea05e12a783ecf835f2210ce3dc6af
+  FirebaseInstallations: 8f581fca6478a50705d2bd2abd66d306e0f5736e
   FirebaseMessaging: 06c414a21b122396a26847c523d5c370f8325df5
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
@@ -770,7 +771,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-safe-area-context: 7aa8e6d9d0f3100a820efb1a98af68aa747f9284
+  react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
   React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00
@@ -789,12 +790,12 @@ SPEC CHECKSUMS:
   React-utils: b79f2411931f9d3ea5781404dcbb2fa8a837e13a
   ReactCommon: 4b2bdcb50a3543e1c2b2849ad44533686610826d
   RNCAsyncStorage: 10591b9e0a91eaffee14e69b3721009759235125
-  RNCClipboard: 3f0451a8100393908bea5c5c5b16f96d45f30bfc
-  RNDeviceInfo: 02ea8b23e2280fa18e00a06d7e62804d74028579
+  RNCClipboard: 60fed4b71560d7bfe40e9d35dea9762b024da86d
+  RNDeviceInfo: 4f9c7cfd6b9db1b05eb919620a001cf35b536423
   RNFBApp: a3e139715386fe79a09c387f2dbeb6890eb05b39
   RNFBMessaging: a65862d8eba03cb6c838241bd328166504996894
-  RNGestureHandler: c0d04458598fcb26052494ae23dda8f8f5162b13
-  RNScreens: 85d3880b52d34db7b8eeebe2f1a0e807c05e69fa
+  RNGestureHandler: 7909c50383a18f0cb10ce1db7262b9a6da504c03
+  RNScreens: 3c5b9f4a9dcde752466854b6109b79c0e205dad3
   RNSnackbar: 3727b42bf6c4314a53c18185b5203e915a4ab020
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 3efc43e0d48686ce2e8c60f99d4e6bd349aff981

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "react-native": "src/index",
   "source": "src/index",
   "expoVersion": "",
-  "cioNativeiOSSdkVersion": "= 2.12.5",
+  "cioNativeiOSSdkVersion": "= 2.13.0",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
Closes: https://linear.app/customerio/issue/MBL-190/release-react-native

This commit installs the latest version of the native iOS SDK which includes the new Apple privacy manifest files.