### PR TITLE
feat: improve initialization state handling and expo auto init support

### DIFF
--- a/android/cio-core.gradle
+++ b/android/cio-core.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation "io.customer.android:datapipelines:$cioAndroidSDKVersion"
-    implementation "io.customer.android:messaging-push-fcm:$cioAndroidSDKVersion"
-    implementation "io.customer.android:messaging-in-app:$cioAndroidSDKVersion"
+    api "io.customer.android:datapipelines:$cioAndroidSDKVersion"
+    api "io.customer.android:messaging-push-fcm:$cioAndroidSDKVersion"
+    api "io.customer.android:messaging-in-app:$cioAndroidSDKVersion"
 }

--- a/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModuleImpl.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModuleImpl.kt
@@ -29,18 +29,36 @@ internal object NativeCustomerIOModuleImpl {
     private val logger: Logger
         get() = SDKComponent.logger
 
-    private fun customerIO(): CustomerIO? = runCatching {
+    // Returns CustomerIO instance if initialized, null otherwise, with configurable failure handling.
+    private inline fun getSDKInstanceOrNull(
+        onFailure: (exception: Throwable) -> Unit = {}
+    ): CustomerIO? = runCatching {
         // If the SDK is not initialized, `CustomerIO.instance()` throws an exception
         CustomerIO.instance()
-    }.onFailure {
-        logger.error("Customer.io instance not initialized")
-    }.getOrNull()
+    }.onFailure(onFailure).getOrNull()
+
+    // Returns CustomerIO instance if initialized, null otherwise, logging error on failure.
+    private fun requireSDKInstance(): CustomerIO? = getSDKInstanceOrNull {
+        logger.error("CustomerIO SDK is not initialized. Please call initialize() first.")
+    }
+
+    fun isInitialized(promise: Promise?) {
+        val isInitialized = getSDKInstanceOrNull() != null
+        promise?.resolve(isInitialized)
+    }
 
     fun initialize(
         reactContext: ReactApplicationContext,
         sdkConfig: ReadableMap?,
         promise: Promise?
     ) {
+        // Skip initialization if already initialized
+        if (getSDKInstanceOrNull() != null) {
+            logger.info("CustomerIO SDK is already initialized. Skipping initialization.")
+            promise?.resolve(true)
+            return
+        }
+
         try {
             val packageConfig = sdkConfig.toMap()
             val cdpApiKey = packageConfig.getTypedValue<String>(
@@ -98,7 +116,7 @@ internal object NativeCustomerIOModuleImpl {
     }
 
     fun clearIdentify() {
-        customerIO()?.clearIdentify()
+        requireSDKInstance()?.clearIdentify()
     }
 
     fun identify(params: ReadableMap?) {
@@ -111,39 +129,39 @@ internal object NativeCustomerIOModuleImpl {
         }
 
         userId?.let {
-            customerIO()?.identify(userId, traits.toMap())
+            requireSDKInstance()?.identify(userId, traits.toMap())
         } ?: run {
-            customerIO()?.profileAttributes = traits.toMap()
+            requireSDKInstance()?.profileAttributes = traits.toMap()
         }
     }
 
     fun track(name: String?, properties: ReadableMap?) {
         val eventName = assertNotNull(name) ?: return
 
-        customerIO()?.track(eventName, properties.toMap())
+        requireSDKInstance()?.track(eventName, properties.toMap())
     }
 
     fun setDeviceAttributes(attributes: ReadableMap?) {
-        customerIO()?.deviceAttributes = attributes.toMap()
+        requireSDKInstance()?.deviceAttributes = attributes.toMap()
     }
 
     fun setProfileAttributes(attributes: ReadableMap?) {
-        customerIO()?.profileAttributes = attributes.toMap()
+        requireSDKInstance()?.profileAttributes = attributes.toMap()
     }
 
     fun screen(title: String?, properties: ReadableMap?) {
         val screenTitle = assertNotNull(title) ?: return
 
-        customerIO()?.screen(screenTitle, properties.toMap())
+        requireSDKInstance()?.screen(screenTitle, properties.toMap())
     }
 
     fun registerDeviceToken(token: String?) {
         val deviceToken = assertNotNull(token) ?: return
 
-        customerIO()?.registerDeviceToken(deviceToken)
+        requireSDKInstance()?.registerDeviceToken(deviceToken)
     }
 
     fun deleteDeviceToken() {
-        customerIO()?.deleteDeviceToken()
+        requireSDKInstance()?.deleteDeviceToken()
     }
 }

--- a/android/src/newarch/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
+++ b/android/src/newarch/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
@@ -20,6 +20,10 @@ class NativeCustomerIOModule(
         )
     }
 
+    override fun isInitialized(promise: Promise?) {
+        NativeCustomerIOModuleImpl.isInitialized(promise)
+    }
+
     override fun identify(params: ReadableMap?) {
         NativeCustomerIOModuleImpl.identify(params)
     }

--- a/android/src/oldarch/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
+++ b/android/src/oldarch/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
@@ -15,6 +15,11 @@ class NativeCustomerIOModule(
     override fun getName(): String = NativeCustomerIOModuleImpl.NAME
 
     @ReactMethod
+    fun isInitialized(promise: Promise?) {
+        NativeCustomerIOModuleImpl.isInitialized(promise)
+    }
+
+    @ReactMethod
     fun initialize(
         configJson: ReadableMap,
         @Suppress("UNUSED_PARAMETER") sdkArgs: ReadableMap?,

--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -78,7 +78,9 @@ export class CustomerIO {
     // (undocumented)
     static readonly inAppMessaging: CustomerIOInAppMessaging;
     static readonly initialize: (config: CioConfig) => Promise<void>;
+    // @deprecated
     static readonly isInitialized: () => boolean;
+    static readonly isInitializedAsync: () => Promise<boolean>;
     // (undocumented)
     static readonly pushMessaging: CustomerIOPushMessaging;
     static readonly registerDeviceToken: (token: string) => Promise<void>;

--- a/ios/wrappers/NativeCustomerIO.mm
+++ b/ios/wrappers/NativeCustomerIO.mm
@@ -42,6 +42,12 @@ RCT_EXPORT_MODULE()
   return NO;
 }
 
+- (void)isInitialized:(nonnull RCTPromiseResolveBlock)resolve
+               reject:(nonnull RCTPromiseRejectBlock)reject {
+  [self assertBridgeAvailable:@"during isInitialized"];
+  [_swiftBridge isInitialized:resolve reject:reject];
+}
+
 - (void)initialize:(NSDictionary *)config
               args:(NSDictionary *)args
            resolve:(RCTPromiseResolveBlock)resolve
@@ -102,6 +108,9 @@ Class<RCTBridgeModule> NativeCustomerIOCls(void) { return RCTNativeCustomerIO.cl
 
 @interface RCT_EXTERN_REMAP_MODULE (NativeCustomerIO, NativeCustomerIO, NSObject)
 
+RCT_EXTERN_METHOD(isInitialized
+                  : (RCTPromiseResolveBlock)resolve reject
+                  : (RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(initialize
                   : (NSDictionary *)config args
                   : (NSDictionary *)args resolve

--- a/ios/wrappers/inapp/ReactInAppEventListener.swift
+++ b/ios/wrappers/inapp/ReactInAppEventListener.swift
@@ -4,9 +4,9 @@ import CioMessagingInApp
  * React Native bridge for Customer.io in-app messaging events.
  * Converts native SDK events to JavaScript compatible format.
  */
-class ReactInAppEventListener: InAppEventListener {
+public class ReactInAppEventListener: InAppEventListener {
     // Shared instance for global access
-    static let shared = ReactInAppEventListener()
+    public static let shared = ReactInAppEventListener()
     // Event emitter function to send events to React Native layer
     private var eventEmitter: (([String: Any?]) -> Void)?
 

--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -25,11 +25,6 @@ const nativeModule = ensureNativeModule(NativeModule);
 
 // Wrapper function that ensures SDK is initialized before calling native methods
 const withNativeModule = <R>(fn: (native: CodegenSpec) => R): R => {
-  if (!_initialized) {
-    throw new Error(
-      'CustomerIO SDK must be initialized before calling any methods. Please call CustomerIO.initialize() first.'
-    );
-  }
   return callNativeModule(nativeModule, fn);
 };
 
@@ -155,8 +150,31 @@ export class CustomerIO {
     return withNativeModule((native) => native.deleteDeviceToken());
   };
 
-  /** Check if the CustomerIO SDK has been initialized. */
+  /**
+   * Check if the CustomerIO SDK has been initialized.
+   * @deprecated Use isInitializedAsync() for more reliable initialization checking.
+   */
   static readonly isInitialized = () => _initialized;
+
+  /**
+   * Asynchronously check if CustomerIO SDK has been properly initialized.
+   * This method queries native SDK directly for the most accurate status.
+   * Use this instead of isInitialized() for reliable initialization checking.
+   *
+   * @returns Promise that resolves to true if SDK is initialized, false otherwise
+   */
+  static readonly isInitializedAsync = async (): Promise<boolean> => {
+    try {
+      // Use native module to verify actual initialization state
+      const result = await withNativeModule((native) => native.isInitialized());
+      // Update cached state to match native state
+      _initialized = result;
+      return result;
+    } catch {
+      // If native module call fails, fallback to cached initialization state
+      return _initialized;
+    }
+  };
 
   static readonly inAppMessaging = new CustomerIOInAppMessaging();
   static readonly pushMessaging = new CustomerIOPushMessaging();

--- a/src/native-logger-listener.ts
+++ b/src/native-logger-listener.ts
@@ -60,16 +60,39 @@ export class NativeLoggerListener {
         native.onCioLogEvent(logHandler);
       } catch {
         // Fallback to old arch NativeEventEmitter when new arch method fails
-        const bridge = new NativeEventEmitter(native);
-        bridge.addListener('CioLogEvent', logHandler);
+        try {
+          // Use try-catch to prevent crashes for cases where native module may
+          // not be available instantly
+          const bridge = new NativeEventEmitter(native);
+          bridge.addListener('CioLogEvent', logHandler);
+        } catch (error) {
+          NativeLoggerListener.warn(
+            'Failed to attach old arch log listener:',
+            error
+          );
+        }
       }
     });
     this.isInitialized = true;
   }
 
-  static warn(message: string) {
+  // Logs warning messages in development mode only, with CIO prefix
+  static warn(message: string, error?: unknown) {
     if (__DEV__) {
-      console.warn(this.loggerPrefix + message);
+      console.warn(this.loggerPrefix + message, error);
     }
   }
 }
+
+// Initializes native logger listener with error handling
+function initNativeLogger() {
+  try {
+    NativeLoggerListener.initialize();
+  } catch (error) {
+    NativeLoggerListener.warn('Failed to initialize native logger:', error);
+  }
+}
+
+// Initialize logger immediately when module loads to capture early SDK logs
+// and support auto SDK initialization in Expo applications
+initNativeLogger();

--- a/src/specs/modules/NativeCustomerIO.ts
+++ b/src/specs/modules/NativeCustomerIO.ts
@@ -38,6 +38,7 @@ type NativeBridgeObject = UnsafeObject;
  * Uses generic Object types for React Native Codegen compatibility.
  */
 export interface Spec extends TurboModule {
+  isInitialized(): Promise<boolean>;
   initialize(
     config: NativeBridgeObject,
     args: NativeBridgeObject


### PR DESCRIPTION
part of: [MBL-1317](https://linear.app/customerio/issue/MBL-1317/add-code-for-native-sdk-initialization-ios), [MBL-1318](https://linear.app/customerio/issue/MBL-1318/add-code-for-native-sdk-initialization-android), [MBL-1319](https://linear.app/customerio/issue/MBL-1319/handle-multiple-initialization-warnings)

### Summary

Improves React Native SDK support for expo auto initialization by syncing init state with native SDKs.

### Changes:

- Updated `isInitialized` check to rely on native SDKs instead of internal JS state, so auto initialized native SDK return correct state
- Deprecated current `isInitialized` in JS and added`isInitializedAsync` that checks native state (intended for future default usage)
- Updated Android SDK dependency from `implementation` to `api` to make it accessible from the Expo apps
- Made in-app message listeners `public` to allow Expo plugin to set them during native SDK initialization
- Initialized `NativeLoggerListener` immediately via `setImmediate()` to capture logs even when auto-init is used

### Notes

- No breaking changes for customers
- Fully backward compatible, existing usages of `isInitialized` and listeners remain valid for customers not using expo auto initialization