### PR TITLE
chore: TurboModule method signature mismatch in Swift by removing external parameter label

### DIFF
--- a/ios/wrappers/push/CioRctPushMessaging.swift
+++ b/ios/wrappers/push/CioRctPushMessaging.swift
@@ -6,7 +6,7 @@ enum PushPermissionStatus: String, CaseIterable {
     case denied
     case notDetermined
     case granted
-    
+
     var value: String {
         return rawValue.uppercased()
     }
@@ -18,24 +18,24 @@ class CioRctPushMessaging: NSObject {
     @objc static func requiresMainQueueSetup() -> Bool {
         false /// false because our native module's initialization does not require access to UIKit
     }
-    
+
     // Tracks `opened` push metrics when a push notification is interacted with.
     @objc
-    func trackNotificationResponseReceived(payload: NSDictionary) {
+    func trackNotificationResponseReceived(_ payload: NSDictionary) {
         trackPushMetrics(payload: payload, event: .opened)
     }
-    
+
     // Tracks `delivered` push metrics when a push notification is received.
     @objc
-    func trackNotificationReceived(payload: NSDictionary) {
-        
+    func trackNotificationReceived(_ payload: NSDictionary) {
+
         trackPushMetrics(payload: payload, event: .delivered)
     }
-   
+
     // Get the currently registered device token for the app
     @objc(getRegisteredDeviceToken:rejecter:)
     func getRegisteredDeviceToken(resolver resolve: @escaping(RCTPromiseResolveBlock), rejecter reject: @escaping(RCTPromiseRejectBlock)) -> Void {
-        
+
          guard let token = CustomerIO.shared.registeredDeviceToken else {
             reject(CustomerioConstants.cioTag, CustomerioConstants.showDeviceTokenFailureError, nil)
              return
@@ -46,18 +46,18 @@ class CioRctPushMessaging: NSObject {
     private func trackPushMetrics(payload: NSDictionary, event : Metric) {
         guard let deliveryId = payload[CustomerioConstants.CioDeliveryId] as? String, let deviceToken = payload[CustomerioConstants.CioDeliveryToken] as? String else
         {return}
-        
+
         MessagingPush.shared.trackMetric(deliveryID: deliveryId, event: event, deviceToken: deviceToken)
     }
-    
+
     @objc(showPromptForPushNotifications:resolver:rejecter:)
     func showPromptForPushNotifications(options : Dictionary<String, AnyHashable>, resolver resolve: @escaping(RCTPromiseResolveBlock),  rejecter reject: @escaping(RCTPromiseRejectBlock)) -> Void {
-        
+
         // Show prompt if status is not determined
         getPushNotificationPermissionStatus { status in
             if status == .notDetermined {
                 self.requestPushAuthorization(options: options) { permissionStatus in
-                    
+
                     guard let isGranted = permissionStatus as? Bool else {
                         reject(CustomerioConstants.cioTag, CustomerioConstants.showPromptFailureError, permissionStatus as? Error)
                         return
@@ -69,20 +69,20 @@ class CioRctPushMessaging: NSObject {
             }
         }
     }
-    
+
     @objc(getPushPermissionStatus:rejecter:)
     func getPushPermissionStatus(resolver resolve: @escaping(RCTPromiseResolveBlock), rejecter reject: @escaping(RCTPromiseRejectBlock)) -> Void {
         getPushNotificationPermissionStatus { status in
             resolve(status.value)
         }
     }
-    
+
     private func requestPushAuthorization(options: [String: Any], onComplete : @escaping(Any) -> Void
         ) {
             let current = UNUserNotificationCenter.current()
             var notificationOptions : UNAuthorizationOptions = [.alert]
             if let ios = options[CustomerioConstants.platformiOS] as? [String: Any] {
-                
+
                 if let soundOption = ios[CustomerioConstants.sound] as? Bool, soundOption {
                     notificationOptions.insert(.sound)
                 }
@@ -98,7 +98,7 @@ class CioRctPushMessaging: NSObject {
                 onComplete(isGranted)
             }
         }
-        
+
     private func getPushNotificationPermissionStatus(completionHandler: @escaping(PushPermissionStatus) -> Void) {
         var status = PushPermissionStatus.notDetermined
         let current = UNUserNotificationCenter.current()


### PR DESCRIPTION
# Overview

This PR fixes an issue while building RN app based on 0.76.

| <img width="350" alt="image" src="https://github.com/user-attachments/assets/ddee065d-abfb-4943-b329-d08cd0abc912"> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/889d7a24-9925-4768-aed0-e537eca641be"> |
|:-------------------------------------------------------------------------------------------------------------------:|---|

## Problem

When calling the `trackNotificationResponseReceived` method via TurboModule for React Native, a compilation failure occurred at the parameter mapping stage between JavaScript and Swift/Objective-C. Debug logs revealed that the `trackNotificationResponseReceived:(NSDictionary *)payload` method was not recognized correctly because the arguments array was passed as null.

## Solution

To remove this inconsistency, we added `_` (an unnamed label) to Swift class for the payload parameter in the `trackNotificationResponseReceived` and `trackNotificationReceived` methods. This made both methods more compatible with Objective-C because `_` removes the need to specify the parameter name when calling it, thus eliminating signature differences and allowing TurboModule to recognize the method correctly.

### Logs
```
#3	0x000000010b31a394 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::basic_string[abi:de180100]<0> at Developer/SDKs/iPhoneSimulator18.0.sdk/usr/include/c++/v1/string:953

#4	0x000000010b319f3c in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::basic_string[abi:de180100]<0> at Developer/SDKs/iPhoneSimulator18.0.sdk/usr/include/c++/v1/string:952

#5	0x000000010c228800 in facebook::react::(anonymous namespace)::parseExportedMethods at node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.mm:127
...
```

I've also added some logs to identify the problematic methods:

RCTInteropTurboModule.parseExportedMethods:
```
...
    NSMethodSignature *objCMethodSignature = [moduleClass instanceMethodSignatureForSelector:objCMethodSelector];
      NSLog(@"\n\n---\n\nJs method name: %@\n\n\n\nobj name: %s\n\narguments: %@\n\nselector: %s\n\nsignature: %@\n\nclass: %@\n\n---\n\n", jsMethodName, methodInfo->objcName, arguments, objCMethodSelector, objCMethodSignature, moduleClass);
    std::string objCMethodReturnType = [objCMethodSignature methodReturnType];
...
```

Other methods:

```
---

Js method name: supportedEvents



obj name: supportedEvents

arguments: (null)

selector: supportedEvents

signature: <NSMethodSignature: 0xb21a5f2c0267cedf>

class: CioRctInAppMessaging

---


---

Js method name: dismissMessage



obj name: dismissMessage

arguments: (null)

selector: dismissMessage

signature: <NSMethodSignature: 0xb21a5f2c02676087>

class: CioRctInAppMessaging

---
```

Broken one:

```
Js method name: trackNotificationResponseReceived



obj name: trackNotificationResponseReceived : (nonnull NSDictionary *) payload]

arguments: (
    "<RCTMethodArgument: 0x6000003898c0>"
)

selector: trackNotificationResponseReceived:

signature: (null)

class: CioRctPushMessaging
```