### PR TITLE
chore: deeplinks functionality 

### DIFF
--- a/example/ios/APN/Info.plist
+++ b/example/ios/APN/Info.plist
@@ -20,6 +20,19 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>amiapp-reactnative-apns</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>amiapp-reactnative-apns</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/example/ios/Shared/AppDelegate.mm
+++ b/example/ios/Shared/AppDelegate.mm
@@ -4,6 +4,7 @@
 #import <UserNotifications/UNUserNotificationCenter.h>
 #import <CustomerIOReactNativePush-Swift.h>
 #import "Constants.h"
+#import <React/RCTLinkingManager.h>
 
 #if __has_include(<FirebaseMessaging/FirebaseMessaging.h>)
 #define FCM
@@ -61,4 +62,11 @@
 #endif
 }
 
+// Deep linking
+ - (BOOL)application:(UIApplication *)application
+   openURL:(NSURL *)url
+   options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+ {
+   return [RCTLinkingManager application:application openURL:url options:options];
+ }
 @end

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -29,6 +29,16 @@ export default function App({ moduleName }: { moduleName: string }) {
     loadFromStorage();
   }, [storage]);
 
+  // Deep linking configuration
+  const getLinkingConfig = () => ({
+    prefixes: ['amiapp-reactnative-apns://'],
+    config: {
+      screens: {
+        Login: 'login',
+        Settings: 'qa-settings',
+      },
+    },
+  });
   return (
     <>
       {isLoading && <BodyText>Loading....</BodyText>}
@@ -76,7 +86,8 @@ export default function App({ moduleName }: { moduleName: string }) {
             },
           }}
         >
-          <NavigationContainer theme={appTheme}>
+          <NavigationContainer theme={appTheme}
+          linking={getLinkingConfig()}>
             <ContentNavigator moduleName={moduleName} />
             <FlashMessage position="top" duration={4000} />
           </NavigationContainer>


### PR DESCRIPTION
This PR introduces deep linking support in sample app. It allows users to be directed to specific screens within the app via deep links. This PR uses `amiapp-reactnative-apns` as url-scheme.


### Changes
- Added a linking configuration object in the main app.tsx
- Configured URL prefixes to recognize `amiapp-reactnative-apns://` links.
- Mapped specific paths to the settings screen (QA screen)
- Consume linking configuration in `NavigationContainer`
- Added required code in AppDelegate.mm file
- Added url scheme in info.plist

### Testing
- Send a push notification with deep link `amiapp-reactnative-apns://qa-settings` or `amiapp-reactnative-apns://login`
- Tap on the push notification
- You will be taken to settings screen or login screen based on the deep link

Dev testing cases covered:
- Push notification received
- Rich push notification with image received
- Rich push notification with image and deeplink received
- When the app is in the foreground, background, and on tapping, QA screen opens
- When the app is in a killed state, on tapping, QA screen opens
- Push metrics tracked https://fly.customer.io/workspaces/122175/journeys/people/bfba0700f103f203

Since `autoTrackPushMetrics` is true by default, the auto tracking of push metrics is also covered in this PR.
