### PR TITLE
chore: Fix Android compilation error for RN 0.78.x

### DIFF
--- a/android/src/main/java/io/customer/reactnative/sdk/extension/MapExtensions.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/extension/MapExtensions.kt
@@ -3,7 +3,7 @@ package io.customer.reactnative.sdk.extension
 import com.facebook.react.bridge.ReadableMap
 
 internal fun ReadableMap?.toMap(): Map<String, Any> {
-    return this?.toHashMap()?.filterValues { it != null } ?: emptyMap()
+    return this?.toHashMap()?.filterValues { it != null }?.mapValues { it.value as Any } ?: emptyMap()
 }
 
 internal inline fun <reified V> Map<String, Any?>?.getTypedValue(key: String): V? {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-reactnative",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-reactnative",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
This fixes: [MBL-982](https://linear.app/customerio/issue/MBL-982/[react-native][android]-sdk-fails-to-compile-with-react-native-078)

### Context
When building Android apps using our CIO RN SDK using latest RN version `0.78.x`, you get a compilation error:
```
error Failed to install the app. Command failed with exit code 1: ./gradlew app:installDebug -PreactNativeDevServerPort=8081
e: file:/node_modules/customerio-reactnative/android/src/main/java/io/customer/reactnative/sdk/extension/MapExtensions.kt:6:12 Type mismatch: inferred type is 'kotlin.Any?', but 'kotlin.Any' was expected.
e: file:/node_modules/customerio-reactnative/android/src/main/java/io/customer/reactnative/sdk/extension/MapExtensions.kt:6:12 Return type mismatch: expected 'kotlin.collections.Map<kotlin.String, kotlin.Any>', actual 'kotlin.collections.Map<kotlin.String, kotlin.Any?>'. FAILURE: Build failed with an exception. * What went wrong:
Execution failed for task ':customerio-reactnative:compileDebugKotlin'.
```
The root cause of the issue seems to be that with newer Kotlin versions, the compiler has gotten stricter and no longer accepts the type inference we were doing in a particular [extension function](https://github.com/customerio/customerio-reactnative/blob/f1932d64b64ea44aaa6423a815b13bd91e4684cf/android/src/main/java/io/customer/reactnative/sdk/extension/MapExtensions.kt#L5-L7).

### Solution
I've modified the function to explicitly maps the return type to `Map<String, Any>` by mapping the values to a non-null `Any` type. We were already filtering nulls but didn't explicitly cast the type.

### Testing
Unfortunately, our sample apps don't yet use RN version `0.78.x`, so temporarily, we can test the change using a new project created with that version.

You can create a new project using instructions [here](https://reactnative.dev/docs/getting-started-without-a-framework) by running: `npx @react-native-community/cli@latest init AwesomeProject`

In the new project add CIO RN dependency using npm pointing to this branch or locally pointing to the generated tgz like so: 
- Using this branch: `"customerio-reactnative": "customerio/customerio-reactnative#MBL-982-fix-android-compile-error"`
- Using local tgz: `"customerio-reactnative": "file:../customerio-reactnative/customerio-reactnative.tgz" // Update path to root of customerio-reactnative` 

I will follow this PR with PRs to update the RN version used in our sample apps.