### PR TITLE
chore: add TurboModule Android support for Data Pipelines

### DIFF
--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackageImpl.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackageImpl.kt
@@ -31,8 +31,8 @@ object CustomerIOReactNativePackageImpl {
         val inAppMessagingModule = modules.getOrPut(RNCIOInAppMessaging.NAME) {
             RNCIOInAppMessaging(reactContext)
         } as RNCIOInAppMessaging
-        val mainModule = modules.getOrPut(CustomerIOReactNativeModule.NAME) {
-            CustomerIOReactNativeModule(
+        val mainModule = modules.getOrPut(NativeCustomerIOModuleImpl.NAME) {
+            NativeCustomerIOModule(
                 reactContext = reactContext,
                 pushMessagingModule = pushMessagingModule,
                 inAppMessagingModule = inAppMessagingModule,
@@ -43,7 +43,7 @@ object CustomerIOReactNativePackageImpl {
             RNCIOConsoleLoggerModule.NAME to loggerModule,
             RNCIOPushMessaging.NAME to pushMessagingModule,
             RNCIOInAppMessaging.NAME to inAppMessagingModule,
-            CustomerIOReactNativeModule.NAME to mainModule
+            NativeCustomerIOModuleImpl.NAME to mainModule
         )
     }
 

--- a/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModuleImpl.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModuleImpl.kt
@@ -1,17 +1,15 @@
 package io.customer.reactnative.sdk
 
 import android.app.Application
-import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContextBaseJavaModule
-import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
+import io.customer.datapipelines.config.ScreenView
 import io.customer.reactnative.sdk.constant.Keys
 import io.customer.reactnative.sdk.extension.getTypedValue
 import io.customer.reactnative.sdk.extension.toMap
 import io.customer.reactnative.sdk.messaginginapp.RNCIOInAppMessaging
 import io.customer.reactnative.sdk.messagingpush.RNCIOPushMessaging
-import io.customer.datapipelines.config.ScreenView
+import io.customer.reactnative.sdk.util.assertNotNull
 import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOBuilder
 import io.customer.sdk.core.di.SDKComponent
@@ -19,14 +17,17 @@ import io.customer.sdk.core.util.CioLogLevel
 import io.customer.sdk.core.util.Logger
 import io.customer.sdk.data.model.Region
 
-class CustomerIOReactNativeModule(
-    reactContext: ReactApplicationContext,
-    private val pushMessagingModule: RNCIOPushMessaging,
-    private val inAppMessagingModule: RNCIOInAppMessaging,
-) : ReactContextBaseJavaModule(reactContext) {
-    override fun getName(): String = NAME
+/**
+ * Shared implementation logic for Customer.io Native SDK communication in React Native.
+ * Contains actual business logic used by both old and new architecture [NativeCustomerIOModule] classes.
+ * Handles SDK initialization, user identification, event tracking, and device management.
+ */
+internal object NativeCustomerIOModuleImpl {
+    const val NAME = "NativeCustomerIO"
 
-    private val logger: Logger = SDKComponent.logger
+    private val logger: Logger
+        get() = SDKComponent.logger
+
     private fun customerIO(): CustomerIO? = runCatching {
         // If the SDK is not initialized, `CustomerIO.instance()` throws an exception
         CustomerIO.instance()
@@ -34,10 +35,14 @@ class CustomerIOReactNativeModule(
         logger.error("Customer.io instance not initialized")
     }.getOrNull()
 
-    @ReactMethod
-    fun initialize(configJson: ReadableMap, sdkArgs: ReadableMap) {
+    fun initialize(
+        reactContext: ReactApplicationContext,
+        sdkConfig: ReadableMap?,
+        inAppMessagingModule: RNCIOInAppMessaging,
+        pushMessagingModule: RNCIOPushMessaging,
+    ) {
         try {
-            val packageConfig = configJson.toMap()
+            val packageConfig = sdkConfig.toMap()
             val cdpApiKey = packageConfig.getTypedValue<String>(
                 Keys.Config.CDP_API_KEY
             ) ?: throw IllegalArgumentException("CDP API Key is required to initialize Customer.io")
@@ -45,10 +50,11 @@ class CustomerIOReactNativeModule(
             val logLevelRawValue = packageConfig.getTypedValue<String>(Keys.Config.LOG_LEVEL)
             val regionRawValue = packageConfig.getTypedValue<String>(Keys.Config.REGION)
             val region = regionRawValue.let { Region.getRegion(it) }
-            val screenViewRawValue = packageConfig.getTypedValue<String>(Keys.Config.SCREEN_VIEW_USE)
+            val screenViewRawValue =
+                packageConfig.getTypedValue<String>(Keys.Config.SCREEN_VIEW_USE)
 
             CustomerIOBuilder(
-                applicationContext = reactApplicationContext.applicationContext as Application,
+                applicationContext = reactContext.applicationContext as Application,
                 cdpApiKey = cdpApiKey
             ).apply {
                 logLevelRawValue?.let { logLevel(CioLogLevel.getLogLevel(it)) }
@@ -89,65 +95,53 @@ class CustomerIOReactNativeModule(
         }
     }
 
-    @ReactMethod
     fun clearIdentify() {
         customerIO()?.clearIdentify()
     }
 
-    @ReactMethod
-    fun identify(identifier: String?, attributes: ReadableMap?) {
-        if (identifier == null && attributes == null) {
-            logger.error("Please provide either an ID or traits to identify.")
+    fun identify(params: ReadableMap?) {
+        val userId = params?.getString("userId")
+        val traits = params?.getMap("traits")
+
+        if (userId == null && traits == null) {
+            logger.error("Either userId or traits must be provided for identify")
             return
         }
-        identifier?.let {
-            customerIO()?.identify(identifier, attributes.toMap())
+
+        userId?.let {
+            customerIO()?.identify(userId, traits.toMap())
         } ?: run {
-            customerIO()?.profileAttributes = attributes.toMap()
+            customerIO()?.profileAttributes = traits.toMap()
         }
     }
 
-    @ReactMethod
-    fun track(name: String, attributes: ReadableMap?) {
-        customerIO()?.track(name, attributes.toMap())
+    fun track(name: String?, properties: ReadableMap?) {
+        val eventName = assertNotNull(name) ?: return
+
+        customerIO()?.track(eventName, properties.toMap())
     }
 
-    @ReactMethod
     fun setDeviceAttributes(attributes: ReadableMap?) {
         customerIO()?.deviceAttributes = attributes.toMap()
     }
 
-    @ReactMethod
     fun setProfileAttributes(attributes: ReadableMap?) {
         customerIO()?.profileAttributes = attributes.toMap()
     }
 
-    @ReactMethod
-    fun screen(name: String, attributes: ReadableMap?) {
-        customerIO()?.screen(name, attributes.toMap())
+    fun screen(title: String?, properties: ReadableMap?) {
+        val screenTitle = assertNotNull(title) ?: return
+
+        customerIO()?.screen(screenTitle, properties.toMap())
     }
 
-    @ReactMethod
-    fun registerDeviceToken(token: String) {
-        customerIO()?.registerDeviceToken(token)
+    fun registerDeviceToken(token: String?) {
+        val deviceToken = assertNotNull(token) ?: return
+
+        customerIO()?.registerDeviceToken(deviceToken)
     }
 
-    @ReactMethod
     fun deleteDeviceToken() {
         customerIO()?.deleteDeviceToken()
-    }
-
-    @ReactMethod
-    fun getPushPermissionStatus(promise: Promise) {
-        pushMessagingModule.getPushPermissionStatus(promise)
-    }
-
-    @ReactMethod
-    fun showPromptForPushNotifications(pushConfigurationOptions: ReadableMap?, promise: Promise) {
-        pushMessagingModule.showPromptForPushNotifications(pushConfigurationOptions, promise)
-    }
-
-    companion object {
-        const val NAME = "NativeCustomerIO"
     }
 }

--- a/android/src/main/java/io/customer/reactnative/sdk/util/Preconditions.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/util/Preconditions.kt
@@ -1,0 +1,18 @@
+package io.customer.reactnative.sdk.util
+
+import io.customer.reactnative.sdk.BuildConfig
+
+/**
+ * Asserts that a value is non-null in debug builds.
+ * Returns the value (even if null) in release builds to avoid crashing.
+ */
+inline fun <T : Any> assertNotNull(
+    value: T?,
+    lazyMessage: () -> String = { "Required value was null." }
+): T? {
+    return if (BuildConfig.DEBUG) {
+        requireNotNull(value, lazyMessage)
+    } else {
+        value
+    }
+}

--- a/android/src/newarch/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
+++ b/android/src/newarch/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
@@ -7,8 +7,8 @@ import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
 import io.customer.reactnative.sdk.logging.RNCIOConsoleLoggerModule
-import io.customer.reactnative.sdk.messaginginapp.InlineInAppMessageViewManager
 import io.customer.reactnative.sdk.messaginginapp.BaseInlineInAppMessageViewManager
+import io.customer.reactnative.sdk.messaginginapp.InlineInAppMessageViewManager
 import io.customer.reactnative.sdk.messaginginapp.RNCIOInAppMessaging
 import io.customer.reactnative.sdk.messagingpush.RNCIOPushMessaging
 
@@ -48,19 +48,25 @@ class CustomerIOReactNativePackage : BaseReactPackage() {
     private fun createReactModuleInfoEntry(
         name: String,
         className: String = name,
-        isTurboModule: Boolean = false
+        canOverrideExistingModule: Boolean = false,
+        needsEagerInit: Boolean = false,
+        isCxxModule: Boolean = false,
+        isTurboModule: Boolean = false,
     ) = name to ReactModuleInfo(
-        name, // name
-        className, // className
-        false, // canOverrideExistingModule
-        false, // needsEagerInit
-        false, // isCxxModule
-        isTurboModule, // isTurboModule
+        name,
+        className,
+        canOverrideExistingModule,
+        needsEagerInit,
+        isCxxModule,
+        isTurboModule,
     )
 
     override fun getReactModuleInfoProvider() = ReactModuleInfoProvider {
         mapOf(
-            createReactModuleInfoEntry(name = CustomerIOReactNativeModule.NAME),
+            createReactModuleInfoEntry(
+                name = NativeCustomerIOModuleImpl.NAME,
+                isTurboModule = true
+            ),
             createReactModuleInfoEntry(name = RNCIOConsoleLoggerModule.NAME),
             createReactModuleInfoEntry(name = RNCIOInAppMessaging.NAME),
             createReactModuleInfoEntry(name = RNCIOPushMessaging.NAME),

--- a/android/src/newarch/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
+++ b/android/src/newarch/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
@@ -1,0 +1,58 @@
+package io.customer.reactnative.sdk
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
+import io.customer.reactnative.sdk.messaginginapp.RNCIOInAppMessaging
+import io.customer.reactnative.sdk.messagingpush.RNCIOPushMessaging
+
+/**
+ * React Native module implementation for Customer.io Native SDK using using
+ * Turbo Modules with new architecture.
+ */
+class NativeCustomerIOModule(
+    private val reactContext: ReactApplicationContext,
+    private val inAppMessagingModule: RNCIOInAppMessaging,
+    private val pushMessagingModule: RNCIOPushMessaging,
+) : NativeCustomerIOSpec(reactContext) {
+
+    override fun initialize(config: ReadableMap?, args: ReadableMap?) {
+        NativeCustomerIOModuleImpl.initialize(
+            reactContext = reactContext,
+            sdkConfig = config,
+            inAppMessagingModule = inAppMessagingModule,
+            pushMessagingModule = pushMessagingModule
+        )
+    }
+
+    override fun identify(params: ReadableMap?) {
+        NativeCustomerIOModuleImpl.identify(params)
+    }
+
+    override fun clearIdentify() {
+        NativeCustomerIOModuleImpl.clearIdentify()
+    }
+
+    override fun track(name: String?, properties: ReadableMap?) {
+        NativeCustomerIOModuleImpl.track(name, properties)
+    }
+
+    override fun screen(title: String?, properties: ReadableMap?) {
+        NativeCustomerIOModuleImpl.screen(title, properties)
+    }
+
+    override fun setProfileAttributes(attributes: ReadableMap?) {
+        NativeCustomerIOModuleImpl.setProfileAttributes(attributes)
+    }
+
+    override fun setDeviceAttributes(attributes: ReadableMap?) {
+        NativeCustomerIOModuleImpl.setDeviceAttributes(attributes)
+    }
+
+    override fun registerDeviceToken(token: String?) {
+        NativeCustomerIOModuleImpl.registerDeviceToken(token)
+    }
+
+    override fun deleteDeviceToken() {
+        NativeCustomerIOModuleImpl.deleteDeviceToken()
+    }
+}

--- a/android/src/oldarch/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
+++ b/android/src/oldarch/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
@@ -1,0 +1,83 @@
+package io.customer.reactnative.sdk
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+import io.customer.reactnative.sdk.messaginginapp.RNCIOInAppMessaging
+import io.customer.reactnative.sdk.messagingpush.RNCIOPushMessaging
+
+/**
+ * React Native module implementation for Customer.io Native SDK using using old architecture.
+ */
+class NativeCustomerIOModule(
+    reactContext: ReactApplicationContext,
+    private val pushMessagingModule: RNCIOPushMessaging,
+    private val inAppMessagingModule: RNCIOInAppMessaging,
+) : ReactContextBaseJavaModule(reactContext) {
+    override fun getName(): String = NativeCustomerIOModuleImpl.NAME
+
+    @ReactMethod
+    fun initialize(
+        configJson: ReadableMap,
+        @Suppress("UNUSED_PARAMETER") sdkArgs: ReadableMap
+    ) {
+        NativeCustomerIOModuleImpl.initialize(
+            reactContext = reactApplicationContext,
+            sdkConfig = configJson,
+            inAppMessagingModule = inAppMessagingModule,
+            pushMessagingModule = pushMessagingModule
+        )
+    }
+
+    @ReactMethod
+    fun clearIdentify() {
+        NativeCustomerIOModuleImpl.clearIdentify()
+    }
+
+    @ReactMethod
+    fun identify(params: ReadableMap?) {
+        NativeCustomerIOModuleImpl.identify(params = params)
+    }
+
+    @ReactMethod
+    fun track(name: String, attributes: ReadableMap?) {
+        NativeCustomerIOModuleImpl.track(name, attributes)
+    }
+
+    @ReactMethod
+    fun setDeviceAttributes(attributes: ReadableMap?) {
+        NativeCustomerIOModuleImpl.setDeviceAttributes(attributes)
+    }
+
+    @ReactMethod
+    fun setProfileAttributes(attributes: ReadableMap?) {
+        NativeCustomerIOModuleImpl.setProfileAttributes(attributes)
+    }
+
+    @ReactMethod
+    fun screen(name: String, attributes: ReadableMap?) {
+        NativeCustomerIOModuleImpl.screen(name, attributes)
+    }
+
+    @ReactMethod
+    fun registerDeviceToken(token: String) {
+        NativeCustomerIOModuleImpl.registerDeviceToken(token)
+    }
+
+    @ReactMethod
+    fun deleteDeviceToken() {
+        NativeCustomerIOModuleImpl.deleteDeviceToken()
+    }
+
+    @ReactMethod
+    fun getPushPermissionStatus(promise: Promise) {
+        pushMessagingModule.getPushPermissionStatus(promise)
+    }
+
+    @ReactMethod
+    fun showPromptForPushNotifications(pushConfigurationOptions: ReadableMap?, promise: Promise) {
+        pushMessagingModule.showPromptForPushNotifications(pushConfigurationOptions, promise)
+    }
+}


### PR DESCRIPTION
part of: [MBL-1253](https://linear.app/customerio/issue/MBL-1253/convert-customerio-datapipelines-to-turbomodule-android)

### Background

This PR completes `TurboModule` migration for `CustomerIO` Data Pipelines module by implementing native Android support. It builds on the previously introduced TypeScript `TurboModule` specification and enables full compatibility with the new React Native architecture for Data Pipelines.

### Changes

- Implemented Android `TurboModule` under `newarch/` to support the new architecture
- Added a backward compatibility layer under `oldarch/` to support apps still using the old architecture
- Refactored the existing module implementation to support both architectures with minimal duplication
- Added utility classes for improved parameter validation and error messaging
- Aligned the module structure with React Native's TurboModule recommendations and naming conventions

### Notes

- The `example` app should now work correctly on Android, with TurboModule support fully enabled
- iOS `TurboModule` implementation will be added in next PR to complete full cross platform migration for Data Pipelines module

#### References

- [Turbo Native Modules](https://reactnative.dev/docs/turbo-native-modules-introduction?platforms=android)