### PR TITLE
chore: add TurboModule TypeScript support for InApp

### DIFF
--- a/src/customerio-inapp.ts
+++ b/src/customerio-inapp.ts
@@ -1,70 +1,70 @@
-import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
+import { NativeEventEmitter, type TurboModule } from 'react-native';
 import { InlineInAppMessageView } from './components';
-
-const LINKING_ERROR =
-  `The package 'customerio-reactnative' doesn't seem to be linked. Make sure: \n\n` +
-  Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
-  '- You rebuilt the app after installing the package\n' +
-  '- You are not using Expo managed workflow\n';
-
-/**
- * Get CustomerioInAppMessaging native module
- */
-const InAppMessagingNative = NativeModules.CioRctInAppMessaging
-  ? NativeModules.CioRctInAppMessaging
-  : new Proxy(
-      {},
-      {
-        get() {
-          throw new Error(LINKING_ERROR);
-        },
-      }
-    );
+import NativeCustomerIOMessagingInApp, {
+  type Spec as CodegenSpec,
+} from './specs/modules/NativeCustomerIOMessagingInApp';
+import type { InAppMessageEventType } from './types';
+import { callNativeModule, ensureNativeModule } from './utils/native-bridge';
 
 // Constant value used for emitting all events for in-app from native modules
 const InAppEventListenerEventName = 'InAppEventListener';
 
+// Ensures all methods defined in codegen spec are implemented by the public module
+interface NativeSpec
+  extends Omit<
+    CodegenSpec,
+    | keyof TurboModule
+    | 'onInAppEventReceived'
+    | 'isNewArchEnabled'
+    | 'addListener'
+    | 'removeListeners'
+  > {}
+
+// Reference to the native CustomerIO Data Pipelines module for SDK operations
+const nativeModule = ensureNativeModule(NativeCustomerIOMessagingInApp);
+
+// Wrapper function that ensures SDK is initialized before calling native methods
+const withNativeModule = <R>(fn: (native: CodegenSpec) => R): R => {
+  return callNativeModule(nativeModule, fn);
+};
+
 /**
  * Helper class so that registering event listeners is easier for customers.
  */
