### PR TITLE
chore: logging feature in react native package and ios native module

### DIFF
--- a/Apps/APN/src/services/CustomerIOService.js
+++ b/Apps/APN/src/services/CustomerIOService.js
@@ -10,8 +10,9 @@ export const initializeCustomerIoSDK = (sdkConfig) => {
     }
  };
  if (sdkConfig.debugMode) {
-  config.logLevel = CioLogLevel.debug;
+  config.logLevel = CioLogLevel.Debug;
 }
+
 CustomerIO.initialize(config)
 };
 

--- a/ios/wrappers/CioRctWrapper.swift
+++ b/ios/wrappers/CioRctWrapper.swift
@@ -15,7 +15,7 @@ class CioRctWrapper: NSObject {
         do {
             logger = CioLoggerWrapper.getInstance(moduleRegistry: moduleRegistry, logLevel: CioLogLevel(rawValue: logLevel) ?? .none)
 
-            logger.debug("Initializing CIO with config: \(configJson)")
+            logger.debug("Initializing Customer.io SDK with config: \(configJson)")
             let rtcConfig = try RCTCioConfig.from(configJson)
             let cioInitConfig = cioInitializeConfig(from: rtcConfig, logLevel: logLevel)
             CustomerIO.initialize(withConfig: cioInitConfig.cdp)
@@ -27,7 +27,7 @@ class CioRctWrapper: NSObject {
                 }
             }
         } catch {
-            // TODO: Add log when logger feature is implemented
+            logger.error("Initializing Customer.io SDK failed with error \(error)")
         }
     }
     
@@ -40,7 +40,7 @@ class CioRctWrapper: NSObject {
         } else if codableTraits != nil {
             CustomerIO.shared.identify(traits: codableTraits!)
         } else {
-            // TODO: Add log when logger feature is implemented
+            logger.error("Provide id or traits to identify a user profile.")
         }
     }
     

