### PR TITLE
chore: fix branch name for public release builds

### DIFF
--- a/.github/workflows/build-release-sample-apps.yml
+++ b/.github/workflows/build-release-sample-apps.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       sdk_version:
-        description: "SDK version to build sample apps with (optional, defaults to latest)"
+        description: "SDK version to build sample app with (optional, e.g., 4.1.0, defaults to latest)"
         required: false
         type: string
 

--- a/.github/workflows/build-release-sample-apps.yml
+++ b/.github/workflows/build-release-sample-apps.yml
@@ -9,6 +9,15 @@ on:
         type: string
 
 jobs:
+  determine-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      branch_name: ${{ steps.get_branch.outputs.branch }}
+    steps:
+      - name: Extract Branch Name
+        id: get_branch
+        run: echo "branch=$(echo $GITHUB_REF_NAME)" >> $GITHUB_OUTPUT
+
   determine-sdk-version:
     runs-on: ubuntu-latest
     outputs:
@@ -26,10 +35,11 @@ jobs:
           fi
 
   build-sample-app:
-    needs: determine-sdk-version
+    needs: [determine-branch, determine-sdk-version]
     uses: ./.github/workflows/build-sample-app.yml
     with:
       app_name: "APN"
+      branch_name: ${{ needs.determine-branch.outputs.branch_name }}
       cio-workspace-name: "Mobile: React Native"
       sdk_version: ${{ needs.determine-sdk-version.outputs.resolved_version }}
     secrets: inherit

--- a/.github/workflows/build-sample-app.yml
+++ b/.github/workflows/build-sample-app.yml
@@ -7,6 +7,10 @@ on:
         description: "Name of the sample app to build"
         required: true
         type: string
+      branch_name:
+        description: "Branch name for versioning"
+        required: false
+        type: string
       cio-workspace-name:
         description: "Name of the Customer.io workspace to use"
         required: true
@@ -97,7 +101,12 @@ jobs:
         with:
           subdirectory: Apps/${{ inputs.app_name }}
           lane: "generate_new_version"
-          options: '{"branch_name":"${{ github.ref_name }}", "pull_request_number":"${{ github.event.pull_request.number }}", "sdk_version":"${{ inputs.sdk_version }}"}'
+          options: > 
+            {
+              "branch_name": "${{ inputs.branch_name || github.ref_name }}",
+              "pull_request_number": "${{ github.event.pull_request.number }}",
+              "sdk_version": "${{ inputs.sdk_version }}"
+            }
 
       - name: Export App and SDK Version Info
         id: export-vars

--- a/Apps/fastlane/helpers/version_helper.rb
+++ b/Apps/fastlane/helpers/version_helper.rb
@@ -10,6 +10,8 @@ lane :generate_new_version do |options|
     branch_name = github.pr_source_branch
   elsif github.is_commit_pushed
     branch_name = github.push_branch
+  else
+    branch_name = options[:branch_name] || "manual-release"
   end
 
   # Replace '/' with '-' to avoid issues with unsupported characters in version name


### PR DESCRIPTION
closes: [MBL-881](https://linear.app/customerio/issue/MBL-881/[react-native]-public-release-builds)

### Changes

- Determined and passed correct branch name for public release builds
- Updated `generate_new_version` lane to include a fallback value in case the branch name cannot be determined