### PR TITLE
chore: update TurboModule spec types import and clean up arch checks

### DIFF
--- a/android/src/newarch/io/customer/reactnative/sdk/messaginginapp/NativeMessagingInAppModule.kt
+++ b/android/src/newarch/io/customer/reactnative/sdk/messaginginapp/NativeMessagingInAppModule.kt
@@ -31,10 +31,6 @@ class NativeMessagingInAppModule(
         NativeMessagingInAppModuleImpl.dismissMessage()
     }
 
-    override fun isNewArchEnabled(promise: Promise?) {
-        promise?.resolve(true)
-    }
-
     override fun addListener(eventName: String?) {
         onlyForLegacyArch("addListener")
     }

--- a/android/src/oldarch/io/customer/reactnative/sdk/messaginginapp/NativeMessagingInAppModule.kt
+++ b/android/src/oldarch/io/customer/reactnative/sdk/messaginginapp/NativeMessagingInAppModule.kt
@@ -41,17 +41,12 @@ class NativeMessagingInAppModule(
     }
 
     @ReactMethod
-    fun isNewArchEnabled(promise: Promise) {
-        promise.resolve(false)
-    }
-
-    @ReactMethod
     fun addListener(eventName: String?) {
         listenerCount++
     }
 
     @ReactMethod
-    fun removeListeners(count: Int) {
-        listenerCount -= count
+    fun removeListeners(count: Double) {
+        listenerCount -= count.toInt()
     }
 }

--- a/ios/wrappers/inapp/NativeMessagingInApp.mm
+++ b/ios/wrappers/inapp/NativeMessagingInApp.mm
@@ -71,10 +71,6 @@ RCT_EXPORT_MODULE()
   [_swiftBridge dismissMessage];
 }
 
-- (void)isNewArchEnabled:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
-  resolve(@(YES));
-}
-
 - (void)addListener:(nonnull NSString *)eventName {
   RCT_LEGACY_ARCH_WARNING(addListener);
 }
