### PR TITLE
chore: fix Data Pipelines TypeScript types exports

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -4382,9 +4382,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.4.2",
+      "version": "4.4.3",
       "resolved": "file:../customerio-reactnative.tgz",
-      "integrity": "sha512-xivfC3G5DIEgyWHs528QDGVW6RMxC3AxXA2n49uJESod3avZmdmOEkBEnWbB2Nnfh6AWPkUJIcOfb+7r3/CjxQ==",
+      "integrity": "sha512-V0wtflg5LSxF94teoM1RGhnHLSrzpxAIiTwHUhQ1KA4/vTkmiulaSO1JsiKo/hnh5oo99/SCeeeDYLty01I/1A==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-reactnative",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-reactnative",
-      "version": "4.4.2",
+      "version": "4.4.3",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/src/cio-config.ts
+++ b/src/cio-config.ts
@@ -1,11 +1,3 @@
-export {
-  CioLogLevel,
-  CioRegion,
-  PushClickBehaviorAndroid,
-  ScreenView,
-} from './specs/modules/NativeCustomerIO';
-export type { CioConfig } from './specs/modules/NativeCustomerIO';
-
 export type CioPushPermissionOptions = {
   ios?: {
     badge: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * This file serves as the entry point for the module customerio-reactnative.
  */
-export * from './cio-config';
 export * from './customerio-cdp';
 export * from './customerio-inapp';
 export * from './customerio-push';
+export * from './types';

--- a/src/native-logger-listener.ts
+++ b/src/native-logger-listener.ts
@@ -1,5 +1,5 @@
 import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
-import { CioLogLevel } from './cio-config';
+import { CioLogLevel } from './types';
 
 const LINKING_ERROR =
   `The package 'customerio-reactnative' doesn't seem to be linked. Make sure: ` +

--- a/src/specs/modules/NativeCustomerIO.ts
+++ b/src/specs/modules/NativeCustomerIO.ts
@@ -1,106 +1,48 @@
 import { TurboModuleRegistry, type TurboModule } from 'react-native';
 
 /**
- * Types and interfaces are defined here instead of importing from other modules
- * because React Native Codegen does not yet support importing types from external files.
- * By defining them here and exposing them publicly, we avoid type redundancy across the codebase.
+ * Native module specification for CustomerIO React Native SDK
  *
- * See https://github.com/facebook/react-native/issues/38769 for more details.
+ * This module defines the TurboModule interface for CustomerIO SDK native bridge.
+ * Types use basic primitives for React Native Codegen compatibility, while the public
+ * API layer provides more specific TypeScript types for better developer experience.
+ *
+ * The separation allows:
+ * - Native bridge compatibility with Codegen constraints
+ * - Type-safe public API with proper TypeScript definitions
+ * - Alignment between codegen spec and public contract
+ *
+ * @see https://github.com/facebook/react-native/issues/38769 for Codegen limitations
  */
-
-// =============================================================================
-// PUBLIC API TYPES - Exposed in the SDK interface
-// =============================================================================
-
-/** Data center regions for CustomerIO API endpoints */
-export enum CioRegion {
-  US = 'US',
-  EU = 'EU',
-}
-
-/** Log levels for CustomerIO SDK debugging and monitoring */
-export enum CioLogLevel {
-  None = 'none',
-  Error = 'error',
-  Info = 'info',
-  Debug = 'debug',
-}
 
 /**
- * Enum to define how CustomerIO SDK should handle screen view events.
- * - all: Send screen events to destinations for analytics purposes and to display in-app messages
- * - inApp: Only display in-app messages and not send screen events to destinations
+ * Generic object type for native bridge parameter passing.
+ *
+ * Used for all complex data structures passed to native methods to ensure
+ * React Native Codegen compatibility. The public API layer converts these
+ * to proper TypeScript types (CustomAttributes, CioConfig, etc.) for
+ * better type safety and developer experience.
+ *
+ * @internal - Not exported to avoid conflicts with public API types
  */
-export enum ScreenView {
-  All = 'all',
-  InApp = 'inApp',
-}
-
-/** Android-specific behaviors for handling push notification clicks */
-export enum PushClickBehaviorAndroid {
-  ResetTaskStack = 'RESET_TASK_STACK',
-  ActivityPreventRestart = 'ACTIVITY_PREVENT_RESTART',
-  ActivityNoFlags = 'ACTIVITY_NO_FLAGS',
-}
-
-/** Configuration options for initializing the CustomerIO SDK */
-export type CioConfig = {
-  cdpApiKey: string;
-  migrationSiteId?: string;
-  region?: CioRegion;
-  logLevel?: CioLogLevel;
-  flushAt?: number;
-  flushInterval?: number;
-  screenViewUse?: ScreenView;
-  trackApplicationLifecycleEvents?: boolean;
-  autoTrackDeviceAttributes?: boolean;
-  inApp?: {
-    siteId: string;
-  };
-  push?: {
-    android?: {
-      pushClickBehavior?: PushClickBehaviorAndroid;
-    };
-  };
-};
-
-// =============================================================================
-// INTERNAL TYPES – Not part of public API
-// =============================================================================
-
-/** Arguments passed to native SDK for package identification */
-export type NativeSDKArgs = {
-  packageSource: string;
-  packageVersion: string;
-};
-
-/** Parameters for identifying a user with optional ID and traits */
-export interface IdentifyParams {
-  userId?: string;
-  traits?: CustomAttributes;
-}
-
-/**
- * Key-value pairs for custom user attributes and event properties.
- * Uses `Object` type for Codegen compatibility, public API redefines as
- * `Record<string, any>` for better typing.
- * Do not export to avoid type conflicts between native bridge and public API.
- */
-type CustomAttributes = Object;
+type NativeBridgeObject = Object;
 
 // =============================================================================
 // TURBO MODULE SPEC – Defines native bridge interface
 // =============================================================================
 
-/** TurboModule specification for CustomerIO SDK native methods */
+/**
+ * TurboModule specification for CustomerIO SDK native bridge methods.
+ * Uses generic Object types for React Native Codegen compatibility.
+ */
 export interface Spec extends TurboModule {
-  initialize(config: CioConfig, args: NativeSDKArgs): void;
-  identify(params?: IdentifyParams): void;
+  initialize(config: NativeBridgeObject, args: NativeBridgeObject): void;
+  identify(params?: NativeBridgeObject): void;
   clearIdentify(): void;
-  track(name: string, properties?: CustomAttributes): void;
-  screen(title: string, properties?: CustomAttributes): void;
-  setProfileAttributes(attributes: CustomAttributes): void;
-  setDeviceAttributes(attributes: CustomAttributes): void;
+  track(name: string, properties?: NativeBridgeObject): void;
+  screen(title: string, properties?: NativeBridgeObject): void;
+  setProfileAttributes(attributes: NativeBridgeObject): void;
+  setDeviceAttributes(attributes: NativeBridgeObject): void;
   registerDeviceToken(token: string): void;
   deleteDeviceToken(): void;
 }

--- a/src/types/data-pipelines.ts
+++ b/src/types/data-pipelines.ts
@@ -1,0 +1,102 @@
+import type { PushClickBehaviorAndroid } from './PushClickBehaviorAndroid';
+
+/**
+ * Key-value pairs for custom user attributes and event properties.
+ *
+ * Provides a type-safe interface for passing custom data to CustomerIO.
+ * While the native bridge uses generic Object types for Codegen compatibility,
+ * this type gives developers better TypeScript intellisense and validation.
+ *
+ * @example
+ * ```typescript
+ * const attributes: CustomAttributes = {
+ *   age: 25,
+ *   email: 'user@example.com',
+ *   preferences: { theme: 'dark' }
+ * };
+ * ```
+ */
+export type CustomAttributes = Record<string, any>;
+
+/**
+ * Parameters for identifying a user in CustomerIO.
+ *
+ * @param userId - Unique identifier for the user (email, username, etc.)
+ * @param traits - Additional user attributes and properties
+ */
+export interface IdentifyParams {
+  userId?: string;
+  traits?: CustomAttributes;
+}
+
+/**
+ * Configuration options for initializing the CustomerIO SDK.
+ *
+ * @param cdpApiKey - Customer Data Platform API key from CustomerIO dashboard
+ * @param migrationSiteId - Legacy site ID for migrating from tracking API
+ * @param region - Data center region (US or EU)
+ * @param logLevel - SDK logging verbosity level
+ * @param flushAt - Number of events to batch before sending
+ * @param flushInterval - Time interval (seconds) to flush events
+ * @param screenViewUse - How to handle screen view tracking
+ * @param trackApplicationLifecycleEvents - Auto-track app lifecycle events
+ * @param autoTrackDeviceAttributes - Auto-track device information
+ * @param inApp - In-app messaging configuration
+ * @param push - Push notification configuration
+ */
+export type CioConfig = {
+  cdpApiKey: string;
+  migrationSiteId?: string;
+  region?: CioRegion;
+  logLevel?: CioLogLevel;
+  flushAt?: number;
+  flushInterval?: number;
+  screenViewUse?: ScreenView;
+  trackApplicationLifecycleEvents?: boolean;
+  autoTrackDeviceAttributes?: boolean;
+  inApp?: {
+    siteId: string;
+  };
+  push?: {
+    android?: {
+      pushClickBehavior?: PushClickBehaviorAndroid;
+    };
+  };
+};
+
+/**
+ * Log levels for CustomerIO SDK debugging and monitoring.
+ *
+ * Controls the verbosity of SDK logging output for debugging purposes.
+ */
+export enum CioLogLevel {
+  /** No logging output */
+  None = 'none',
+  /** Only error messages */
+  Error = 'error',
+  /** Error and informational messages */
+  Info = 'info',
+  /** All messages including debug information */
+  Debug = 'debug',
+}
+
+/**
+ * Data center regions for CustomerIO API endpoints.
+ */
+export enum CioRegion {
+  US = 'US',
+  EU = 'EU',
+}
+
+/**
+ * Screen view tracking behavior configuration.
+ *
+ * Defines how the SDK should handle automatic screen view events
+ * for analytics and in-app message targeting.
+ */
+export enum ScreenView {
+  /** Send screen events to destinations and display in-app messages */
+  All = 'all',
+  /** Only display in-app messages, don't send to destinations */
+  InApp = 'inApp',
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './data-pipelines';
 export * from './InAppMessage';
 export * from './PushClickBehaviorAndroid';
 export * from './PushPermissionOptions';

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -1,0 +1,20 @@
+/**
+ * Internal-only types used within the Customer.io React Native SDK implementation.
+ *
+ * Not intended for public use.
+ */
+
+/**
+ * Arguments passed to native SDK for package identification.
+ *
+ * Provides metadata about the host environment and SDK version to native
+ * CustomerIO SDK for debugging and analytics.
+ *
+ * @internal
+ */
+export type NativeSDKArgs = {
+  /** The package manager or framework hosting the SDK (ReactNative, Expo) */
+  packageSource: string;
+  /** Version of the SDK package being used */
+  packageVersion: string;
+};

--- a/src/utils/param-validation.ts
+++ b/src/utils/param-validation.ts
@@ -1,7 +1,7 @@
 // Argument validation utilities for SDK internal use
 // Ensures input safety and throws clear errors when validation fails
 
-import type { CioConfig } from 'src/index';
+import type { CioConfig } from '../types';
 
 /**
  * Builds a standardized error message for validation failures.


### PR DESCRIPTION
part of: [MBL-1254](https://linear.app/customerio/issue/MBL-1254/convert-customerio-datapipelines-to-turbomodule-ios)

### Background

Initially, types were exported from separate files but I earlier moved into Codegen spec for better alignment between internal and public APIs. However, Codegen generated types are only usable from Objective-C and not Swift friendly. This PR reverts that approach to simplify Codegen while cleanly maintaining a shared contract between native and TypeScript using dedicated export files.

### Changes

- Reorganized type exports into modular files: `data-pipelines.ts`  (public API types), `internal.ts` (native/internal types)
- Improved native bridge type naming (e.g., renamed `CustomAttributes` to `NativeBridgeObject` in the spec for clarity)
- Added brief JSDoc comments for all public types and APIs in `customerio-cdp.ts`
- Fixed and simplified import paths
- Separated internal native bridge types from public facing API types
- Grouped types by module (currently Data Pipelines; Push Messaging and In-App Messaging will follow in future PRs)

#### Notes

- No changes to the public API, all method signatures and exported types remain unchanged
- Maintains compatibility between Codegen spec and the public TypeScript contract
- Enhances TypeScript developer experience with improved type clarity
- Improves internal maintainability by isolating internal types from public API