### PR TITLE
fix: Preserve numeric types when doing sanitization for JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 3.10.7",
+  "cioNativeiOSSdkVersion": "= 3.10.8",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
Update native iOS SDK to latest