### PR TITLE
feat: support for android gradle plugin 8

### DIFF
--- a/Apps/APN/android/build.gradle
+++ b/Apps/APN/android/build.gradle
@@ -34,7 +34,6 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenLocal()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url("$rootDir/../node_modules/react-native/android")
@@ -52,5 +51,7 @@ allprojects {
         }
         google()
         maven { url 'https://www.jitpack.io' }
+        mavenLocal() // Only required for using locally deployed versions of the SDK
+        maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' } // Only required for using SNAPSHOT versions of the SDK
     }
 }

--- a/Apps/FCM/android/app/src/main/AndroidManifest.xml
+++ b/Apps/FCM/android/app/src/main/AndroidManifest.xml
@@ -55,7 +55,7 @@
              notifications. This is not required. However, if you have multiple services added for
              handling push notifications, you might need to add this service to ensure all
              notifications are handled by Customer.io. Read more:
-             https://www.customer.io/docs/sdk/flutter/push-notifications/multiple-push-providers/ -->
+             https://www.customer.io/docs/sdk/react-native/push-notifications/multiple-push-providers/ -->
         <service
             android:name="io.customer.messagingpush.CustomerIOFirebaseMessagingService"
             android:exported="false">

--- a/Apps/FCM/android/app/src/main/AndroidManifest.xml
+++ b/Apps/FCM/android/app/src/main/AndroidManifest.xml
@@ -51,6 +51,19 @@
             </intent-filter>
         </activity>
 
+        <!-- Register Customer.io Firebase Messaging Service as we want our SDK to handle all push
+             notifications. This is not required. However, if you have multiple services added for
+             handling push notifications, you might need to add this service to ensure all
+             notifications are handled by Customer.io. Read more:
+             https://www.customer.io/docs/sdk/flutter/push-notifications/multiple-push-providers/ -->
+        <service
+            android:name="io.customer.messagingpush.CustomerIOFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"
             android:resource="@drawable/ic_notification" />

--- a/Apps/FCM/android/build.gradle
+++ b/Apps/FCM/android/build.gradle
@@ -24,5 +24,7 @@ buildscript {
 allprojects {
    repositories {
       google()  // Google's Maven repository
+      mavenLocal() // Only required for using locally deployed versions of the SDK
+      maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' } // Only required for using SNAPSHOT versions of the SDK
    }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ android {
   
   buildTypes {
     release {
-      minifyEnabled true
+      minifyEnabled false
     }
   }
   lintOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 android {
+  namespace 'io.customer.reactnative.sdk'
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
@@ -33,15 +34,15 @@ android {
   
   buildTypes {
     release {
-      minifyEnabled false
+      minifyEnabled true
     }
   }
   lintOptions {
     disable 'GradleCompatible'
   }
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 customerio.reactnative.kotlinVersion=1.7.21
-customerio.reactnative.compileSdkVersion=30
-customerio.reactnative.targetSdkVersion=30
+customerio.reactnative.compileSdkVersion=33
+customerio.reactnative.targetSdkVersion=33
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=3.9.2
+customerio.reactnative.cioSDKVersionAndroid=3.10.0

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.customer.reactnative.sdk">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 


### PR DESCRIPTION
closes: [MBL-233](https://linear.app/customerio/issue/MBL-233/react-native-sdk-compatibility-with-gradle-8)
blocked by: release of https://github.com/customerio/customerio-android/pull/296

### Highlights

- Support for Android Gradle Plugin 8.0
- JDK Version is updated to `17` from `1.8`

### Changes

- Updated react native package to make it compatible with changes for Android Gradle Plugin 8.0 in native SDK
- Updated sample app to include local and snapshot repos for testing

### Tasks

- [x] Update Android SDK version to actual required value