### PR TITLE
chore: Trigger sample apps public builds after npm deployment is successful

### DIFF
--- a/.github/workflows/build-release-sample-apps.yml
+++ b/.github/workflows/build-release-sample-apps.yml
@@ -7,6 +7,7 @@ on:
         description: "SDK version to build sample app with (optional, e.g., 4.1.0, defaults to latest)"
         required: false
         type: string
+  workflow_call:
 
 jobs:
   determine-branch:

--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -202,3 +202,12 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  publish-sample-apps-public-builds:
+    needs: deploy-npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sample apps public builds
+        uses: ./.github/workflows/build-release-sample-apps.yml
+
+        


### PR DESCRIPTION
Closes: [MBL-1053](https://linear.app/customerio/issue/MBL-1053/auto-create-testbed-releases-for-every-sdk-release)

This PR triggers a sample apps public release build after the SDK has been deployed successfully to NPM so that internal stakeholders always have up to date versions to test with.