### PR TITLE
chore: update apn sample app name

### DIFF
--- a/Apps/APN/android/app/src/main/res/values/strings.xml
+++ b/Apps/APN/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">RN APN Sample</string>
+    <string name="app_name">React Native</string>
     <string name="filter_view_app_link">React Native Sample App Scheme Links</string>
     <string name="filter_view_universal_link">React Native Sample Universal Scheme Links</string>
 </resources>

--- a/Apps/APN/app.json
+++ b/Apps/APN/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "RN APN Sample",
+    "name": "React Native",
     "slug": "SampleApp",
     "version": "1.0.0",
     "assetBundlePatterns": [
@@ -8,5 +8,5 @@
     ]
   },
   "name": "SampleApp",
-  "displayName": "RN APN Sample"
+  "displayName": "React Native"
 }

--- a/Apps/APN/ios/Podfile.lock
+++ b/Apps/APN/ios/Podfile.lock
@@ -3,19 +3,19 @@ PODS:
     - JSONSafeEncoding (= 2.0.0)
     - Sovran (= 1.1.1)
   - boost (1.83.0)
-  - customerio-reactnative (4.1.1):
-    - customerio-reactnative/nopush (= 4.1.1)
+  - customerio-reactnative (4.2.0):
+    - customerio-reactnative/nopush (= 4.2.0)
     - CustomerIO/DataPipelines (= 3.7.1)
     - CustomerIO/MessagingInApp (= 3.7.1)
     - React-Core
-  - customerio-reactnative-richpush/apn (4.1.1):
+  - customerio-reactnative-richpush/apn (4.2.0):
     - CustomerIO/MessagingPushAPN (= 3.7.1)
-  - customerio-reactnative/apn (4.1.1):
+  - customerio-reactnative/apn (4.2.0):
     - CustomerIO/DataPipelines (= 3.7.1)
     - CustomerIO/MessagingInApp (= 3.7.1)
     - CustomerIO/MessagingPushAPN (= 3.7.1)
     - React-Core
-  - customerio-reactnative/nopush (4.1.1):
+  - customerio-reactnative/nopush (4.2.0):
     - CustomerIO/DataPipelines (= 3.7.1)
     - CustomerIO/MessagingInApp (= 3.7.1)
     - CustomerIO/MessagingPush (= 3.7.1)
@@ -1328,8 +1328,8 @@ SPEC CHECKSUMS:
   AnalyticsSwiftCIO: d03712b33e85baecc86f0d38a6d53c97f7bc5bd1
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   CustomerIO: f533d422104faa98489b84231b56a76452a82ebd
-  customerio-reactnative: 162d471ca6fac8a1b179999d89b7abafd06c0f9d
-  customerio-reactnative-richpush: ca8609621beca08bf81d7f402b38b3e2f0c251ac
+  customerio-reactnative: 6c04968b34fabc7d23689c7a354478e651648911
+  customerio-reactnative-richpush: d43c45b21fa1b5137b9c75c960fa994631fb14e4
   CustomerIOCommon: 0e8447fe53a0806e296cef18c812b7d7af9e1911
   CustomerIODataPipelines: ba5fe9a196bbed151e01943268c27c664f1aa703
   CustomerIOMessagingInApp: e6cf21470898f7468d6e1976d5dfac81e63353e3
@@ -1344,60 +1344,60 @@ SPEC CHECKSUMS:
   hermes-engine: 9cecf9953a681df7556b8cc9c74905de8f3293c0
   JSONSafeEncoding: 54722ebc4fe1482e3e60a8450e1287481e32dd8b
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
+  RCT-Folly: cd21f1661364f975ae76b3308167ad66b09f53f5
   RCTRequired: ca1d7414aba0b27efcfa2ccd37637edb1ab77d96
   RCTTypeSafety: 678e344fb976ff98343ca61dc62e151f3a042292
   React: e296bcebb489deaad87326067204eb74145934ab
   React-callinvoker: d0b7015973fa6ccb592bb0363f6bc2164238ab8c
-  React-Codegen: f034a5de6f28e15e8d95d171df17e581d5309268
-  React-Core: 44c936d0ab879e9c32e5381bd7596a677c59c974
-  React-CoreModules: 558228e12cddb9ca00ff7937894cc5104a21be6b
-  React-cxxreact: 1fcf565012c203655b3638f35aa03c13c2ed7e9e
+  React-Codegen: a89833d9b3ccafeb8cc7b2e87800aad8903b8990
+  React-Core: 3c065b603637303cd150644b633e0b8980d258f1
+  React-CoreModules: 069bdb1c6013215afe85fb9627569dc1f21b8f44
+  React-cxxreact: a1ec4ab2c051f62ab752b86acb3ab1498d46d82f
   React-debug: d444db402065cca460d9c5b072caab802a04f729
