### PR TITLE
chore: Remove RN SDK dependency on itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,8 +146,5 @@
         "InlineMessageNative": "RCTInlineMessageNative"
       }
     }
-  },
-  "dependencies": {
-    "customerio-reactnative": "^4.2.7"
   }
 }


### PR DESCRIPTION
Seems like we've added `customerio-reactnative` dependency on itself by mistake [here](https://github.com/customerio/customerio-reactnative/pull/433/files)

This PR removes this
