### PR TITLE
chore: fix ios example app on real device

### DIFF
--- a/example/ios/SampleApp.xcodeproj.tracked/project.pbxproj
+++ b/example/ios/SampleApp.xcodeproj.tracked/project.pbxproj
@@ -157,6 +157,7 @@
 			buildPhases = (
 				6027E6262DB8477F002F3F8A /* Sources */,
 				6027E6272DB8477F002F3F8A /* Frameworks */,
+				6027E6832DB85200002F3F8A /* Bundle React Native code and images */,
 				6027E6282DB8477F002F3F8A /* Resources */,
 				6027E6732DB84F97002F3F8A /* Embed Foundation Extensions */,
 			);
@@ -245,6 +246,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		6027E6832DB85200002F3F8A /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		6027E6262DB8477F002F3F8A /* Sources */ = {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -4409,9 +4409,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.5.2",
+      "version": "4.6.0",
       "resolved": "file:../customerio-reactnative.tgz",
-      "integrity": "sha512-4lsEPXkFAS5J6TJb9OWVhwymoPMZ8NSK++3lyDReYaCIbfvHRYQ5Kdpl+uXIP3cdjY/Tqoo5Zlu3TzZB9zwboA==",
+      "integrity": "sha512-bZtsa2nJN1NwHb7WDYAcWMzwrjiayvfXrFcj7xmLnh5Ds0HvEAVMK6+RGa6cXi/yRSMVLTIEKq6s5bN/+kPNPQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-reactnative",
-  "version": "4.5.2",
+  "version": "4.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-reactnative",
-      "version": "4.5.2",
+      "version": "4.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
closes: [MBL-1241](https://linear.app/customerio/issue/MBL-1241/fix-react-native-example-app-crash-on-ios-devices)

### Summary

Fixed iOS example app crashing on device with "No script URL provided" error when running builds on real devices.

### Changes:

- Added React Native bundle script to iOS project build phases
- Updated tracked Xcode project with "Bundle React Native code and images" build phase
- Uses standard React Native bundling scripts for automatic debug/release handling

### Testing:

- Release builds now work correctly on physical devices
- Debug builds continue to use Metro as expected