### PR TITLE
chore: anonymously identify user profile when only traits are provided

### DIFF
--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
@@ -83,6 +83,10 @@ class NativeCustomerIOModule(
 
     @ReactMethod
     fun identify(identifier: String?, attributes: ReadableMap?) {
+        if (identifier == null && attributes == null) {
+            logger.error("Please provide either an ID or traits to identify.")
+            return
+        }
         identifier?.let {
             customerIO()?.identify(identifier, attributes.toMap())
         }?: run {

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativeModule.kt
@@ -82,8 +82,12 @@ class NativeCustomerIOModule(
     }
 
     @ReactMethod
-    fun identify(identifier: String, attributes: ReadableMap?) {
-        customerIO()?.identify(identifier, attributes.toMap())
+    fun identify(identifier: String?, attributes: ReadableMap?) {
+        identifier?.let {
+            customerIO()?.identify(identifier, attributes.toMap())
+        }?: run {
+            customerIO()?.profileAttributes = attributes.toMap()
+        }
     }
 
     @ReactMethod


### PR DESCRIPTION
Linear ticket : https://linear.app/customerio/issue/MBL-453/[android]-update-native-module-to-use-identify-using-android-cdp-sdk

### Problem
A user can be identified either by a user profile with an identifier or anonymously. An anonymous user is defined as one who provides traits without an identifier. The React Native package should be able to identify a user profile in either scenario. To support this functionality, both the iOS and Android native modules need to incorporate this feature. 

### Solution
This PR adds support to anonymously identify a user when only traits are provided on Android Native module by updating the profile attributes. As no identifier is provided so the profile attributes are updated anonymously. 