### PR TITLE
fix: Add missing InApp dismissMessage() for legacy RN architecture

### DIFF
--- a/ios/wrappers/inapp/NativeMessagingInApp.swift
+++ b/ios/wrappers/inapp/NativeMessagingInApp.swift
@@ -130,4 +130,12 @@ public class NativeMessagingInAppLegacy: RCTEventEmitter {
     override public func supportedEvents() -> [String]! {
         [CustomerioConstants.inAppEventListener]
     }
+
+    /**
+     * Dismisses any currently displayed in-app message
+     */
+    @objc
+    public func dismissMessage() {
+        MessagingInApp.shared.dismissMessage()
+    }
 }


### PR DESCRIPTION
Closes: [MBL-1365](https://linear.app/customerio/issue/MBL-1365/exception-dismissmessage-is-not-a-recognized-objective-c-method)

## Problem
The [JS bridge](https://github.com/customerio/customerio-reactnative/blob/9849d04e441be164ce6640d2b887c63007577e2b/ios/wrappers/inapp/NativeMessagingInApp.swift#L96) for in-app for legacy RN arch is missing the link to `dismissMessage()`

This causes a crash on iOS for apps using old arch

## How to reproduce
- Un-comment [this line](https://github.com/customerio/customerio-reactnative/blob/9849d04e441be164ce6640d2b887c63007577e2b/example/ios/Podfile#L10) to disable new arch for iOS
- Send an in-app message with:
  -  action behavior -> Perform action
  - custom action -> dismiss