-class CustomerIOInAppMessaging {
-  eventEmitter: NativeEventEmitter = new NativeEventEmitter(
-    InAppMessagingNative
-  );
-
+class CustomerIOInAppMessaging implements NativeSpec {
   registerEventsListener(listener: (event: InAppMessageEvent) => void) {
-    return this.eventEmitter.addListener(
-      InAppEventListenerEventName,
-      (data: any) => {
-        // Make sure all supported events are added to InAppMessageEventType, else it will throw an error
-        let event = new InAppMessageEvent(
-          data.eventType as InAppMessageEventType,
-          data.messageId,
-          data.deliveryId,
-          data.actionValue,
-          data.actionName
-        );
-        listener(event);
+    const emitter = (data: any) => {
+      // Construct a proper InAppMessageEvent instance
+      const event = new InAppMessageEvent(
+        data.eventType as InAppMessageEventType,
+        data.messageId,
+        data.deliveryId,
+        data.actionValue,
+        data.actionName
+      );
+      listener(event);
+    };
+
+    return withNativeModule(async (native) => {
+      // Old arch requires async return via Promise; new arch supports sync
+      const isNewArch = await native.isNewArchEnabled();
+      if (isNewArch) {
+        // If the new architecture is enabled, use the TurboModule's event emitter
+        return native.onInAppEventReceived(emitter);
+      } else {
+        // If the new architecture is not enabled, use the legacy event emitter
+        const eventEmitter = new NativeEventEmitter(native);
+        return eventEmitter.addListener(InAppEventListenerEventName, emitter);
       }
-    );
+    });
   }
 
   /**
    * Dismisses any currently displayed in-app message
    */
   dismissMessage() {
-    InAppMessagingNative.dismissMessage();
+    withNativeModule((native) => native.dismissMessage());
   }
-}
-
-/**
- * Enum to represent the type of event triggered by in-app event callback.
- */
-enum InAppMessageEventType {
-  errorWithMessage = 'errorWithMessage',
-  messageActionTaken = 'messageActionTaken',
-  messageDismissed = 'messageDismissed',
-  messageShown = 'messageShown',
 }
 
 /**
@@ -94,10 +94,4 @@ class InAppMessageEvent {
 
 // Export in-app messaging types and components for simplified imports
 export type { InlineInAppMessageViewProps } from './components';
-export type { InAppMessage } from './types';
-export {
-  CustomerIOInAppMessaging,
-  InAppMessageEvent,
-  InAppMessageEventType,
-  InlineInAppMessageView,
-};
+export { CustomerIOInAppMessaging, InAppMessageEvent, InlineInAppMessageView };

--- a/src/specs/modules/NativeCustomerIOMessagingInApp.ts
+++ b/src/specs/modules/NativeCustomerIOMessagingInApp.ts
@@ -1,0 +1,32 @@
+import {
+  CodegenTypes,
+  TurboModuleRegistry,
+  type TurboModule,
+} from 'react-native';
+
+/**
+ * Native module specification for CustomerIO In-App Messaging React Native SDK
+ *
+ * @see NativeCustomerIO.ts for detailed documentation on TurboModule patterns,
+ * Codegen compatibility, and type safety approach.
+ */
+
+/** Generic object type for native bridge data exchange */
+type NativeBridgeObject = Object;
+
+/** TurboModule interface for CustomerIO In-App Messaging native operations */
+export interface Spec extends TurboModule {
+  dismissMessage(): void;
+  readonly onInAppEventReceived: CodegenTypes.EventEmitter<NativeBridgeObject>;
+  /** @internal - Added because React Native has no simpler way to check for New Architecture */
+  isNewArchEnabled(): Promise<boolean>;
+  // Old architecture support: EventEmitter requires these methods for proper functionality
+  /** @internal - Registers an event listener for old architecture EventEmitter */
+  addListener: (eventName: string) => void;
+  /** @internal - Removes event listeners for old architecture EventEmitter */
+  removeListeners: (count: CodegenTypes.Double) => void;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeCustomerIOMessagingInApp'
+);

--- a/src/types/InAppMessage.ts
+++ b/src/types/InAppMessage.ts
@@ -1,8 +1,0 @@
-/**
- * InApp message data structure for callbacks.
- */
-export interface InAppMessage {
-  messageId: string;
-  deliveryId?: string;
-  elementId?: string;
-}

--- a/src/types/in-app.ts
+++ b/src/types/in-app.ts
@@ -1,0 +1,24 @@
+/**
+ * In-app message data structure for event callbacks.
+ *
+ * Contains metadata about displayed in-app messages that can be used
+ * for tracking user interactions and message performance analytics.
+ */
+export interface InAppMessage {
+  /** Unique identifier for the message template */
+  messageId: string;
+  /** Unique identifier for this specific message delivery */
+  deliveryId?: string;
+  /** Element ID for inline message UI component that was interacted with */
+  elementId?: string;
+}
+
+/**
+ * Enum to represent the type of event triggered by in-app event callback.
+ */
+export enum InAppMessageEventType {
+  errorWithMessage = 'errorWithMessage',
+  messageActionTaken = 'messageActionTaken',
+  messageDismissed = 'messageDismissed',
+  messageShown = 'messageShown',
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,3 @@
 export * from './data-pipelines';
-export * from './InAppMessage';
+export * from './in-app';
 export * from './push';


### PR DESCRIPTION
part of: [MBL-1257](https://linear.app/customerio/issue/MBL-1257/convert-inappmessaging-to-turbomodule-android), [MBL-1258](https://linear.app/customerio/issue/MBL-1258/convert-inappmessaging-to-turbomodule-ios)

### Background

This PR adds `TurboModule` TypeScript support for In-App messaging module as part of React Native New Architecture migration. The changes consolidate in-app related types and add proper `Codegen` compatible specifications for enhanced type safety.

### Changes

- Added `NativeCustomerIOMessagingInApp.ts` TurboModule specification with proper TypeScript interfaces
- Consolidated push types into unified `in-app.ts` file, removing separate type files
- Updated `customerio-inapp.ts` to use TurboModule patterns and native bridge utilities
- Enhanced type imports across affected modules for better organization

### PRs Stack:

- #472 👈🏻 
- #473 
- #474 

### Notes

- The example app may not function as expected in this PR as it uses new architecture and assumes TurboModule support is already implemented on native platforms.
- Android and iOS `TurboModule` implementations will be included in upcoming PRs.
- There is no change in public API as part of this update, usage should remain the same for all customers.

#### References

- [Turbo Native Modules](https://reactnative.dev/docs/turbo-native-modules-introduction)