### PR TITLE
chore: auto register device attributes 

### DIFF
--- a/Apps/APN/src/screens/Settings.js
+++ b/Apps/APN/src/screens/Settings.js
@@ -213,6 +213,13 @@ const Settings = ({ navigation, route }) => {
             contentDesc="App Lifecycle Events Tracking Toggle"
           />
         </View>
+        <SwitchField
+            style={settingsStyles.switchRow}
+            label="Auto track device attributes"
+            onValueChange={() => setTrackDeviceAttributesEnabled(!isTrackDeviceAttributesEnabled)}
+            value={isTrackDeviceAttributesEnabled}
+            contentDesc="Auto track device attributes Toggle"
+          />
         <View style={settingsStyles.section}>
         <Text style={settingsStyles.sectionLabel}>Development</Text>
           <SwitchField

--- a/Apps/APN/src/services/CustomerIOService.js
+++ b/Apps/APN/src/services/CustomerIOService.js
@@ -5,6 +5,7 @@ export const initializeCustomerIoSDK = (sdkConfig) => {
     cdpApiKey: Env.cdpApiKey, // Mandatory
     migrationSiteId: Env.siteId, // For migration
     trackApplicationLifecycleEvents: true, // TODO: Update this to a configurable property based on settings
+    autoTrackDeviceAttributes: sdkConfig.autoTrackDeviceAttributes,
     inApp: {
 	    siteId: 'site_id',
     }

--- a/Apps/FCM/src/services/CustomerIOService.ts
+++ b/Apps/FCM/src/services/CustomerIOService.ts
@@ -11,6 +11,7 @@ export const initializeCustomerIoSDK = (sdkConfig: CustomerIoSDKConfig) => {
     cdpApiKey: Env.cdpApiKey, // Mandatory
     migrationSiteId: Env.siteId, // For migration
     trackApplicationLifecycleEvents: true, // TODO: Update this to a configurable property based on settings
+    autoTrackDeviceAttributes: sdkConfig.trackDeviceAttributes,
     inApp: {
       siteId: 'site_id',
     },

--- a/ios/wrappers/utils/CioConfigUtils.swift
+++ b/ios/wrappers/utils/CioConfigUtils.swift
@@ -16,6 +16,7 @@ struct RCTCioConfig: Decodable {
     let siteId: String?
     let region: Region?
     let trackApplicationLifecycleEvents: Bool?
+    let autoTrackDeviceAttributes: Bool?
     let enableInApp: Bool?
     let qa: QASettings?
     
@@ -43,6 +44,7 @@ func cioInitializeConfig(from config: RCTCioConfig, logLevel: String?) -> CioCon
     let cioLogLevel = CioLogLevel(rawValue: logLevel ?? "no log level")
     ifNotNil(config.siteId, thenPassItTo: cdpConfigBuilder.migrationSiteId)
     ifNotNil(config.region, thenPassItTo: cdpConfigBuilder.region)
+    ifNotNil(config.autoTrackDeviceAttributes, thenPassItTo: cdpConfigBuilder.autoTrackDeviceAttributes)
     ifNotNil(config.trackApplicationLifecycleEvents, thenPassItTo: cdpConfigBuilder.trackApplicationLifecycleEvents)
     ifNotNil(cioLogLevel, thenPassItTo: cdpConfigBuilder.logLevel)
     ifNotNil(config.qa?.cdnHost, thenPassItTo: cdpConfigBuilder.cdnHost)


### PR DESCRIPTION
Linear ticket : https://linear.app/customerio/issue/MBL-508/automatic-device-token-and-attribute-collection-on-ios-and-android

### Problem:
As a developer, I need the ability to manually or automatically collect device tokens and set device attributes, either through manual input or automatically, so that these tokens and attributes can be consumed on Fly for building workflows. This feature would allow for more efficient device management and workflow automation based on device-specific data.

### Solution:
Added feature to auto track device attributes and made fixes for the feature wherever required.