### PR TITLE
chore: category not required in screen tracking in ios native module

### DIFF
--- a/ios/wrappers/CioRctWrapper.mm
+++ b/ios/wrappers/CioRctWrapper.mm
@@ -7,7 +7,7 @@ RCT_EXTERN_METHOD(initialize:(id)config logLevel:(NSString *)logLevel)
 RCT_EXTERN_METHOD(identify:(NSString *)identify traits:(NSDictionary *)traits)
 RCT_EXTERN_METHOD(clearIdentify)
 RCT_EXTERN_METHOD(track:(NSString *)name properties:(NSDictionary *)properties)
-RCT_EXTERN_METHOD(screen:(NSString *)title category: (NSString *)category properties:(NSDictionary *))
+RCT_EXTERN_METHOD(screen:(NSString *)title properties:(NSDictionary *))
 RCT_EXTERN_METHOD(setProfileAttributes: (NSDictionary *)attributes)
 RCT_EXTERN_METHOD(setDeviceAttributes: (NSDictionary *)attributes)
 

--- a/ios/wrappers/CioRctWrapper.swift
+++ b/ios/wrappers/CioRctWrapper.swift
@@ -57,8 +57,8 @@ class CioRctWrapper: NSObject {
     }
     
     @objc
-    func screen(_ title: String, category: String?, properties: [String: Any]?) {
-        CustomerIO.shared.screen(title: title, category: category, properties: properties)
+    func screen(_ title: String, properties: [String: Any]?) {
+        CustomerIO.shared.screen(title: title, properties: properties)
         flush()
     }
     

--- a/ios/wrappers/CioRctWrapper.swift
+++ b/ios/wrappers/CioRctWrapper.swift
@@ -53,7 +53,6 @@ class CioRctWrapper: NSObject {
     @objc
     func screen(_ title: String, properties: [String: Any]?) {
         CustomerIO.shared.screen(title: title, properties: properties)
-        flush()
     }
     
     @objc

--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -63,14 +63,13 @@ export class CustomerIO {
 
   static readonly screen = async (
     title: string,
-    category?: string,
     properties?: Record<string, any>
   ) => {
     CustomerIO.assrtInitialized();
     if (!title) {
       throw new Error('You must provide a name to screen');
     }
-    return NativeCustomerIO.screen(title, category, properties);
+    return NativeCustomerIO.screen(title, properties);
   };
 
   static readonly setProfileAttributes = async (

--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -62,13 +62,14 @@ export class CustomerIO {
 
   static readonly screen = async (
     title: string,
+    category?: string,
     properties?: Record<string, any>
   ) => {
     CustomerIO.assrtInitialized();
     if (!title) {
       throw new Error('You must provide a name to screen');
     }
-    return NativeCustomerIO.screen(title, properties);
+    return NativeCustomerIO.screen(title, category, properties);
   };
 
   static readonly setProfileAttributes = async (


### PR DESCRIPTION
Linear ticket : [https://linear.app/customerio/issue/MBL-450/[android]-update-native-module-to-use-track-event-using-android-cdp](https://linear.app/customerio/issue/MBL-450/%5Bandroid%5D-update-native-module-to-use-track-event-using-android-cdp)

This PR updates react iOS native module to use screen tracking without category as a parameter as per tech doc.