### PR TITLE
fix: compatibility with react native 0.76

### DIFF
--- a/ios/wrappers/CioRctWrapper.mm
+++ b/ios/wrappers/CioRctWrapper.mm
@@ -2,11 +2,11 @@
 
 @interface RCT_EXTERN_REMAP_MODULE (NativeCustomerIO, CioRctWrapper, NSObject)
 
-RCT_EXTERN_METHOD(initialize : (id)config args : (id _Nullable)args)
-RCT_EXTERN_METHOD(identify : (NSString* _Nullable)userId traits : (NSDictionary* _Nullable)traits)
+RCT_EXTERN_METHOD(initialize : (id)config args : (id)args)
+RCT_EXTERN_METHOD(identify : (NSString*)userId traits : (NSDictionary*)traits)
 RCT_EXTERN_METHOD(clearIdentify)
-RCT_EXTERN_METHOD(track : (NSString*)name properties : (NSDictionary* _Nullable)properties)
-RCT_EXTERN_METHOD(screen : (NSString*)title properties : (NSDictionary* _Nullable)properties)
+RCT_EXTERN_METHOD(track : (NSString*)name properties : (NSDictionary*)properties)
+RCT_EXTERN_METHOD(screen : (NSString*)title properties : (NSDictionary*)properties)
 RCT_EXTERN_METHOD(setProfileAttributes : (NSDictionary*)attributes)
 RCT_EXTERN_METHOD(setDeviceAttributes : (NSDictionary*)attributes)
 RCT_EXTERN_METHOD(registerDeviceToken : (NSString*)token)

--- a/ios/wrappers/CioRctWrapper.mm
+++ b/ios/wrappers/CioRctWrapper.mm
@@ -1,16 +1,15 @@
 #import <React/RCTBridgeModule.h>
 
+@interface RCT_EXTERN_REMAP_MODULE (NativeCustomerIO, CioRctWrapper, NSObject)
 
-@interface RCT_EXTERN_REMAP_MODULE(NativeCustomerIO, CioRctWrapper, NSObject)
-
-RCT_EXTERN_METHOD(initialize:(id)config args:(id)args)
-RCT_EXTERN_METHOD(identify:(NSString *)identify traits:(NSDictionary *)traits)
+RCT_EXTERN_METHOD(initialize : (id)config args : (id _Nullable)args)
+RCT_EXTERN_METHOD(identify : (NSString* _Nullable)userId traits : (NSDictionary* _Nullable)traits)
 RCT_EXTERN_METHOD(clearIdentify)
-RCT_EXTERN_METHOD(track:(NSString *)name properties:(NSDictionary *)properties)
-RCT_EXTERN_METHOD(screen:(NSString *)title properties:(NSDictionary *))
-RCT_EXTERN_METHOD(setProfileAttributes: (NSDictionary *)attributes)
-RCT_EXTERN_METHOD(setDeviceAttributes: (NSDictionary *)attributes)
-RCT_EXTERN_METHOD(registerDeviceToken: (NSString *)token)
+RCT_EXTERN_METHOD(track : (NSString*)name properties : (NSDictionary* _Nullable)properties)
+RCT_EXTERN_METHOD(screen : (NSString*)title properties : (NSDictionary* _Nullable)properties)
+RCT_EXTERN_METHOD(setProfileAttributes : (NSDictionary*)attributes)
+RCT_EXTERN_METHOD(setDeviceAttributes : (NSDictionary*)attributes)
+RCT_EXTERN_METHOD(registerDeviceToken : (NSString*)token)
 RCT_EXTERN_METHOD(deleteDeviceToken)
 
 + (BOOL)requiresMainQueueSetup

--- a/ios/wrappers/CioRctWrapper.swift
+++ b/ios/wrappers/CioRctWrapper.swift
@@ -39,7 +39,7 @@ class CioRctWrapper: NSObject {
         }
     }
 
