### PR TITLE
chore: register and delete device token in react native & ios

### DIFF
--- a/ios/wrappers/CioRctWrapper.mm
+++ b/ios/wrappers/CioRctWrapper.mm
@@ -10,6 +10,8 @@ RCT_EXTERN_METHOD(track:(NSString *)name properties:(NSDictionary *)properties)
 RCT_EXTERN_METHOD(screen:(NSString *)title properties:(NSDictionary *))
 RCT_EXTERN_METHOD(setProfileAttributes: (NSDictionary *)attributes)
 RCT_EXTERN_METHOD(setDeviceAttributes: (NSDictionary *)attributes)
+RCT_EXTERN_METHOD(registerDeviceToken: (NSString *)identify)
+RCT_EXTERN_METHOD(deleteDeviceToken)
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/ios/wrappers/CioRctWrapper.mm
+++ b/ios/wrappers/CioRctWrapper.mm
@@ -10,7 +10,7 @@ RCT_EXTERN_METHOD(track:(NSString *)name properties:(NSDictionary *)properties)
 RCT_EXTERN_METHOD(screen:(NSString *)title properties:(NSDictionary *))
 RCT_EXTERN_METHOD(setProfileAttributes: (NSDictionary *)attributes)
 RCT_EXTERN_METHOD(setDeviceAttributes: (NSDictionary *)attributes)
-RCT_EXTERN_METHOD(registerDeviceToken: (NSString *)identify)
+RCT_EXTERN_METHOD(registerDeviceToken: (NSString *)token)
 RCT_EXTERN_METHOD(deleteDeviceToken)
 
 + (BOOL)requiresMainQueueSetup

--- a/ios/wrappers/CioRctWrapper.swift
+++ b/ios/wrappers/CioRctWrapper.swift
@@ -9,18 +9,18 @@ class CioRctWrapper: NSObject {
     
     @objc var moduleRegistry: RCTModuleRegistry!
     private var logger: CioLogger!
-        
+    
     @objc
     func initialize(_ configJson: AnyObject, logLevel: String) {
         do {
             logger = CioLoggerWrapper.getInstance(moduleRegistry: moduleRegistry, logLevel: CioLogLevel(rawValue: logLevel) ?? .none)
-
+            
             logger.debug("Initializing Customer.io SDK with config: \(configJson)")
             let rtcConfig = try RCTCioConfig.from(configJson)
             let cioInitConfig = cioInitializeConfig(from: rtcConfig, logLevel: logLevel)
             CustomerIO.initialize(withConfig: cioInitConfig.cdp)
             if let inAppConfig = cioInitConfig.inApp {
-                    // In app initializes UIView(s) which would crash if run from non-UI queues
+                // In app initializes UIView(s) which would crash if run from non-UI queues
                 DispatchQueue.main.async {
                     MessagingInApp.initialize(withConfig: inAppConfig)
                     MessagingInApp.shared.setEventListener(self)
@@ -67,6 +67,16 @@ class CioRctWrapper: NSObject {
     @objc
     func setDeviceAttributes(_ attrs: [String: Any]) {
         CustomerIO.shared.deviceAttributes = attrs
+    }
+    
+    @objc
+    func registerDeviceToken(_ token: String){
+        CustomerIO.shared.registerDeviceToken(token)
+    }
+    
+    @objc
+    func deleteDeviceToken(){
+        CustomerIO.shared.deleteDeviceToken()
     }
 }
 

--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -81,6 +81,19 @@ export class CustomerIO {
   ) => {
     return NativeCustomerIO.setDeviceAttributes(attributes);
   };
+  
+  static readonly registerDeviceToken = async (
+    token: string
+  ) => {
+    if (token === null || token === undefined) {
+      throw new Error('You must provide a token to registerDeviceToken');
+    }
+    NativeCustomerIO.registerDeviceToken(token);
+  };
+
+  static readonly deleteDeviceToken = async () => {
+    NativeCustomerIO.deleteDeviceToken();
+  };
 
   static readonly isInitialized = () => CustomerIO.initialized;
 

--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -86,7 +86,7 @@ export class CustomerIO {
     token: string
   ) => {
     if (token === null || token === undefined) {
-      throw new Error('You must provide a token to registerDeviceToken');
+      throw new Error('You must provide a valid token to register device token.');
     }
     NativeCustomerIO.registerDeviceToken(token);
   };


### PR DESCRIPTION
Linear ticket:
https://linear.app/customerio/issue/MBL-505/register-and-delete-already-registered-device-token-in-react-native
https://linear.app/customerio/issue/MBL-506/register-and-delete-token-feature-support-in-ios-native-module

This PR introduces two new methods, `registerDeviceToken` and `deleteDeviceToken`, to both the React Native and iOS native modules. These methods have been implemented and tested to ensure proper functionality.

### Changes:
**React Native Module:**
- Added registerDeviceToken method.
- Added deleteDeviceToken method.
**iOS Native Module:**
- Implemented registerDeviceToken method.
- Implemented deleteDeviceToken method.

### Purpose:
The purpose of these changes is to provide a more comprehensive device token management solution within the React Native and iOS native modules, enabling better handling of device tokens.

### Testing:
Dev testing has been done on the following users:
- Register device token : [User](https://fly.customer.io/workspaces/122175/journeys/people/bfba0700e404e504) 
- Delete device token : [User](https://fly.customer.io/workspaces/122175/journeys/people/bfba0700e404e504)

### Notes:
- Since there is no test button in our current sample apps, testing was conducted by manually updating the methods on certain existing buttons. This approach may be a limitation for QA testing.