### PR TITLE
fix: package author

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "android"
   ],
   "repository": "https://github.com/customerio/customerio-reactnative",
-  "author": "ami-aman <aman@customer.io> (https://customer.io/)",
+  "author": "Customer.io Mobile Dev Team (https://customer.io/)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/customerio/customerio-reactnative/issues"


### PR DESCRIPTION
This is a very old left over being corrected


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