-    @objc(identify:traits:)
+    @objc
     func identify(_ userId: String?, _ traits: [String: Any]?) {
         if let userId = userId {
             CustomerIO.shared.identify(userId: userId, traits: traits)
@@ -54,37 +54,37 @@ class CioRctWrapper: NSObject {
         }
     }
 
-    @objc(clearIdentify)
+    @objc
     func clearIdentify() {
         CustomerIO.shared.clearIdentify()
     }
 
-    @objc(track:properties:)
+    @objc
     func track(_ name: String, _ properties: [String: Any]?) {
         CustomerIO.shared.track(name: name, properties: properties)
     }
 
-    @objc(screen:properties:)
+    @objc
     func screen(_ title: String, _ properties: [String: Any]?) {
         CustomerIO.shared.screen(title: title, properties: properties)
     }
 
-    @objc(setProfileAttributes:)
+    @objc
     func setProfileAttributes(_ attrs: [String: Any]) {
         CustomerIO.shared.profileAttributes = attrs
     }
 
-    @objc(setDeviceAttributes:)
+    @objc
     func setDeviceAttributes(_ attrs: [String: Any]) {
         CustomerIO.shared.deviceAttributes = attrs
     }
 
-    @objc(registerDeviceToken:)
+    @objc
     func registerDeviceToken(_ token: String) {
         CustomerIO.shared.registerDeviceToken(token)
     }
 
-    @objc(deleteDeviceToken)
+    @objc
     func deleteDeviceToken() {
         CustomerIO.shared.deleteDeviceToken()
     }

--- a/ios/wrappers/CioRctWrapper.swift
+++ b/ios/wrappers/CioRctWrapper.swift
@@ -40,7 +40,7 @@ class CioRctWrapper: NSObject {
     }
 
     @objc
-    func identify(_ userId: String?, _ traits: [String: Any]?) {
+    func identify(_ userId: String?, traits: [String: Any]?) {
         if let userId = userId {
             CustomerIO.shared.identify(userId: userId, traits: traits)
         } else if traits != nil {
@@ -60,12 +60,12 @@ class CioRctWrapper: NSObject {
     }
 
     @objc
-    func track(_ name: String, _ properties: [String: Any]?) {
+    func track(_ name: String, properties: [String: Any]?) {
         CustomerIO.shared.track(name: name, properties: properties)
     }
 
     @objc
-    func screen(_ title: String, _ properties: [String: Any]?) {
+    func screen(_ title: String, properties: [String: Any]?) {
         CustomerIO.shared.screen(title: title, properties: properties)
     }
 

--- a/ios/wrappers/CioRctWrapper.swift
+++ b/ios/wrappers/CioRctWrapper.swift
@@ -1,17 +1,16 @@
-import CioInternalCommon
+import CioAnalytics
 import CioDataPipelines
+import CioInternalCommon
 import CioMessagingInApp
 import CioMessagingPush
-import UserNotifications
 import React
-import CioAnalytics
+import UserNotifications
 
 @objc(CioRctWrapper)
 class CioRctWrapper: NSObject {
-    
     @objc var moduleRegistry: RCTModuleRegistry!
     private let logger: CioInternalCommon.Logger = DIGraphShared.shared.logger
-    
+
     @objc(initialize:args:)
     func initialize(_ configJson: AnyObject, _ sdkArgs: AnyObject?) {
         do {
@@ -22,14 +21,14 @@ class CioRctWrapper: NSObject {
             let sdkParams = sdkArgs as? [String: Any?]
             let packageSource = sdkParams?["packageSource"] as? String
             let packageVersion = sdkParams?["packageVersion"] as? String
-            
+
             if let source = packageSource, let sdkVersion = packageVersion {
                 DIGraphShared.shared.override(value: CustomerIOSdkClient(source: source, sdkVersion: sdkVersion), forType: SdkClient.self)
             }
 
             let sdkConfigBuilder = try SDKConfigBuilder.create(from: sdkConfig)
             CustomerIO.initialize(withConfig: sdkConfigBuilder.build())
-            
+
             if let inAppConfig = try? MessagingInAppConfigBuilder.build(from: sdkConfig) {
                 MessagingInApp.initialize(withConfig: inAppConfig)
                 MessagingInApp.shared.setEventListener(self)
@@ -39,9 +38,9 @@ class CioRctWrapper: NSObject {
             logger.error("Initializing Customer.io SDK failed with error: \(error)")
         }
     }
-    
-    @objc
-    func identify(_ userId: String? = nil, traits: [String: Any]? = nil) {
+
+    @objc(identify:traits:)
+    func identify(_ userId: String?, _ traits: [String: Any]?) {
         if let userId = userId {
             CustomerIO.shared.identify(userId: userId, traits: traits)
         } else if traits != nil {
@@ -54,39 +53,39 @@ class CioRctWrapper: NSObject {
             logger.error("Provide id or traits to identify a user profile.")
         }
     }
-    
-    @objc
+
+    @objc(clearIdentify)
     func clearIdentify() {
         CustomerIO.shared.clearIdentify()
     }
-    
-    @objc
-    func track(_ name: String, properties: [String: Any]?) {
+
+    @objc(track:properties:)
+    func track(_ name: String, _ properties: [String: Any]?) {
         CustomerIO.shared.track(name: name, properties: properties)
     }
-    
-    @objc
-    func screen(_ title: String, properties: [String: Any]?) {
+
+    @objc(screen:properties:)
+    func screen(_ title: String, _ properties: [String: Any]?) {
         CustomerIO.shared.screen(title: title, properties: properties)
     }
-    
-    @objc
+
+    @objc(setProfileAttributes:)
     func setProfileAttributes(_ attrs: [String: Any]) {
         CustomerIO.shared.profileAttributes = attrs
     }
-    
-    @objc
+
+    @objc(setDeviceAttributes:)
     func setDeviceAttributes(_ attrs: [String: Any]) {
         CustomerIO.shared.deviceAttributes = attrs
     }
-    
-    @objc
-    func registerDeviceToken(_ token: String){
+
+    @objc(registerDeviceToken:)
+    func registerDeviceToken(_ token: String) {
         CustomerIO.shared.registerDeviceToken(token)
     }
-    
-    @objc
-    func deleteDeviceToken(){
+
+    @objc(deleteDeviceToken)
+    func deleteDeviceToken() {
         CustomerIO.shared.deleteDeviceToken()
     }
 }
@@ -109,19 +108,19 @@ extension CioRctWrapper: InAppEventListener {
             body: body
         )
     }
-    
+
     func messageShown(message: InAppMessage) {
         sendEvent(eventType: CustomerioConstants.messageShown, message: message)
     }
-    
+
     func messageDismissed(message: InAppMessage) {
         sendEvent(eventType: CustomerioConstants.messageDismissed, message: message)
     }
-    
+
     func errorWithMessage(message: InAppMessage) {
         sendEvent(eventType: CustomerioConstants.errorWithMessage, message: message)
     }
-    
+
     func messageActionTaken(message: InAppMessage, actionValue: String, actionName: String) {
         sendEvent(eventType: CustomerioConstants.messageActionTaken, message: message, actionValue: actionValue, actionName: actionName)
     }

--- a/ios/wrappers/inapp/CioRctInAppMessaging.mm
+++ b/ios/wrappers/inapp/CioRctInAppMessaging.mm
@@ -1,6 +1,6 @@
 #import <React/RCTEventEmitter.h>
 
-@interface RCT_EXTERN_REMAP_MODULE(CioRctInAppMessaging, CioRctInAppMessaging, RCTEventEmitter)
+@interface RCT_EXTERN_REMAP_MODULE (CioRctInAppMessaging, CioRctInAppMessaging, RCTEventEmitter)
 
 RCT_EXTERN_METHOD(supportedEvents)
 

--- a/ios/wrappers/inapp/CioRctInAppMessaging.swift
+++ b/ios/wrappers/inapp/CioRctInAppMessaging.swift
@@ -28,7 +28,7 @@ class CioRctInAppMessaging: RCTEventEmitter {
     /**
      * Dismisses any currently displayed in-app message
      */
-    @objc
+    @objc(dismissMessage)
     func dismissMessage() {
         MessagingInApp.shared.dismissMessage()
     }

--- a/ios/wrappers/inapp/CioRctInAppMessaging.swift
+++ b/ios/wrappers/inapp/CioRctInAppMessaging.swift
@@ -28,7 +28,7 @@ class CioRctInAppMessaging: RCTEventEmitter {
     /**
      * Dismisses any currently displayed in-app message
      */
-    @objc(dismissMessage)
+    @objc
     func dismissMessage() {
         MessagingInApp.shared.dismissMessage()
     }

--- a/ios/wrappers/inapp/CioRctInAppMessaging.swift
+++ b/ios/wrappers/inapp/CioRctInAppMessaging.swift
@@ -1,6 +1,6 @@
+import CioMessagingInApp
 import Foundation
 import React
-import CioMessagingInApp
 
 @objc(CioRctInAppMessaging)
 class CioRctInAppMessaging: RCTEventEmitter {
@@ -21,8 +21,8 @@ class CioRctInAppMessaging: RCTEventEmitter {
      * Overriding supportedEvents method to return an array of supported event names.
      * We are combining in-app events against single name so only one event is added.
      */
-    open override func supportedEvents() -> [String]! {
-        return [CustomerioConstants.inAppEventListener]
+    override open func supportedEvents() -> [String]! {
+        [CustomerioConstants.inAppEventListener]
     }
 
     /**

--- a/ios/wrappers/logging/CioLoggingEmitter.mm
+++ b/ios/wrappers/logging/CioLoggingEmitter.mm
@@ -1,4 +1,5 @@
 #import <React/RCTEventEmitter.h>
 
-@interface RCT_EXTERN_REMAP_MODULE(CioLoggingEmitter, CioLoggingEmitter, RCTEventEmitter)
+@interface RCT_EXTERN_REMAP_MODULE (CioLoggingEmitter, CioLoggingEmitter, RCTEventEmitter)
+
 @end

--- a/ios/wrappers/logging/CioLoggingEmitter.swift
+++ b/ios/wrappers/logging/CioLoggingEmitter.swift
@@ -1,51 +1,49 @@
-
-import React
 import CioInternalCommon
+import React
 
 @objc(CioLoggingEmitter)
 class CioLoggingEmitter: RCTEventEmitter {
-    
     fileprivate static var eventName = "CioLogEvent"
-    
+
     fileprivate var hasObservers = false
-    
+
     // Requires adding requiresMainQueueSetup method
     // since it overrides init
-    @objc static override func requiresMainQueueSetup() -> Bool {
-        return true // Return true if the module must be initialized on the main queue
+    @objc override static func requiresMainQueueSetup() -> Bool {
+        true // Return true if the module must be initialized on the main queue
     }
-    
+
     override init() {
         super.init()
 
         DIGraphShared.shared.logger.setLogDispatcher { [weak self] level, message in
             guard let self else { return }
-            
+
             emit(level: level, message: message)
         }
     }
-    
+
     deinit {
         // Clear log dispatcher if the emitter has been deallocated
         DIGraphShared.shared.logger.setLogDispatcher(nil)
     }
-    
+
     override func startObserving() {
         hasObservers = true
     }
-    
+
     override func stopObserving() {
         hasObservers = false
     }
-    
+
     override func supportedEvents() -> [String] {
         [Self.eventName]
     }
-    
+
     override var methodQueue: dispatch_queue_t! {
         DispatchQueue(label: Self.moduleName())
     }
-    
+
     private var emitter: CioLoggingEmitter? {
         moduleRegistry?.module(forName: "CioLoggingEmitter") as? CioLoggingEmitter
     }

--- a/ios/wrappers/push/CioRctPushMessaging.mm
+++ b/ios/wrappers/push/CioRctPushMessaging.mm
@@ -1,19 +1,22 @@
 #import <React/RCTBridgeModule.h>
 
-@interface RCT_EXTERN_REMAP_MODULE(CioRctPushMessaging, CioRctPushMessaging, NSObject)
+@interface RCT_EXTERN_REMAP_MODULE (CioRctPushMessaging, CioRctPushMessaging, NSObject)
 
-RCT_EXTERN_METHOD(trackNotificationResponseReceived : (nonnull NSDictionary *) payload])
+RCT_EXTERN_METHOD(trackNotificationResponseReceived : (NSDictionary*)payload)
 
-RCT_EXTERN_METHOD(trackNotificationReceived : (nonnull NSDictionary *) payload])
+RCT_EXTERN_METHOD(trackNotificationReceived : (NSDictionary*)payload)
 
-RCT_EXTERN_METHOD(getRegisteredDeviceToken: (RCTPromiseResolveBlock) resolver
-                  rejecter:(RCTPromiseRejectBlock)rejecter)
+RCT_EXTERN_METHOD(getRegisteredDeviceToken
+                  : (RCTPromiseResolveBlock)resolver rejecter
+                  : (RCTPromiseRejectBlock)rejecter)
 
-RCT_EXTERN_METHOD(showPromptForPushNotifications: (nonnull NSDictionary *) options
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXTERN_METHOD(showPromptForPushNotifications
+                  : (NSDictionary*)options resolver
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(getPushPermissionStatus: (RCTPromiseResolveBlock) resolver
-                  rejecter:(RCTPromiseRejectBlock)rejecter)
+RCT_EXTERN_METHOD(getPushPermissionStatus
+                  : (RCTPromiseResolveBlock)resolver rejecter
+                  : (RCTPromiseRejectBlock)reject)
 
 @end

--- a/ios/wrappers/push/CioRctPushMessaging.swift
+++ b/ios/wrappers/push/CioRctPushMessaging.swift
@@ -19,19 +19,19 @@ class CioRctPushMessaging: NSObject {
     }
 
     // Tracks `opened` push metrics when a push notification is interacted with.
-    @objc(trackNotificationResponseReceived:)
+    @objc
     func trackNotificationResponseReceived(_ payload: NSDictionary) {
         trackPushMetrics(payload: payload, event: .opened)
     }
 
     // Tracks `delivered` push metrics when a push notification is received.
-    @objc(trackNotificationReceived:)
+    @objc
     func trackNotificationReceived(_ payload: NSDictionary) {
         trackPushMetrics(payload: payload, event: .delivered)
     }
 
     // Get the currently registered device token for the app
-    @objc(getRegisteredDeviceToken:rejecter:)
+    @objc
     func getRegisteredDeviceToken(resolver resolve: @escaping (RCTPromiseResolveBlock), rejecter reject: @escaping (RCTPromiseRejectBlock)) {
         guard let token = CustomerIO.shared.registeredDeviceToken else {
             reject(CustomerioConstants.cioTag, CustomerioConstants.showDeviceTokenFailureError, nil)
@@ -47,7 +47,7 @@ class CioRctPushMessaging: NSObject {
         MessagingPush.shared.trackMetric(deliveryID: deliveryId, event: event, deviceToken: deviceToken)
     }
 
-    @objc(showPromptForPushNotifications:resolver:rejecter:)
+    @objc
     func showPromptForPushNotifications(options: [String: AnyHashable], resolver resolve: @escaping (RCTPromiseResolveBlock), rejecter reject: @escaping (RCTPromiseRejectBlock)) {
         // Show prompt if status is not determined
         getPushNotificationPermissionStatus { status in
@@ -66,7 +66,7 @@ class CioRctPushMessaging: NSObject {
         }
     }
 
-    @objc(getPushPermissionStatus:rejecter:)
+    @objc
     func getPushPermissionStatus(resolver resolve: @escaping (RCTPromiseResolveBlock), rejecter _: @escaping (RCTPromiseRejectBlock)) {
         getPushNotificationPermissionStatus { status in
             resolve(status.value)

--- a/ios/wrappers/push/CioRctPushMessaging.swift
+++ b/ios/wrappers/push/CioRctPushMessaging.swift
@@ -47,7 +47,7 @@ class CioRctPushMessaging: NSObject {
         MessagingPush.shared.trackMetric(deliveryID: deliveryId, event: event, deviceToken: deviceToken)
     }
 
-    @objc
+    @objc(showPromptForPushNotifications:resolver:rejecter:)
     func showPromptForPushNotifications(options: [String: AnyHashable], resolver resolve: @escaping (RCTPromiseResolveBlock), rejecter reject: @escaping (RCTPromiseRejectBlock)) {
         // Show prompt if status is not determined
         getPushNotificationPermissionStatus { status in

--- a/ios/wrappers/push/CioRctPushMessaging.swift
+++ b/ios/wrappers/push/CioRctPushMessaging.swift
@@ -1,6 +1,6 @@
-import Foundation
 import CioInternalCommon
 import CioMessagingPush
+import Foundation
 
 enum PushPermissionStatus: String, CaseIterable {
     case denied
@@ -8,51 +8,47 @@ enum PushPermissionStatus: String, CaseIterable {
     case granted
 
     var value: String {
-        return rawValue.uppercased()
+        rawValue.uppercased()
     }
 }
 
 @objc(CioRctPushMessaging)
 class CioRctPushMessaging: NSObject {
-
     @objc static func requiresMainQueueSetup() -> Bool {
         false /// false because our native module's initialization does not require access to UIKit
     }
 
     // Tracks `opened` push metrics when a push notification is interacted with.
-    @objc
+    @objc(trackNotificationResponseReceived:)
     func trackNotificationResponseReceived(_ payload: NSDictionary) {
         trackPushMetrics(payload: payload, event: .opened)
     }
 
     // Tracks `delivered` push metrics when a push notification is received.
-    @objc
+    @objc(trackNotificationReceived:)
     func trackNotificationReceived(_ payload: NSDictionary) {
-
         trackPushMetrics(payload: payload, event: .delivered)
     }
 
     // Get the currently registered device token for the app
     @objc(getRegisteredDeviceToken:rejecter:)
-    func getRegisteredDeviceToken(resolver resolve: @escaping(RCTPromiseResolveBlock), rejecter reject: @escaping(RCTPromiseRejectBlock)) -> Void {
-
-         guard let token = CustomerIO.shared.registeredDeviceToken else {
+    func getRegisteredDeviceToken(resolver resolve: @escaping (RCTPromiseResolveBlock), rejecter reject: @escaping (RCTPromiseRejectBlock)) {
+        guard let token = CustomerIO.shared.registeredDeviceToken else {
             reject(CustomerioConstants.cioTag, CustomerioConstants.showDeviceTokenFailureError, nil)
-             return
+            return
         }
         resolve(token)
     }
 
-    private func trackPushMetrics(payload: NSDictionary, event : Metric) {
-        guard let deliveryId = payload[CustomerioConstants.CioDeliveryId] as? String, let deviceToken = payload[CustomerioConstants.CioDeliveryToken] as? String else
-        {return}
+    private func trackPushMetrics(payload: NSDictionary, event: Metric) {
+        guard let deliveryId = payload[CustomerioConstants.CioDeliveryId] as? String, let deviceToken = payload[CustomerioConstants.CioDeliveryToken] as? String
+        else { return }
 
         MessagingPush.shared.trackMetric(deliveryID: deliveryId, event: event, deviceToken: deviceToken)
     }
 
     @objc(showPromptForPushNotifications:resolver:rejecter:)
-    func showPromptForPushNotifications(options : Dictionary<String, AnyHashable>, resolver resolve: @escaping(RCTPromiseResolveBlock),  rejecter reject: @escaping(RCTPromiseRejectBlock)) -> Void {
-
+    func showPromptForPushNotifications(options: [String: AnyHashable], resolver resolve: @escaping (RCTPromiseResolveBlock), rejecter reject: @escaping (RCTPromiseRejectBlock)) {
         // Show prompt if status is not determined
         getPushNotificationPermissionStatus { status in
             if status == .notDetermined {
@@ -71,39 +67,37 @@ class CioRctPushMessaging: NSObject {
     }
 
     @objc(getPushPermissionStatus:rejecter:)
-    func getPushPermissionStatus(resolver resolve: @escaping(RCTPromiseResolveBlock), rejecter reject: @escaping(RCTPromiseRejectBlock)) -> Void {
+    func getPushPermissionStatus(resolver resolve: @escaping (RCTPromiseResolveBlock), rejecter _: @escaping (RCTPromiseRejectBlock)) {
         getPushNotificationPermissionStatus { status in
             resolve(status.value)
         }
     }
 
-    private func requestPushAuthorization(options: [String: Any], onComplete : @escaping(Any) -> Void
-        ) {
-            let current = UNUserNotificationCenter.current()
-            var notificationOptions : UNAuthorizationOptions = [.alert]
-            if let ios = options[CustomerioConstants.platformiOS] as? [String: Any] {
-
-                if let soundOption = ios[CustomerioConstants.sound] as? Bool, soundOption {
-                    notificationOptions.insert(.sound)
-                }
-                if let badgeOption = ios[CustomerioConstants.badge] as? Bool, badgeOption {
-                    notificationOptions.insert(.badge)
-                }
+    private func requestPushAuthorization(options: [String: Any], onComplete: @escaping (Any) -> Void) {
+        let current = UNUserNotificationCenter.current()
+        var notificationOptions: UNAuthorizationOptions = [.alert]
+        if let ios = options[CustomerioConstants.platformiOS] as? [String: Any] {
+            if let soundOption = ios[CustomerioConstants.sound] as? Bool, soundOption {
+                notificationOptions.insert(.sound)
             }
-            current.requestAuthorization(options: notificationOptions) { isGranted, error in
-                if let error = error {
-                    onComplete(error)
-                    return
-                }
-                onComplete(isGranted)
+            if let badgeOption = ios[CustomerioConstants.badge] as? Bool, badgeOption {
+                notificationOptions.insert(.badge)
             }
         }
+        current.requestAuthorization(options: notificationOptions) { isGranted, error in
+            if let error = error {
+                onComplete(error)
+                return
+            }
+            onComplete(isGranted)
+        }
+    }
 
-    private func getPushNotificationPermissionStatus(completionHandler: @escaping(PushPermissionStatus) -> Void) {
+    private func getPushNotificationPermissionStatus(completionHandler: @escaping (PushPermissionStatus) -> Void) {
         var status = PushPermissionStatus.notDetermined
         let current = UNUserNotificationCenter.current()
         current.getNotificationSettings(completionHandler: { permission in
-            switch permission.authorizationStatus  {
+            switch permission.authorizationStatus {
             case .authorized, .provisional, .ephemeral:
                 status = .granted
             case .denied:

--- a/ios/wrappers/push/CioRctPushMessaging.swift
+++ b/ios/wrappers/push/CioRctPushMessaging.swift
@@ -31,7 +31,7 @@ class CioRctPushMessaging: NSObject {
     }
 
     // Get the currently registered device token for the app
-    @objc
+    @objc(getRegisteredDeviceToken:rejecter:)
     func getRegisteredDeviceToken(resolver resolve: @escaping (RCTPromiseResolveBlock), rejecter reject: @escaping (RCTPromiseRejectBlock)) {
         guard let token = CustomerIO.shared.registeredDeviceToken else {
             reject(CustomerioConstants.cioTag, CustomerioConstants.showDeviceTokenFailureError, nil)
@@ -66,7 +66,7 @@ class CioRctPushMessaging: NSObject {
         }
     }
 
-    @objc
+    @objc(getPushPermissionStatus:rejecter:)
     func getPushPermissionStatus(resolver resolve: @escaping (RCTPromiseResolveBlock), rejecter _: @escaping (RCTPromiseRejectBlock)) {
         getPushNotificationPermissionStatus { status in
             resolve(status.value)

--- a/ios/wrappers/utils/CioConfigUtils.swift
+++ b/ios/wrappers/utils/CioConfigUtils.swift
@@ -56,7 +56,7 @@ extension RawRepresentable where RawValue == String {
         thenPassItTo handler: (Transformed) -> Any,
         transformingBy transform: (Raw) -> Transformed?
     ) {
-        if let value = config?[self.rawValue] as? Raw, let result = transform(value) {
+        if let value = config?[rawValue] as? Raw, let result = transform(value) {
             _ = handler(result)
         }
     }

--- a/ios/wrappers/utils/CioConstants.swift
+++ b/ios/wrappers/utils/CioConstants.swift
@@ -1,4 +1,4 @@
-struct CustomerioConstants {
+enum CustomerioConstants {
     // InApp Messaging
     static let inAppEventListener = "InAppEventListener"
     static let eventType = "eventType"
@@ -10,7 +10,7 @@ struct CustomerioConstants {
     static let messageDismissed = "messageDismissed"
     static let errorWithMessage = "errorWithMessage"
     static let messageActionTaken = "messageActionTaken"
-    
+
     // Push Messaging
     static let CioDeliveryId = "CIO-Delivery-ID"
     static let CioDeliveryToken = "CIO-Delivery-Token"
@@ -19,7 +19,7 @@ struct CustomerioConstants {
     static let platformiOS = "ios"
     static let sound = "sound"
     static let badge = "badge"
-    
+
     // Logging
     static let cioTag = "[CIO]"
 }


### PR DESCRIPTION
fixes: [MBL-642](https://linear.app/customerio/issue/MBL-642/crash-on-react-native-0761)

### Changes

- Added consistent `objc` annotations to all Swift methods used by Objective-C classes
- Formatted Swift code using the same formatter as native iOS codebase
- Formatted Objective-C code using [online formatter](https://formatter.org/objc-formatter) for consistency

### Tested On

- [x] Current APN sample app (compiled and ran without errors)
- [x] New sample app with React Native 0.76 (compiled and ran without errors)