-  React-Fabric: 7d11905695e42f8bdaedddcf294959b43b290ab8
-  React-FabricImage: 6e06a512d2fb5f55669c721578736785d915d4f5
-  React-graphics: 5500206f7c9a481456365403c9fcf1638de108b7
-  React-hermes: 783023e43af9d6be4fbaeeb96b5beee00649a5f7
-  React-ImageManager: df193215ff3cf1a8dad297e554c89c632e42436c
-  React-jserrorhandler: a4d0f541c5852cf031db2f82f51de90be55b1334
-  React-jsi: ae102ccb38d2e4d0f512b7074d0c9b4e1851f402
-  React-jsiexecutor: bd12ec75873d3ef0a755c11f878f2c420430f5a9
+  React-Fabric: 30d61b17f5ec61b8f69e074d359a942c8edb48ed
+  React-FabricImage: 52209c0a7828893788d89b342657747fff852e52
+  React-graphics: 2d3bb1c23fb71e7dc0f25e1c13f9cd8a0f331166
+  React-hermes: 2b8dd8fa2082a7e219cd329ee1c5eec18b82b206
+  React-ImageManager: 37eeded59dc2bac8d76c9f78f421980c972215b6
+  React-jserrorhandler: 1ddd1e3e596bd3846ad81d2aa7ca3946c15b9ed0
+  React-jsi: 84c4e48ed0a563c9e103514ea9572bac486a61a1
+  React-jsiexecutor: 6206f71ec0fe8e0d5db321a7f7d91922d310fee9
   React-jsinspector: 85583ef014ce53d731a98c66a0e24496f7a83066
-  React-logger: 3eb80a977f0d9669468ef641a5e1fabbc50a09ec
-  React-Mapbuffer: 84ea43c6c6232049135b1550b8c60b2faac19fab
-  react-native-notifications: 4601a5a8db4ced6ae7cfc43b44d35fe437ac50c4
-  react-native-safe-area-context: 4532f1a0c5d34a46b9324ccaaedcb5582a302b7d
+  React-logger: 55764cd993880c6f887505854581c9faf68feff2
+  React-Mapbuffer: 15dfcfeb4428d8799cce75e7fe85b18b706029e0
+  react-native-notifications: 3bafa1237ae8a47569a84801f17d80242fe9f6a5
+  react-native-safe-area-context: b13be9714d9771fbde0120bc519c963484de3a71
   React-nativeconfig: b4d4e9901d4cabb57be63053fd2aa6086eb3c85f
-  React-NativeModulesApple: cd26e56d56350e123da0c1e3e4c76cb58a05e1ee
+  React-NativeModulesApple: 541d64309a3037060cc416db5c8a63ee5884048e
   React-perflogger: 5f49905de275bac07ac7ea7f575a70611fa988f2
   React-RCTActionSheet: 37edf35aeb8e4f30e76c82aab61f12d1b75c04ec
-  React-RCTAnimation: a69de7f3daa8462743094f4736c455e844ea63f7
-  React-RCTAppDelegate: 51fb96b554a6acd0cd7818acecd5aa5ca2f3ab9f
-  React-RCTBlob: d91771caebf2d015005d750cd1dc2b433ad07c99
-  React-RCTFabric: c5b9451d1f2b546119b7a0353226a8a26247d4a9
-  React-RCTImage: a0bfe87b6908c7b76bd7d74520f40660bd0ad881
-  React-RCTLinking: 5f10be1647952cceddfa1970fdb374087582fc34
-  React-RCTNetwork: a0bc3dd45a2dc7c879c80cebb6f9707b2c8bbed6
-  React-RCTSettings: 28c202b68afa59afb4067510f2c69c5a530fb9e3
-  React-RCTText: 4119d9e53ca5db9502b916e1b146e99798986d21
-  React-RCTVibration: 55bd7c48487eb9a2562f2bd3fdc833274f5b0636
-  React-rendererdebug: 5fa97ba664806cee4700e95aec42dff1b6f8ea36
+  React-RCTAnimation: b49b2e3beffa553e2120ef0767ce99b4591893c4
+  React-RCTAppDelegate: 95e826d48b372cb5c90947c72667f3ce86e77009
+  React-RCTBlob: c88cdc50aa116f53353b82d2d394d49e1de47ad3
+  React-RCTFabric: b6f90f1bfd1f601e66f4deeb9b21e217c6fb6b69
+  React-RCTImage: 665aaf80481423b2e896dcc67afa72e5993a2a4c
+  React-RCTLinking: a9321777212cf50b396983b4f3b3190fbfe53aa8
+  React-RCTNetwork: 4726e738c784679902d8425bd02c78f7e69d2ebf
+  React-RCTSettings: 4831390d89a911f10f154d5c440f6312f8aebe3d
+  React-RCTText: 7b1451059ba1d2c40f057c58211864c5e81e90a4
+  React-RCTVibration: d23654befc1d9eda8b69b0e9d4127800abcae76f
+  React-rendererdebug: ec22f2e3e545bd0ad15abc6e5710595ccfe45c94
   React-rncore: b0a8e1d14dabb7115c7a5b4ec8b9b74d1727d382
   React-runtimeexecutor: bb328dbe2865f3a550df0240df8e2d8c3aaa4c57
