### PR TITLE
chore: finish modal message early if native android sdk not initialized on restore

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ customerio.reactnative.kotlinVersion=1.7.21
 customerio.reactnative.compileSdkVersion=33
 customerio.reactnative.targetSdkVersion=33
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=4.5.6
+customerio.reactnative.cioSDKVersionAndroid=4.6.1

--- a/example/android/app/src/main/java/io/customer/rn_sample/fcm/MainActivity.kt
+++ b/example/android/app/src/main/java/io/customer/rn_sample/fcm/MainActivity.kt
@@ -36,4 +36,9 @@ class MainActivity : ReactActivity() {
    */
   override fun createReactActivityDelegate(): ReactActivityDelegate =
       ReactDelegate(this, mainComponentName, fabricEnabled)
+
+  //react-native-screens override
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(null);
+  }
 }


### PR DESCRIPTION
part of: [MBL-940](https://linear.app/customerio/issue/MBL-940/android-crash-on-flutter-211-sdks)

### Changes

- Updated native Android SDK to version `4.6.1` to fix an issue where Android app could crash when restored from background while a modal in-app message was active and native Android SDK was not initialized
- See https://github.com/customerio/customerio-android/pull/561 for more details
- Updated example app's `MainActivity` as [recommended by `react-native-screens`](https://github.com/software-mansion/react-native-screens?tab=readme-ov-file#android). Without this fix, the app would crash on restore with the following error:

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{io.customer.rn_sample.fcm/io.customer.rn_sample.fcm.MainActivity}: androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment com.swmansion.rnscreens.ScreenStackFragment: calling Fragment constructor caused an exception
```