### PR TITLE
chore: simplify codegen imports

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -4382,9 +4382,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.4.1",
+      "version": "4.4.2",
       "resolved": "file:../customerio-reactnative.tgz",
-      "integrity": "sha512-+K349X4Eq42+NNWsM5equ3m2jyEE4p5FHQsM/rKJNkU63QrjZT+He2ENBNkd02V+0veGsRNlQHZIVdvB2YJg2A==",
+      "integrity": "sha512-BaSF3lxXsw04ae4XNTtdKFcFIRSBU5MWQd+8X/xuzXM0EMA3EmrRqLH901bl3rjJnMlJFSzcdQ1aARDy2SIgvA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-reactnative",
-  "version": "4.4.0",
+  "version": "4.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-reactnative",
-      "version": "4.4.0",
+      "version": "4.4.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/specs/components/InlineMessageNativeComponent.ts
+++ b/src/specs/components/InlineMessageNativeComponent.ts
@@ -1,15 +1,11 @@
-import type { HostComponent, ViewProps } from 'react-native';
-import type {
-  DirectEventHandler,
-  Double,
-} from 'react-native/Libraries/Types/CodegenTypes';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import type { CodegenTypes, HostComponent, ViewProps } from 'react-native';
+import { codegenNativeComponent } from 'react-native';
 
 /** Event data for inline message size changes. */
 export interface SizeChangeEvent {
-  width: Double;
-  height: Double;
-  duration?: Double;
+  width: CodegenTypes.Double;
+  height: CodegenTypes.Double;
+  duration?: CodegenTypes.Double;
 }
 
 /** States representing the loading and display status of inline messages. */
@@ -40,9 +36,9 @@ export interface ActionClickEvent {
 export interface NativeProps extends ViewProps {
   /** Required element ID for retrieving inline message content. */
   elementId: string;
-  onSizeChange: DirectEventHandler<SizeChangeEvent>;
-  onStateChange?: DirectEventHandler<StateChangeEvent>;
-  onActionClick?: DirectEventHandler<ActionClickEvent>;
+  onSizeChange: CodegenTypes.DirectEventHandler<SizeChangeEvent>;
+  onStateChange?: CodegenTypes.DirectEventHandler<StateChangeEvent>;
+  onActionClick?: CodegenTypes.DirectEventHandler<ActionClickEvent>;
 }
 
 // React Native Codegen automatically generates the native component bridge based on the NativeProps interface


### PR DESCRIPTION
part of: [MBL-1252](https://linear.app/customerio/issue/MBL-1252/create-turbomodule-typescript-specifications)

### Changes

- Updated codegen existing imports to simplify and align with the latest React Native documentation
- Updated lock files

#### References

- [Fabric Native Components -  Define Specification for Codegen](https://reactnative.dev/docs/fabric-native-components-introduction#1-define-specification-for-codegen)