### PR TITLE
chore: category not required in screen tracking in react native package

### DIFF
--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -63,14 +63,13 @@ export class CustomerIO {
 
   static readonly screen = async (
     title: string,
-    category?: string,
     properties?: Record<string, any>
   ) => {
     CustomerIO.assrtInitialized();
     if (!title) {
       throw new Error('You must provide a name to screen');
     }
-    return NativeCustomerIO.screen(title, category, properties);
+    return NativeCustomerIO.screen(title, properties);
   };
 
   static readonly setProfileAttributes = async (


### PR DESCRIPTION
Linear ticket : https://linear.app/customerio/issue/MBL-450/[android]-update-native-module-to-use-track-event-using-android-cdp

This PR updates react native package to use screen tracking without category as a parameter as per tech doc. 