--- a/ios/wrappers/CioRctWrapper.swift
+++ b/ios/wrappers/CioRctWrapper.swift
@@ -8,10 +8,14 @@ import React
 class CioRctWrapper: NSObject {
     
     @objc var moduleRegistry: RCTModuleRegistry!
+    private var logger: CioLogger!
         
     @objc
     func initialize(_ configJson: AnyObject, logLevel: String) {
         do {
+            logger = CioLoggerWrapper.getInstance(moduleRegistry: moduleRegistry, logLevel: CioLogLevel(rawValue: logLevel) ?? .none)
+
+            logger.debug("Initializing CIO with config: \(configJson)")
             let rtcConfig = try RCTCioConfig.from(configJson)
             let cioInitConfig = cioInitializeConfig(from: rtcConfig, logLevel: logLevel)
             CustomerIO.initialize(withConfig: cioInitConfig.cdp)

--- a/ios/wrappers/logging/CioLoggingEmitter.mm
+++ b/ios/wrappers/logging/CioLoggingEmitter.mm
@@ -1,0 +1,4 @@
+#import <React/RCTEventEmitter.h>
+
+@interface RCT_EXTERN_REMAP_MODULE(CioLoggingEmitter, CioLoggingEmitter, RCTEventEmitter)
+@end

--- a/ios/wrappers/logging/CioLoggingEmitter.swift
+++ b/ios/wrappers/logging/CioLoggingEmitter.swift
@@ -36,7 +36,7 @@ class CioLoggingEmitter: RCTEventEmitter {
 
 class CioLoggerWrapper: CioLogger {
     private(set) var logLevel: CioLogLevel
-    private var moduleRegistry: RCTModuleRegistry
+    private weak var moduleRegistry: RCTModuleRegistry?
     
     static func getInstance (moduleRegistry: RCTModuleRegistry, logLevel: CioLogLevel) -> CioLogger {
         if let wrapper = DIGraphShared.shared.logger as? Self  {
@@ -90,7 +90,7 @@ class CioLoggerWrapper: CioLogger {
     }
     
     private var emitter: CioLoggingEmitter? {
-        moduleRegistry.module(forName: "CioLoggingEmitter") as? CioLoggingEmitter
+        moduleRegistry?.module(forName: "CioLoggingEmitter") as? CioLoggingEmitter
     }
     
 }

--- a/ios/wrappers/logging/CioLoggingEmitter.swift
+++ b/ios/wrappers/logging/CioLoggingEmitter.swift
@@ -8,9 +8,14 @@ typealias CioLogger = CioInternalCommon.Logger
 class CioLoggingEmitter: RCTEventEmitter {
     
     fileprivate static var eventName = "CioLogEvent"
-
+    
     fileprivate var hasObservers = false
-        
+    
+    // Requires adding requiresMainQueueSetup method
+    // since it overrides init
+    @objc static override func requiresMainQueueSetup() -> Bool {
+        return true // Return true if the module must be initialized on the main queue
+    }
     override func startObserving() {
         hasObservers = true
     }
@@ -18,7 +23,7 @@ class CioLoggingEmitter: RCTEventEmitter {
     override func stopObserving() {
         hasObservers = false
     }
-
+    
     override func supportedEvents() -> [String] {
         [Self.eventName]
     }

--- a/ios/wrappers/logging/CioLoggingEmitter.swift
+++ b/ios/wrappers/logging/CioLoggingEmitter.swift
@@ -1,0 +1,91 @@
+
+import React
+import CioInternalCommon
+
+typealias CioLogger = CioInternalCommon.Logger
+
+@objc(CioLoggingEmitter)
+class CioLoggingEmitter: RCTEventEmitter {
+    
+    fileprivate static var eventName = "CioLogEvent"
+
+    fileprivate var hasObservers = false
+        
+    override func startObserving() {
+        hasObservers = true
+    }
+    
+    override func stopObserving() {
+        hasObservers = false
+    }
+
+    override func supportedEvents() -> [String] {
+        [Self.eventName]
+    }
+    
+    override var methodQueue: dispatch_queue_t! {
+        DispatchQueue(label: Self.moduleName())
+    }
+}
+
+
+class CioLoggerWrapper: CioLogger {
+    private(set) var logLevel: CioLogLevel
+    private var moduleRegistry: RCTModuleRegistry
+    
+    static func getInstance (moduleRegistry: RCTModuleRegistry, logLevel: CioLogLevel) -> CioLogger {
+        if let wrapper = DIGraphShared.shared.logger as? Self  {
+            wrapper.logLevel = logLevel
+            wrapper.moduleRegistry = moduleRegistry
+            return wrapper
+        }
+        
+        let wrapper = CioLoggerWrapper(moduleRegistry: moduleRegistry, logLevel: logLevel)
+        DIGraphShared.shared.override(value: wrapper, forType: CioLogger.self)
+        return wrapper
+    }
+    
+    private init(moduleRegistry: RCTModuleRegistry, logLevel: CioLogLevel?) {
+        self.logLevel = logLevel ?? .none
+        self.moduleRegistry = moduleRegistry
+    }
+    
+    func setLogLevel(_ level: CioLogLevel) {
+        logLevel = level
+    }
+
+    func debug(_ message: String) {
+        emit(message, level: .debug)
+    }
+    
+    func info(_ message: String) {
+        emit(message, level: .info)
+    }
+    
+    func error(_ message: String) {
+        emit(message, level: .error)
+    }
+    
+    private func emit(_ message: String, level: CioLogLevel) {
+        if shouldEmit(level: level), let emitter, emitter.hasObservers {
+            emitter.sendEvent(withName: CioLoggingEmitter.eventName, body: ["logLevel": level.rawValue, "message": message])
+        }
+    }
+    
+    private func shouldEmit(level: CioLogLevel) -> Bool {
+        switch self.logLevel {
+        case .none: return false
+        case .error:
+            return level == .error
+        case .info:
+            return level == .error || level == .info
+        case .debug:
+            return true
+        }
+    }
+    
+    private var emitter: CioLoggingEmitter? {
+        moduleRegistry.module(forName: "CioLoggingEmitter") as? CioLoggingEmitter
+    }
+    
+}

--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -1,7 +1,7 @@
 import { NativeModules, Platform } from 'react-native';
 import { CioLogLevel, type CioConfig } from './cio-config';
 import {type IdentifyParams } from './cio-params';
-// TODO: Import the CustomerIOInAppMessaging, NativeLoggerListener and CustomerIOPushMessaging classes from their respective files
+// TODO: Import the CustomerIOInAppMessaging and CustomerIOPushMessaging classes from their respective files
 // when they are implemented.
 // import { CustomerIOInAppMessaging } from './customerio-inapp';
 // import { CustomerIOPushMessaging } from './customerio-push';

--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -5,7 +5,7 @@ import {type IdentifyParams } from './cio-params';
 // when they are implemented.
 // import { CustomerIOInAppMessaging } from './customerio-inapp';
 // import { CustomerIOPushMessaging } from './customerio-push';
-// import { NativeLoggerListener } from './native-logger-listener';
+import { NativeLoggerListener } from './native-logger-listener';
 
 const LINKING_ERROR =
   `The package 'customerio-reactnative' doesn't seem to be linked. Make sure: ` +
@@ -28,10 +28,9 @@ export class CustomerIO {
   private static initialized = false;
 
   static readonly initialize = async (config: CioConfig) => {
-    // TODO: Initialize logger when it is implemented.
-    // if (config.logLevel && config.logLevel !== CioLogLevel.None) {
-    //   NativeLoggerListener.initialize();
-    // }
+    if (config.logLevel && config.logLevel !== CioLogLevel.None) {
+      NativeLoggerListener.initialize();
+    }
     let logLevel = config.logLevel?.valueOf() ?? CioLogLevel.Error.valueOf();
     NativeCustomerIO.initialize(config, logLevel);
     CustomerIO.initialized = true;

--- a/src/native-logger-listener.ts
+++ b/src/native-logger-listener.ts
@@ -24,21 +24,23 @@ export class NativeLoggerListener {
     bridge.addListener(
       'CioLogEvent',
       (event: { logLevel: CioLogLevel; message: string }) => {
-        // if we just use console.log, it will log to the JS side but it will prevent RN default behavior of redirecting logs to the native side
-        // doing it async allows to be logged to the JS side and then to the native side
+        // Using console.log will log to the JavaScript side but prevent
+        // React Native’s default behavior of redirecting logs to the native side.
+        // By doing it asynchronously, we ensure the logs are captured on both
+        // the JavaScript and native ends.
         async function log() {
           switch (event.logLevel) {
             case CioLogLevel.Debug:
-              console.debug(event.message);
+              console.debug("[CIO] " + event.message);
               break;
             case CioLogLevel.Info:
-              console.info(event.message);
+              console.info("[CIO] " + event.message);
               break;
             case CioLogLevel.Error:
-              console.error(event.message);
+              console.error("[CIO] " + event.message);
               break;
             default:
-              console.log(event);
+              console.log("[CIO] " + event);
               break;
           }
         }

--- a/src/native-logger-listener.ts
+++ b/src/native-logger-listener.ts
@@ -1,0 +1,49 @@
+import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
+import { CioLogLevel } from './cio-config';
+
+const LINKING_ERROR =
+  `The package 'customerio-reactnative' doesn't seem to be linked. Make sure: ` +
+  Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
+  '- You rebuilt the app after installing the package\n' +
+  '- You are not using Expo Go\n';
+
+const CioLoggingEmitter = NativeModules.CioLoggingEmitter
+  ? NativeModules.CioLoggingEmitter
+  : new Proxy(
+      {},
+      {
+        get() {
+          throw new Error(LINKING_ERROR);
+        },
+      }
+    );
+
+export class NativeLoggerListener {
+  static initialize() {
+    const bridge = new NativeEventEmitter(CioLoggingEmitter);
+    bridge.addListener(
+      'CioLogEvent',
+      (event: { logLevel: CioLogLevel; message: string }) => {
+        // if we just use console.log, it will log to the JS side but it will prevent RN default behavior of redirecting logs to the native side
+        // doing it async allows to be logged to the JS side and then to the native side
+        async function log() {
+          switch (event.logLevel) {
+            case CioLogLevel.Debug:
+              console.debug(event.message);
+              break;
+            case CioLogLevel.Info:
+              console.info(event.message);
+              break;
+            case CioLogLevel.Error:
+              console.error(event.message);
+              break;
+            default:
+              console.log(event);
+              break;
+          }
+        }
+        log();
+      }
+    );
+  }
+}

--- a/src/native-logger-listener.ts
+++ b/src/native-logger-listener.ts
@@ -19,8 +19,10 @@ const CioLoggingEmitter = NativeModules.CioLoggingEmitter
     );
 
 export class NativeLoggerListener {
+  
   static initialize() {
     const bridge = new NativeEventEmitter(CioLoggingEmitter);
+    const loggerPrefix = "[CIO] ";
     bridge.addListener(
       'CioLogEvent',
       (event: { logLevel: CioLogLevel; message: string }) => {
@@ -31,16 +33,16 @@ export class NativeLoggerListener {
         async function log() {
           switch (event.logLevel) {
             case CioLogLevel.Debug:
-              console.debug("[CIO] " + event.message);
+              console.debug(loggerPrefix + event.message);
               break;
             case CioLogLevel.Info:
-              console.info("[CIO] " + event.message);
+              console.info(loggerPrefix + event.message);
               break;
             case CioLogLevel.Error:
-              console.error("[CIO] " + event.message);
+              console.error(loggerPrefix + event.message);
               break;
             default:
-              console.log("[CIO] " + event);
+              console.log(loggerPrefix + event);
               break;
           }
         }


### PR DESCRIPTION
Linear ticket : https://linear.app/customerio/issue/MBL-477/add-logging-support-in-package-ios-and-react-native

### Problem
As a developer, I want to have logging support integrated into the package so that I can easily access logs without needing to open Xcode.

### Solution
Added logger support in React Native using event emitters from the iOS native module, enabling all native logs to be output to the React Native console. This eliminates the need for customers to open Xcode to retrieve logs, as they currently do.