-  React-runtimescheduler: 9636eee762c699ca7c85751a359101797e4c8b3b
-  React-utils: d16c1d2251c088ad817996621947d0ac8167b46c
-  ReactCommon: 2aa35648354bd4c4665b9a5084a7d37097b89c10
-  RNCAsyncStorage: ec53e44dc3e75b44aa2a9f37618a49c3bc080a7a
-  RNCClipboard: 69ab8e51324d5b351f6ba72bbdb72478087a2c64
-  RNCPushNotificationIOS: 64218f3c776c03d7408284a819b2abfda1834bc8
-  RNDeviceInfo: 59344c19152c4b2b32283005f9737c5c64b42fba
-  RNGestureHandler: 61436ff36e771935850001e439bf3d060fa1e2ed
-  RNScreens: 69850d4519d95b9359cec15a67bb5f9d0bd75262
-  RNSnackbar: 37ce6daf19c8bd35cf6133db5797aa298c8782ac
+  React-runtimescheduler: a01dfb7ca980edebcc7d2d289ca900dea5d7e28b
+  React-utils: 288c9cb9a73bb150c273c84df7c2f8546f28e23f
+  ReactCommon: 2e5492a3e3a8e72d635c266405e49d12627e5bf0
+  RNCAsyncStorage: b6410dead2732b5c72a7fdb1ecb5651bbcf4674b
+  RNCClipboard: dbcf25b8f666b4685c02eeb65be981d30198e505
+  RNCPushNotificationIOS: 6c4ca3388c7434e4a662b92e4dfeeee858e6f440
+  RNDeviceInfo: 98bb51ba1519cd3f19f14e7236b5bb1c312c780f
+  RNGestureHandler: 97abadb0ce9f5331102420ac4b24fe729fb94102
+  RNScreens: 30e365555fd36db9d8ede5542127e3d25e8f904e
+  RNSnackbar: f5ad232be3bcab6d5ef7e3b02cdaae621c944b75
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Sovran: f8212bb3855042a24689a73ea0219ca5295235da
   Yoga: 805bf71192903b20fc14babe48080582fee65a80
 
 PODFILE CHECKSUM: 4fd33e739b5364991c8ac49c0c56e7b4a80e4c02
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/Apps/APN/ios/SampleApp/Base.lproj/LaunchScreen.xib
+++ b/Apps/APN/ios/SampleApp/Base.lproj/LaunchScreen.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,7 +19,7 @@
                     <color key="textColor" systemColor="darkTextColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Ami App" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="React Native (APN)" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
                     <rect key="frame" x="20" y="140" width="441" height="43"/>
                     <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
                     <color key="textColor" systemColor="darkTextColor"/>

--- a/Apps/APN/ios/SampleApp/Info.plist
+++ b/Apps/APN/ios/SampleApp/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>RN APN Sample</string>
+	<string>React Native</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/Apps/APN/package-lock.json
+++ b/Apps/APN/package-lock.json
@@ -5848,9 +5848,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.1.1",
+      "version": "4.2.0",
       "resolved": "file:../../customerio-reactnative.tgz",
-      "integrity": "sha512-cgoBFazJhnYLMer2pLg0EP3LKIK91sk2cx6bycnaUfAutOF/wlPLAX3D+4+GDNpJZKysobkduYO6/nKYH7OD3w==",
+      "integrity": "sha512-sLDctKTMpuV4LYKjvvZ7+FKLFAnG2rcdkFnbW4QkLg7nNjzAIasOud20TW7nbbGOEvWD6DkVinTzhHFfogV61A==",
       "hasInstallScript": true,
       "license": "MIT",
       "peerDependencies": {

--- a/Apps/APN/src/screens/Login.js
+++ b/Apps/APN/src/screens/Login.js
@@ -73,7 +73,7 @@ const Login = ({ navigation }) => {
       </View>
 
       <ScrollView contentContainerStyle={styles.container}>
-        <Text style={styles.title}>React Native APN Ami App</Text>
+        <Text style={styles.title}>React Native (APN)</Text>
 
         <View style={styles.spaceTop} />
 


### PR DESCRIPTION
part of: [MBL-742](https://linear.app/customerio/issue/MBL-742/has-easy-to-understand-app-name)

### Changes

- Renamed app from `RN APN Sample` to `React Native`
- Updated app name on the Splash Screen and Login Screen for consistency
- Lock file updates

Please refer to linked ticket for more details about these changes.

### Screenshots  

**Launcher**

_iOS_

![Simulator Screenshot - iPhone 16 - React Native](https://github.com/user-attachments/assets/24f54f61-450c-47da-b046-1ede86557411)

_Android_



**Login Screen**

![Simulator Screenshot - iPhone 16 - 2025-01-07 at 13 46 51](https://github.com/user-attachments/assets/1edd7104-8a94-40e4-9198-7c8f1d5a3ff5)
