### PR TITLE
chore: register device token and delete already registered device token

### DIFF
--- a/ios/wrappers/CioRctWrapper.mm
+++ b/ios/wrappers/CioRctWrapper.mm
@@ -10,6 +10,7 @@ RCT_EXTERN_METHOD(track:(NSString *)name properties:(NSDictionary *)properties)
 RCT_EXTERN_METHOD(screen:(NSString *)title category: (NSString *)category properties:(NSDictionary *))
 RCT_EXTERN_METHOD(setProfileAttributes: (NSDictionary *)attributes)
 RCT_EXTERN_METHOD(setDeviceAttributes: (NSDictionary *)attributes)
+RCT_EXTERN_METHOD(registerDeviceToken: (NSString *)identify)
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/ios/wrappers/CioRctWrapper.mm
+++ b/ios/wrappers/CioRctWrapper.mm
@@ -11,6 +11,7 @@ RCT_EXTERN_METHOD(screen:(NSString *)title category: (NSString *)category proper
 RCT_EXTERN_METHOD(setProfileAttributes: (NSDictionary *)attributes)
 RCT_EXTERN_METHOD(setDeviceAttributes: (NSDictionary *)attributes)
 RCT_EXTERN_METHOD(registerDeviceToken: (NSString *)identify)
+RCT_EXTERN_METHOD(deleteDeviceToken)
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/ios/wrappers/CioRctWrapper.swift
+++ b/ios/wrappers/CioRctWrapper.swift
@@ -85,6 +85,11 @@ class CioRctWrapper: NSObject {
     func registerDeviceToken(_ token: String){
         CustomerIO.shared.registerDeviceToken(token)
     }
+    
+    @objc
+    func deleteDeviceToken(){
+        CustomerIO.shared.deleteDeviceToken()
+    }
 }
 
 extension CioRctWrapper: InAppEventListener {

--- a/ios/wrappers/CioRctWrapper.swift
+++ b/ios/wrappers/CioRctWrapper.swift
@@ -80,6 +80,11 @@ class CioRctWrapper: NSObject {
         CustomerIO.shared.deviceAttributes = attrs
         flush()
     }
+    
+    @objc
+    func registerDeviceToken(_ token: String){
+        CustomerIO.shared.registerDeviceToken(token)
+    }
 }
 
 extension CioRctWrapper: InAppEventListener {

--- a/src/customer-io.ts
+++ b/src/customer-io.ts
@@ -81,6 +81,15 @@ export class CustomerIO {
     return NativeCustomerIO.setDeviceAttributes(attributes);
   };
 
+  static readonly registerDeviceToken = async (
+    token: string
+  ) => {
+    if (token === null || token === undefined) {
+      throw new Error('You must provide a token to registerDeviceToken');
+    }
+    NativeCustomerIO.registerDeviceToken(token);
+  };
+
   static readonly isInitialized = () => CustomerIO.initialized;
 
   static readonly inAppMessaging = new CustomerIOInAppMessaging();

--- a/src/customer-io.ts
+++ b/src/customer-io.ts
@@ -90,6 +90,9 @@ export class CustomerIO {
     NativeCustomerIO.registerDeviceToken(token);
   };
 
+  static readonly deleteDeviceToken = async () => {
+    NativeCustomerIO.deleteDeviceToken();
+  };
   static readonly isInitialized = () => CustomerIO.initialized;
 
   static readonly inAppMessaging = new CustomerIOInAppMessaging();


### PR DESCRIPTION
This PR introduces two new methods, `registerDeviceToken` and `deleteDeviceToken`, to both the React Native and iOS native modules. These methods have been implemented and tested to ensure proper functionality.

### Changes:
**React Native Module:**
- Added registerDeviceToken method.
- Added deleteDeviceToken method.
**iOS Native Module:**
- Implemented registerDeviceToken method.
- Implemented deleteDeviceToken method.

### Purpose:
The purpose of these changes is to provide a more comprehensive device token management solution within the React Native and iOS native modules, enabling better handling of device tokens.

### Testing:
Dev testing has been done on the following users:
- Register device token : [User](https://fly.customer.io/workspaces/122175/journeys/people/bfba0700f103f203) Note that there are two device tokens registered, first is the actual one and then we have another one as `dummy_token_registration` that is hardcoded to test the feature. 
- Delete device token : [User](https://fly.customer.io/workspaces/122175/journeys/people/bfba0700f203f303)
Note that there is no device registered to this user. If you look at the logs then you will see that device token was initially added and later removed.

### Notes:
- Since there is no test button in our current sample apps, this feature has not been added to the new sample app either.
- Testing was conducted by manually updating the methods on certain existing buttons. This approach may be a limitation for QA testing.