### PR TITLE
chore: utilize WrapperInlineView in android

### DIFF
--- a/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/BaseInlineInAppMessageViewManager.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/BaseInlineInAppMessageViewManager.kt
@@ -3,6 +3,7 @@ package io.customer.reactnative.sdk.messaginginapp
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
+import io.customer.messaginginapp.ui.bridge.WrapperPlatformDelegate
 
 /**
  * Base view manager for inline in-app message components.
@@ -29,8 +30,8 @@ abstract class BaseInlineInAppMessageViewManager :
         val registerCustomEvent = { eventName: String ->
             customEvents.put(eventName, mapOf("registrationName" to eventName))
         }
-        registerCustomEvent("onSizeChange")
-        registerCustomEvent("onStateChange")
+        registerCustomEvent(WrapperPlatformDelegate.ON_SIZE_CHANGE)
+        registerCustomEvent(WrapperPlatformDelegate.ON_STATE_CHANGE)
         return customEvents
     }
 

--- a/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/ReactInAppPlatformDelegate.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/ReactInAppPlatformDelegate.kt
@@ -1,9 +1,8 @@
 package io.customer.reactnative.sdk.messaginginapp
 
 import android.view.View
-import androidx.core.view.postDelayed
 import com.facebook.react.bridge.Arguments
-import io.customer.messaginginapp.ui.bridge.AndroidInAppPlatformDelegate
+import io.customer.messaginginapp.ui.bridge.WrapperPlatformDelegate
 import io.customer.reactnative.sdk.extension.sendUIEventToReactJS
 
 /**
@@ -14,59 +13,15 @@ import io.customer.reactnative.sdk.extension.sendUIEventToReactJS
  */
 class ReactInAppPlatformDelegate(
     view: View,
-) : AndroidInAppPlatformDelegate(view) {
+) : WrapperPlatformDelegate(view) {
     /**
-     * Delegates view size animation to React Native instead of native animation.
-     * Allows React Native to handle layout calculations and animations properly.
+     * Dispatches in-app message events from native Android to React Native components.
+     * Converts native events to React Native UI events using the provided event name and payload.
      */
-    override fun animateViewSize(
-        widthInDp: Double?,
-        heightInDp: Double?,
-        duration: Long?,
-        onStart: (() -> Unit)?,
-        onEnd: (() -> Unit)?
-    ) {
-        onStart?.invoke() // Start callback executes immediately
-
-        val animDuration = duration ?: defaultAnimDuration
-        val payload = Arguments.createMap()
-
-        // Only include positive width values as rendering requires valid width to calculate layout size
-        widthInDp?.takeIf { it > 0 }?.let { payload.putDouble("width", it) }
-        heightInDp?.let { payload.putDouble("height", it) }
-        payload.putDouble("duration", animDuration.toDouble())
-
-        // Notify React Native of size change
+    override fun dispatchEvent(eventName: String, payload: Map<String, Any?>) {
         view.sendUIEventToReactJS(
-            eventName = "onSizeChange",
-            payload = payload,
-        )
-
-        // Schedule end callback to match animation duration
-        onEnd?.let { view.postDelayed(animDuration) { it.invoke() } }
-    }
-
-    /**
-     * Sends loading state changes to React Native.
-     * Notifies the React component about in-app message loading progress.
-     */
-    fun sendLoadingStateEvent(state: InlineInAppMessageStateEvent) {
-        val payload = Arguments.createMap()
-        payload.putString("state", state.name)
-        view.sendUIEventToReactJS(
-            eventName = "onStateChange",
-            payload = payload
+            eventName = eventName,
+            payload = Arguments.makeNativeMap(payload),
         )
     }
-}
-
-/**
- * Loading states for inline in-app messages.
- * Used to communicate message loading progress between native and React Native.
- * See InlineInAppMessageViewCallback in native SDK for more details on how these states are used.
- */
-enum class InlineInAppMessageStateEvent {
-    LoadingStarted,
-    LoadingFinished,
-    NoMessageToDisplay
 }

--- a/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/ReactInlineInAppMessageView.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/ReactInlineInAppMessageView.kt
@@ -5,10 +5,10 @@ import android.util.AttributeSet
 import androidx.annotation.AttrRes
 import androidx.annotation.StyleRes
 import io.customer.messaginginapp.ui.InlineInAppMessageView
-import io.customer.messaginginapp.ui.core.BaseInlineInAppMessageView
+import io.customer.messaginginapp.ui.core.WrapperInlineView
 
 /**
- * React Native implementation of inline in-app message view.
+ * React Native implementation of inline in-app message view extending [WrapperInlineView].
  * Replacement for [InlineInAppMessageView] from native SDK to work seamlessly with React Native.
  * Bridges native in-app message functionality with React Native event handling and layout system.
  */
@@ -17,30 +17,12 @@ class ReactInlineInAppMessageView @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     @AttrRes defStyleAttr: Int = 0,
     @StyleRes defStyleRes: Int = 0
-) : BaseInlineInAppMessageView<ReactInAppPlatformDelegate>(
+) : WrapperInlineView<ReactInAppPlatformDelegate>(
     context, attrs, defStyleAttr, defStyleRes
 ) {
     override val platformDelegate = ReactInAppPlatformDelegate(view = this)
 
     init {
-        this.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
-        configureView()
-    }
-
-    override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
-        onViewDetached()
-    }
-
-    override fun onLoadingStarted() {
-        platformDelegate.sendLoadingStateEvent(InlineInAppMessageStateEvent.LoadingStarted)
-    }
-
-    override fun onLoadingFinished() {
-        platformDelegate.sendLoadingStateEvent(InlineInAppMessageStateEvent.LoadingFinished)
-    }
-
-    override fun onNoMessageToDisplay() {
-        platformDelegate.sendLoadingStateEvent(InlineInAppMessageStateEvent.NoMessageToDisplay)
+        initializeView()
     }
 }


### PR DESCRIPTION
part of: [MBL-1188](https://linear.app/customerio/issue/MBL-1188/support-props-and-callbacks-on-android)

### Changes

- Refactored `ReactInlineInAppMessageView` to inherit from shared `WrapperInlineView` for a smaller, simpler implementation
- Updated `ReactInAppPlatformDelegate` to extend `WrapperPlatformDelegate`, reducing duplication
- Used shared constants for event registration in `BaseInlineInAppMessageViewManager`

### Testing

- Run example app and Inline Messages screen should work as expected on Android
- No behavior changes, messages should display correctly