@@ -104,12 +100,6 @@ Class<RCTBridgeModule> NativeCustomerIOMessagingInAppCls(void) {
 
 RCT_EXTERN_METHOD(supportedEvents)
 RCT_EXTERN_METHOD(dismissMessage)
-
-RCT_REMAP_METHOD(isNewArchEnabled, isNewArchEnabledWithResolver
-                 : (RCTPromiseResolveBlock)resolve rejecter
-                 : (RCTPromiseRejectBlock)reject) {
-  resolve(@(NO));
-}
 
 // Module initialization can happen on background thread
 + (BOOL)requiresMainQueueSetup {

--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -43,11 +43,11 @@ const withNativeModule = <R>(fn: (native: CodegenSpec) => R): R => {
 
 export const CustomerIO = {
   /** Initialize the CustomerIO SDK with given configuration. */
-  initialize: (config: CioConfig) => {
+  initialize: async (config: CioConfig) => {
     assert.config(config);
 
     if (config.logLevel && config.logLevel !== CioLogLevel.None) {
-      NativeLoggerListener.initialize();
+      await NativeLoggerListener.initialize();
     }
 
     const expoVersion = packageJson.expoVersion ?? '';
@@ -74,9 +74,14 @@ export const CustomerIO = {
       usage: 'Identify',
       optional: true,
     });
-    assert.record(traits, 'traits', { usage: 'Identify', optional: true });
+    const normalizedTraits = assert.attributes(traits, 'traits', {
+      usage: 'Identify',
+      optional: true,
+    });
 
-    return withNativeModule((native) => native.identify({ userId, traits }));
+    return withNativeModule((native) =>
+      native.identify({ userId, traits: normalizedTraits })
+    );
   },
 
   /** Clear current user identification and stop tracking. */
@@ -87,39 +92,45 @@ export const CustomerIO = {
   /** Track an event with optional properties. */
   track: (name: string, properties?: CustomAttributes) => {
     assert.string(name, 'name', { usage: 'Track Event' });
-    assert.record(properties, 'properties', {
+    const normalizedProps = assert.attributes(properties, 'properties', {
       usage: 'Track Event',
       optional: true,
     });
 
-    return withNativeModule((native) => native.track(name, properties));
+    return withNativeModule((native) => native.track(name, normalizedProps));
   },
 
   /** Track a screen view event with optional properties. */
   screen: (title: string, properties?: CustomAttributes) => {
     assert.string(title, 'title', { usage: 'Screen' });
-    assert.record(properties, 'properties', {
+    const normalizedProps = assert.attributes(properties, 'properties', {
       usage: 'Screen',
       optional: true,
     });
 
-    return withNativeModule((native) => native.screen(title, properties));
+    return withNativeModule((native) => native.screen(title, normalizedProps));
   },
 
   /** Set or update attributes for the currently identified user profile. */
   setProfileAttributes: (attributes: CustomAttributes) => {
-    assert.record(attributes, 'attributes', { usage: 'Profile' });
+    const normalizedAttrs = assert.attributes(attributes, 'attributes', {
+      usage: 'Profile',
+    }) as CustomAttributes;
 
     return withNativeModule((native) =>
-      native.setProfileAttributes(attributes)
+      native.setProfileAttributes(normalizedAttrs)
     );
   },
 
   /** Set attributes for the current device. */
   setDeviceAttributes: (attributes: CustomAttributes) => {
-    assert.record(attributes, 'attributes', { usage: 'Device' });
+    const normalizedAttrs = assert.attributes(attributes, 'attributes', {
+      usage: 'Device',
+    }) as CustomAttributes;
 
-    return withNativeModule((native) => native.setDeviceAttributes(attributes));
+    return withNativeModule((native) =>
+      native.setDeviceAttributes(normalizedAttrs)
+    );
   },
 
   /** Register a device token for push notifications. */

--- a/src/specs/components/InlineMessageNativeComponent.ts
+++ b/src/specs/components/InlineMessageNativeComponent.ts
@@ -1,11 +1,21 @@
-import type { CodegenTypes, HostComponent, ViewProps } from 'react-native';
-import { codegenNativeComponent } from 'react-native';
+// React Native docs now recommend Codegen types should be imported from the react-native package
+// But it breaks on Expo and older React Native versions, so we import from react-native/Libraries/Types/CodegenTypes
+// for compatibility with all versions until we can fully migrate to the new import style without breaking older versions
+// https://reactnative.dev/docs/strict-typescript-api#codegen-types-should-now-be-imported-from-the-react-native-package
+
+import type { HostComponent, ViewProps } from 'react-native';
+/* eslint-disable @react-native/no-deep-imports */
+import type {
+  DirectEventHandler,
+  Double,
+} from 'react-native/Libraries/Types/CodegenTypes';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 /** Event data for inline message size changes. */
 export interface SizeChangeEvent {
-  width: CodegenTypes.Double;
-  height: CodegenTypes.Double;
-  duration?: CodegenTypes.Double;
+  width: Double;
+  height: Double;
+  duration?: Double;
 }
 
 /** States representing the loading and display status of inline messages. */
@@ -36,9 +46,9 @@ export interface ActionClickEvent {
 export interface NativeProps extends ViewProps {
   /** Required element ID for retrieving inline message content. */
   elementId: string;
-  onSizeChange: CodegenTypes.DirectEventHandler<SizeChangeEvent>;
-  onStateChange?: CodegenTypes.DirectEventHandler<StateChangeEvent>;
-  onActionClick?: CodegenTypes.DirectEventHandler<ActionClickEvent>;
+  onSizeChange: DirectEventHandler<SizeChangeEvent>;
+  onStateChange?: DirectEventHandler<StateChangeEvent>;
+  onActionClick?: DirectEventHandler<ActionClickEvent>;
 }
 
 // React Native Codegen automatically generates the native component bridge based on the NativeProps interface

--- a/src/specs/modules/NativeCustomerIO.ts
+++ b/src/specs/modules/NativeCustomerIO.ts
@@ -1,4 +1,6 @@
 import { TurboModuleRegistry, type TurboModule } from 'react-native';
+/* eslint-disable @react-native/no-deep-imports */
+import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
 
 /**
  * Native module specification for CustomerIO React Native SDK
@@ -25,7 +27,7 @@ import { TurboModuleRegistry, type TurboModule } from 'react-native';
  *
  * @internal - Not exported to avoid conflicts with public API types
  */
-type NativeBridgeObject = Object;
+type NativeBridgeObject = UnsafeObject;
 
 // =============================================================================
 // TURBO MODULE SPEC – Defines native bridge interface

--- a/src/specs/modules/NativeCustomerIOLogging.ts
+++ b/src/specs/modules/NativeCustomerIOLogging.ts
@@ -1,8 +1,10 @@
-import {
-  CodegenTypes,
-  TurboModuleRegistry,
-  type TurboModule,
-} from 'react-native';
+import { TurboModuleRegistry, type TurboModule } from 'react-native';
+/* eslint-disable @react-native/no-deep-imports */
+import type {
+  Double,
+  EventEmitter,
+  UnsafeObject,
+} from 'react-native/Libraries/Types/CodegenTypes';
 
 /**
  * Native module specification for CustomerIO Logging React Native SDK
@@ -14,19 +16,16 @@ import {
  * Codegen compatibility, and type safety approach.
  */
 
-/** Generic object type for native bridge data exchange */
-type NativeBridgeObject = Object;
-
 /** TurboModule interface for CustomerIO logging native operations */
 export interface Spec extends TurboModule {
-  readonly onCioLogEvent: CodegenTypes.EventEmitter<NativeBridgeObject>;
+  readonly onCioLogEvent: EventEmitter<UnsafeObject>;
   /** @internal - Added because React Native has no simpler way to check for New Architecture */
   isNewArchEnabled(): Promise<boolean>;
   // Old architecture support: EventEmitter requires these methods for proper functionality
   /** @internal - Registers an event listener for old architecture EventEmitter */
   addListener: (eventName: string) => void;
   /** @internal - Removes event listeners for old architecture EventEmitter */
-  removeListeners: (count: CodegenTypes.Double) => void;
+  removeListeners: (count: Double) => void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(

--- a/src/specs/modules/NativeCustomerIOMessagingInApp.ts
+++ b/src/specs/modules/NativeCustomerIOMessagingInApp.ts
@@ -1,8 +1,10 @@
-import {
-  CodegenTypes,
-  TurboModuleRegistry,
-  type TurboModule,
-} from 'react-native';
+import { TurboModuleRegistry, type TurboModule } from 'react-native';
+/* eslint-disable @react-native/no-deep-imports */
+import type {
+  Double,
+  EventEmitter,
+  UnsafeObject,
+} from 'react-native/Libraries/Types/CodegenTypes';
 
 /**
  * Native module specification for CustomerIO In-App Messaging React Native SDK
@@ -11,20 +13,15 @@ import {
  * Codegen compatibility, and type safety approach.
  */
 
-/** Generic object type for native bridge data exchange */
-type NativeBridgeObject = Object;
-
 /** TurboModule interface for CustomerIO In-App Messaging native operations */
 export interface Spec extends TurboModule {
   dismissMessage(): void;
-  readonly onInAppEventReceived: CodegenTypes.EventEmitter<NativeBridgeObject>;
-  /** @internal - Added because React Native has no simpler way to check for New Architecture */
-  isNewArchEnabled(): Promise<boolean>;
+  readonly onInAppEventReceived: EventEmitter<UnsafeObject>;
   // Old architecture support: EventEmitter requires these methods for proper functionality
   /** @internal - Registers an event listener for old architecture EventEmitter */
   addListener: (eventName: string) => void;
   /** @internal - Removes event listeners for old architecture EventEmitter */
-  removeListeners: (count: CodegenTypes.Double) => void;
+  removeListeners: (count: Double) => void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(

--- a/src/specs/modules/NativeCustomerIOMessagingPush.ts
+++ b/src/specs/modules/NativeCustomerIOMessagingPush.ts
@@ -1,4 +1,6 @@
 import { TurboModuleRegistry, type TurboModule } from 'react-native';
+/* eslint-disable @react-native/no-deep-imports */
+import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
 
 /**
  * Native module specification for CustomerIO Push Messaging React Native SDK
@@ -7,7 +9,7 @@ import { TurboModuleRegistry, type TurboModule } from 'react-native';
  * Codegen compatibility, and type safety approach.
  */
 
-type NativeBridgeObject = Object;
+type NativeBridgeObject = UnsafeObject;
 
 export interface Spec extends TurboModule {
   onMessageReceived(


### PR DESCRIPTION
part of: [MBL-1261](https://linear.app/customerio/issue/MBL-1261/remove-legacy-bridge-code-and-update-dependencies)

### Changes

- Unified `isNewArchEnabled` check by moving it to logger module which is a lightweight module that can be initialized early and independently
- Removed redundant `isNewArchEnabled` method from in-app module
- Fixed `CustomerIO.inAppMessaging.registerEventsListener` to avoid breaking changes
- Handled `Map` objects in `CustomAttributes` to ensure compatibility with JS Map (was broken in `main` too)
- Updated example app to register in-app message listeners
- Reverted `codegen` type imports to support compatibility with older versions of React Native and Expo

#### References

- [Slack discussion](https://customerio.slack.com/archives/C06H7MMLH6C/p1753424909705239?thread_ts=1753420118.217359&cid=C06H7MMLH6C)
- [Codegen types should now be imported from the react-native package](https://reactnative.dev/docs/strict-typescript-api#codegen-types-should-now-be-imported-from-the-react-native-package)