### PR TITLE
feat: support for custom scheme link with fcm

### DIFF
--- a/example/ios/NotificationServiceExtension/NotificationService.swift
+++ b/example/ios/NotificationServiceExtension/NotificationService.swift
@@ -20,6 +20,7 @@ class NotificationService: UNNotificationServiceExtension {
   
     PushInitializer.initializeForExtension(
       withConfig: MessagingPushConfigBuilder(cdpApiKey: Env.CDP_API_KEY)
+        .logLevel(.debug)
         .build()
     )
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -31,7 +31,6 @@ installation_root = Pod::Config.instance.installation_root
 create_project_file_if_not_exists(installation_root, app_target_name)
 update_project_build_settings(installation_root, app_target_name, nse_target_name, push_provider)
 
-
 if push_provider == "fcm"
   linkage = "dynamic"
 else
@@ -71,6 +70,6 @@ target nse_target_name do
   # Ideally, installing non-production SDK to main target should be enough
   # We should not need to install non-production SDK to app extension separately
   pod "customerio-reactnative-richpush/#{push_provider}", :path => cio_package_path
-  # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: push_provider)
-  # install_non_production_ios_sdk_git_branch(branch_name: 'BRANCH-NAME-HERE', is_app_extension: false, push_service: push_provider)
+  # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: true, push_service: push_provider)
+  # install_non_production_ios_sdk_git_branch(branch_name: 'BRANCH-NAME-HERE', is_app_extension: true, push_service: push_provider)
 end

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -8,19 +8,10 @@ import { Storage } from '@services';
 import { appTheme } from '@utils';
 import { CioConfig, CioPushPermissionStatus, CustomerIO, InAppMessageEvent, InAppMessageEventType } from 'customerio-reactnative';
 import FlashMessage from 'react-native-flash-message';
-import { AppEnvValues } from './env';
+import { getEnvForApp } from './env';
 
 export default function App({ appName }: { appName: string }) {
-  const env =
-    AppEnvValues[appName.toLocaleLowerCase() as keyof typeof AppEnvValues] ??
-    AppEnvValues['default'];
-  if (!env) {
-    console.error(
-      `No default preset environment variables found nor environment variables for the app: ${appName}. The env.ts contains environment values for case-insenetive app names: ${Object.keys(
-        AppEnvValues
-      ).join(', ')}`
-    );
-  }
+  const env = getEnvForApp(appName);
   Storage.setEnv(env);
 
   const [isLoading, setIsLoading] = useState(true);

--- a/example/src/env.ts.sample
+++ b/example/src/env.ts.sample
@@ -3,29 +3,35 @@ export type Env = {
   SITE_ID: string;
 };
 
-export const AppEnvValues = {
-  'default': {
-    API_KEY: '<API_KEY>',
+// Replace placeholders with Customer.io API keys
+const envConfigs = {
+  primary: {
+    API_KEY: '<CDP_API_KEY>',
     SITE_ID: '<SITE_ID>',
   } satisfies Env,
-
-  /**
-   * If you are switching between Firebase and APN frequently for development,
-   * Comment out the Env struct above and uncomment the one below
-   * which will allow you to set API for FCM and APN separately.
-   */
-   /*
-  'apn': {
-    API_KEY: '<API_KEY>',
+  // Optional: for iOS FCM testing
+  secondary: {
+    API_KEY: '<CDP_API_KEY>',
     SITE_ID: '<SITE_ID>',
   } satisfies Env,
-  'fcm': {
-    API_KEY: '<API_KEY>',
-    SITE_ID: '<SITE_ID>',
-  } satisfies Env,
-  'android fcm': {
-    API_KEY: '<API_KEY>',
-    SITE_ID: '<SITE_ID>',
-  } satisfies Env,
-  */
 };
+
+// Maps app names from index.js to configs. Modify if you change app names.
+const appEnvMap: Record<string, Env> = {
+  'React Native APN': envConfigs.primary,
+  'React Native Android': envConfigs.primary,
+  'React Native FCM': envConfigs.secondary,
+};
+
+export function getEnvForApp(appName: string): Env {
+  const env = appEnvMap[appName];
+  
+  if (!env) {
+    console.warn(
+      `No environment config found for app: "${appName}". Using primary config as fallback. Available app names: ${Object.keys(appEnvMap).join(', ')}`
+    );
+    return envConfigs.primary;
+  }
+  
+  return env;
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 3.11.0",
+  "cioNativeiOSSdkVersion": "= 3.13.1",
   "files": [
     "src",
     "lib",


### PR DESCRIPTION
part of: [MBL-1277](https://linear.app/customerio/issue/MBL-1277/react-native-sdk-443-conflict-with-facebook-login-sdk)

### Summary

Upgraded native iOS SDK from `3.11.0` to `3.13.1` which includes following updates:

- Sticky session queue support
- Public API alignment
- Xcode 16 beta fixes
- Fixed deep link issues with FCM when using `CioAppDelegateWrapper`

### Other Changes

- Updated example app `env.ts.sample` to properly support multiple keys (APN and FCM use cases)
- Fixed broken `env` fetching logic in `App.tsx`
- Set `logLevel` to `debug` in example app NSE