### PR TITLE
chore: add TurboModule TypeScript support for Data Pipelines

### DIFF
--- a/src/cio-config.ts
+++ b/src/cio-config.ts
@@ -1,50 +1,10 @@
-export enum CioRegion {
-  US = 'US',
-  EU = 'EU',
-}
-
-/**
- * Enum to define how CustomerIO SDK should handle screen view events.
- * - all: Send screen events to destinations for analytics purposes and to display in-app messages
- * - inApp: Only display in-app messages and not send screen events to destinations
- */
-export enum ScreenView {
-  All = 'all',
-  InApp = 'inApp',
-}
-
-export enum CioLogLevel {
-  None = 'none',
-  Error = 'error',
-  Info = 'info',
-  Debug = 'debug',
-}
-
-export enum PushClickBehaviorAndroid {
-  ResetTaskStack = 'RESET_TASK_STACK',
-  ActivityPreventRestart = 'ACTIVITY_PREVENT_RESTART',
-  ActivityNoFlags = 'ACTIVITY_NO_FLAGS',
-}
-
-export type CioConfig = {
-  cdpApiKey: string;
-  migrationSiteId?: string;
-  region?: CioRegion;
-  logLevel?: CioLogLevel;
-  flushAt?: number;
-  flushInterval?: number;
-  screenViewUse?: ScreenView;
-  trackApplicationLifecycleEvents?: boolean;
-  autoTrackDeviceAttributes?: boolean;
-  inApp?: {
-    siteId: string;
-  };
-  push?: {
-    android?: {
-      pushClickBehavior?: PushClickBehaviorAndroid;
-    };
-  };
-};
+export {
+  CioLogLevel,
+  CioRegion,
+  PushClickBehaviorAndroid,
+  ScreenView,
+} from './specs/modules/NativeCustomerIO';
+export type { CioConfig } from './specs/modules/NativeCustomerIO';
 
 export type CioPushPermissionOptions = {
   ios?: {

--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -11,7 +11,7 @@ import {
   type NativeSDKArgs,
 } from './specs/modules/NativeCustomerIO';
 import { callNativeModule, ensureNativeModule } from './utils/native-bridge';
-import { assert } from './utils/param-validation';
+import { assert, validate } from './utils/param-validation';
 
 const packageJson = require('customerio-reactnative/package.json');
 
@@ -67,15 +67,16 @@ export const CustomerIO = {
   },
 
   identify: ({ userId, traits }: IdentifyParams) => {
-    if (!userId && !traits) {
+    if (validate.isUndefined(userId) && validate.isUndefined(traits)) {
       throw new Error('You must provide either userId or traits to identify');
     }
-    if (userId !== undefined) {
-      assert.string(userId, 'userId', { allowEmpty: false, usage: 'Identify' });
-    }
-    if (traits !== undefined) {
-      assert.record(traits, 'traits', { usage: 'Identify' });
-    }
+
+    assert.string(userId, 'userId', {
+      allowEmpty: false,
+      usage: 'Identify',
+      optional: true,
+    });
+    assert.record(traits, 'traits', { usage: 'Identify', optional: true });
 
     return withNativeModule((native) => native.identify({ userId, traits }));
   },
@@ -86,14 +87,20 @@ export const CustomerIO = {
 
   track: (name: string, properties?: CustomAttributes) => {
     assert.string(name, 'name', { usage: 'Track Event' });
-    assert.record(properties, 'properties', { usage: 'Track Event' });
+    assert.record(properties, 'properties', {
+      usage: 'Track Event',
+      optional: true,
+    });
 
     return withNativeModule((native) => native.track(name, properties));
   },
 
   screen: (title: string, properties?: CustomAttributes) => {
     assert.string(title, 'title', { usage: 'Screen' });
-    assert.record(properties, 'properties', { usage: 'Screen' });
+    assert.record(properties, 'properties', {
+      usage: 'Screen',
+      optional: true,
+    });
 
     return withNativeModule((native) => native.screen(title, properties));
   },

--- a/src/specs/modules/NativeCustomerIO.ts
+++ b/src/specs/modules/NativeCustomerIO.ts
@@ -82,10 +82,11 @@ export interface IdentifyParams {
 
 /**
  * Key-value pairs for custom user attributes and event properties.
- * We use `Object` instead of `Record<string, any>` because React Native
- * Codegen does not yet support generic types like `Record`
+ * Uses `Object` type for Codegen compatibility, public API redefines as
+ * `Record<string, any>` for better typing.
+ * Do not export to avoid type conflicts between native bridge and public API.
  */
-export type CustomAttributes = Object;
+type CustomAttributes = Object;
 
 // =============================================================================
 // TURBO MODULE SPEC – Defines native bridge interface

--- a/src/specs/modules/NativeCustomerIO.ts
+++ b/src/specs/modules/NativeCustomerIO.ts
@@ -1,0 +1,107 @@
+import { TurboModuleRegistry, type TurboModule } from 'react-native';
+
+/**
+ * Types and interfaces are defined here instead of importing from other modules
+ * because React Native Codegen does not yet support importing types from external files.
+ * By defining them here and exposing them publicly, we avoid type redundancy across the codebase.
+ *
+ * See https://github.com/facebook/react-native/issues/38769 for more details.
+ */
+
+// =============================================================================
+// PUBLIC API TYPES - Exposed in the SDK interface
+// =============================================================================
+
+/** Data center regions for CustomerIO API endpoints */
+export enum CioRegion {
+  US = 'US',
+  EU = 'EU',
+}
+
+/** Log levels for CustomerIO SDK debugging and monitoring */
+export enum CioLogLevel {
+  None = 'none',
+  Error = 'error',
+  Info = 'info',
+  Debug = 'debug',
+}
+
+/**
+ * Enum to define how CustomerIO SDK should handle screen view events.
+ * - all: Send screen events to destinations for analytics purposes and to display in-app messages
+ * - inApp: Only display in-app messages and not send screen events to destinations
+ */
+export enum ScreenView {
+  All = 'all',
+  InApp = 'inApp',
+}
+
+/** Android-specific behaviors for handling push notification clicks */
+export enum PushClickBehaviorAndroid {
+  ResetTaskStack = 'RESET_TASK_STACK',
+  ActivityPreventRestart = 'ACTIVITY_PREVENT_RESTART',
+  ActivityNoFlags = 'ACTIVITY_NO_FLAGS',
+}
+
+/** Configuration options for initializing the CustomerIO SDK */
+export type CioConfig = {
+  cdpApiKey: string;
+  migrationSiteId?: string;
+  region?: CioRegion;
+  logLevel?: CioLogLevel;
+  flushAt?: number;
+  flushInterval?: number;
+  screenViewUse?: ScreenView;
+  trackApplicationLifecycleEvents?: boolean;
+  autoTrackDeviceAttributes?: boolean;
+  inApp?: {
+    siteId: string;
+  };
+  push?: {
+    android?: {
+      pushClickBehavior?: PushClickBehaviorAndroid;
+    };
+  };
+};
+
+// =============================================================================
+// INTERNAL TYPES – Not part of public API
+// =============================================================================
+
+/** Arguments passed to native SDK for package identification */
+export type NativeSDKArgs = {
+  packageSource: string;
+  packageVersion: string;
+};
+
+/** Parameters for identifying a user with optional ID and traits */
+export interface IdentifyParams {
+  userId?: string;
+  traits?: CustomAttributes;
+}
+
+/**
+ * Key-value pairs for custom user attributes and event properties.
+ * We use `Object` instead of `Record<string, any>` because React Native
+ * Codegen does not yet support generic types like `Record`
+ */
+export type CustomAttributes = Object;
+
+// =============================================================================
+// TURBO MODULE SPEC – Defines native bridge interface
+// =============================================================================
+
+/** TurboModule specification for CustomerIO SDK native methods */
+export interface Spec extends TurboModule {
+  initialize(config: CioConfig, args: NativeSDKArgs): void;
+  identify(params?: IdentifyParams): void;
+  clearIdentify(): void;
+  track(name: string, properties?: CustomAttributes): void;
+  screen(title: string, properties?: CustomAttributes): void;
+  setProfileAttributes(attributes: CustomAttributes): void;
+  setDeviceAttributes(attributes: CustomAttributes): void;
+  registerDeviceToken(token: string): void;
+  deleteDeviceToken(): void;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('NativeCustomerIO');

--- a/src/utils/native-bridge.ts
+++ b/src/utils/native-bridge.ts
@@ -1,0 +1,30 @@
+import { Platform } from 'react-native';
+
+const LINKING_ERROR =
+  `The package 'customerio-reactnative' doesn't seem to be linked. Make sure: \n\n` +
+  Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
+  '- You rebuilt the app after installing the package\n' +
+  '- You are not using Expo managed workflow\n';
+
+/**
+ * Ensures the native module is available, otherwise throws a helpful linking error.
+ */
+export function ensureNativeModule<NativeModule>(
+  nativeModule: NativeModule | null
+): NativeModule {
+  if (!nativeModule) {
+    throw new Error(LINKING_ERROR);
+  }
+
+  return nativeModule;
+}
+
+/**
+ * Calls a method on a native module with type-safe access.
+ */
+export const callNativeModule = <Spec, Result>(
+  nativeModule: Spec,
+  fn: (native: Spec) => Result
+): Result => {
+  return fn(nativeModule);
+};

--- a/src/utils/param-validation.ts
+++ b/src/utils/param-validation.ts
@@ -1,0 +1,123 @@
+// Argument validation utilities for SDK internal use
+// Ensures input safety and throws clear errors when validation fails
+
+import type { CioConfig } from 'src/index';
+
+/**
+ * Builds a standardized error message for validation failures.
+ */
+function buildErrorMessage(
+  usage: string | undefined,
+  fieldName: string,
+  error: string
+): string {
+  const prefix = usage ? `${usage} ` : '';
+  return `${prefix}"${fieldName}" ${error}.`;
+}
+
+/**
+ * Throws an error if the condition is true.
+ * Use this to fail validation checks with cleaner syntax.
+ */
+function failIf(condition: boolean, message: () => string): void {
+  if (condition) {
+    throw new Error(`[CustomerIO] ${message()}`);
+  }
+}
+
+/**
+ * Validates that a value is defined (not undefined or null).
+ * Useful for checking required fields.
+ */
+function failIfUndefined(
+  value: unknown,
+  fieldName: string,
+  usage?: string
+): void {
+  failIf(value === undefined || value === null, () =>
+    buildErrorMessage(usage, fieldName, 'is required')
+  );
+}
+
+/**
+ * Validates that a value is a string.
+ * Throws if the value is not a string, or if it's empty (unless allowEmpty is true).
+ */
+function validateString(
+  value: unknown,
+  fieldName: string,
+  options: {
+    allowEmpty?: boolean;
+    usage?: string;
+  } = { allowEmpty: true }
+) {
+  const prefix = options.usage ? `${options.usage} ` : '';
+
+  failIfUndefined(value, fieldName, options.usage);
+  failIf(
+    typeof value !== 'string',
+    () => `${prefix}"${fieldName}" must be a string.`
+  );
+  // Since typeof value is already checked to be a string,
+  // we can safely cast it here without additional checks.
+  const typedValue = value as string;
+  failIf(
+    !options.allowEmpty && typedValue.trim() === '',
+    () => `${prefix}"${fieldName}" must be a non-empty string.`
+  );
+}
+
+/**
+ * Validates that a value is a plain object (not null or an array).
+ */
+function validateRecord(
+  value: unknown,
+  fieldName: string,
+  options: {
+    usage?: string;
+    expectedType?: string;
+  } = {}
+) {
+  const prefix = options.usage ? `${options.usage} ` : '';
+  const typeName = options.expectedType ?? 'plain';
+
+  failIfUndefined(value, fieldName, options.usage);
+  failIf(
+    typeof value !== 'object' || Array.isArray(value),
+    () => `${prefix}"${fieldName}" must be a valid ${typeName} object.`
+  );
+}
+
+/**
+ * Validates that the given value is a valid CioConfig object.
+ * Throws if required fields are missing or incorrectly typed.
+ */
+function validateConfig(value: unknown): asserts value is CioConfig {
+  const fieldName = 'config';
+  const usage = 'SDK';
+
+  validateRecord(value, fieldName, {
+    expectedType: 'CioConfig',
+    usage: usage,
+  });
+
+  const obj = value as CioConfig;
+  validateString(obj.cdpApiKey, `${fieldName}.cdpApiKey`, {
+    allowEmpty: false,
+    usage: usage,
+  });
+}
+
+// For type safety, we define a ConfigValidator type that asserts the value is a CioConfig
+// This allows us to use it in the assert object without needing to redefine the function signature
+type ConfigValidator = (value: unknown) => asserts value is CioConfig;
+
+export const assert: {
+  string: typeof validateString;
+  record: typeof validateRecord;
+  config: ConfigValidator;
+} = {
+  string: validateString,
+  record: validateRecord,
+  config: validateConfig,
+};


### PR DESCRIPTION
part of: [MBL-1252](https://linear.app/customerio/issue/MBL-1252/create-turbomodule-typescript-specifications)

### Background

This is the first PR in the effort to migrate our React Native SDK to use React Native's new TurboModule architecture for native communication. This PR focuses solely on Data Pipelines (Main SDK) module. Future updates for Push and In-App modules will follow a similar structure.

### Changes

- Added `NativeCustomerIO.ts`, a TurboModule specification with full Codegen support
- Refactored SDK public interface from a class based to an object based architecture, using strong TypeScript types for public API compliance with codegen
- Consolidated configuration types and enums into spec module to avoid redundancy
- Added improved error handling with validation and clear messaging
- Added native bridge utilities to simplify and standardize communication with native modules

### Notes

- The example app may not function as expected in this PR as it uses new architecture and assumes TurboModule support is already implemented on native platforms.
- Android and iOS `TurboModule` implementations will be included in upcoming PRs.
- There is no change in public API as part of this update, usage should remain the same for all customers.

#### References

- [Turbo Native Modules](https://reactnative.dev/docs/turbo-native-modules-introduction)