### PR TITLE
fix: add RCTFabricComponentsPlugins import for new arch

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -4310,9 +4310,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.3.1",
+      "version": "4.4.0",
       "resolved": "file:../customerio-reactnative.tgz",
-      "integrity": "sha512-Y6nXxYcDlm0G01uH3ctmPaFLVcnfBoRUFn42oJpVlp723qog/RjFHdweBGbnuy1tNkC40SyU/CS3/HyuMIgPlg==",
+      "integrity": "sha512-l0FZaTQizQMM/a9S/8KemRFNtOPN1l7ntvRK1rAeAYzNohZ4npmBLVHcRvRiw68PsstKlA7s46jJ5mEo03e4YQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/ios/wrappers/inapp/inline/RCTInlineMessageNative.mm
+++ b/ios/wrappers/inapp/inline/RCTInlineMessageNative.mm
@@ -4,6 +4,7 @@
 #import "ReactInlineMessageView.h"
 
 #import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
 #import <react/renderer/components/RNCustomerIOSpec/ComponentDescriptors.h>
 #import <react/renderer/components/RNCustomerIOSpec/EventEmitters.h>
 #import <react/renderer/components/RNCustomerIOSpec/Props.h>
@@ -150,5 +151,9 @@ using namespace facebook::react;
 }
 
 @end
+
+Class<RCTComponentViewProtocol> InlineMessageNativeCls(void) {
+  return RCTInlineMessageNative.class;
+}
 
 #endif

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-reactnative",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-reactnative",
-      "version": "4.3.1",
+      "version": "4.4.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
### Changes

- Added `#import <React/RCTFabricComponentsPlugins.h>` to resolve linking error in React Native 0.76 with new architecture enabled
- Implemented `Class<RCTComponentViewProtocol> InlineMessageNativeCls(void)` in `RCTInlineMessageNative.mm` to correctly register the component with the Fabric system

### Error

**Observed in RN 0.76 only**

```
❌  Undefined symbols for architecture arm64
┌─ Symbol: _InlineMessageNativeCls
└─ Referenced from: _RCTThirdPartyFabricComponentsProvider in libReact-RCTFabric.a[41](RCTThirdPartyFabricComponentsProvider.o)

❌  ld: symbol(s) not found for architecture arm64
```

#### References

- Slack thread

#### Notes

- This issue only affects React Native 0.76 with new architecture enabled.
- It does not reproduce on newer React Native versions.