### PR TITLE
chore: reuses native module config

### DIFF
--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/RNCIOPushMessaging.kt
@@ -34,10 +34,6 @@ class RNCIOPushMessaging(
      */
     private var notificationRequestPromise: Promise? = null
 
-    private val SDKComponent.pushModuleConfig: MessagingPushModuleConfig
-        get() = newInstance {
-            modules["MessagingPushFCM"]?.moduleConfig as MessagingPushModuleConfig
-        }
     init {
         reactContext.addActivityEventListener(this)
     }


### PR DESCRIPTION
closes: [MBL-545: Push metrics tracking (iOS & Android - RN)](https://linear.app/customerio/issue/MBL-545/push-metrics-tracking-ios-and-android-rn)

uses exposed module config from native