### PR TITLE
fix: update in-app module to set listener on initialize

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -4409,9 +4409,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.6.0",
+      "version": "4.8.1",
       "resolved": "file:../customerio-reactnative.tgz",
-      "integrity": "sha512-bZtsa2nJN1NwHb7WDYAcWMzwrjiayvfXrFcj7xmLnh5Ds0HvEAVMK6+RGa6cXi/yRSMVLTIEKq6s5bN/+kPNPQ==",
+      "integrity": "sha512-lEf0LAYhUA2NSH7niu0kbzbnbO+BWnH0d26wUsJ5x5EAGvCQtsOxEmJOxlT/BTObrIc5POUeD5s/wgwf+aRBAA==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {

--- a/ios/wrappers/inapp/NativeMessagingInApp.swift
+++ b/ios/wrappers/inapp/NativeMessagingInApp.swift
@@ -19,6 +19,10 @@ class NativeMessagingInAppImplementation {
             let body = data.compactMapValues { $0 }
             inAppEventCallback(body)
         }
+        // If MessagingInApp module has already been initialized, this sets the listener directly.
+        // If this method is called early, accessing ReactInAppEventListener.shared will also register
+        // it into the DI graph, making it available for access in Expo during auto-initialization.
+        MessagingInApp.shared.setEventListener(ReactInAppEventListener.shared)
     }
 
     // Clears the in-app event listener to prevent leaks when module is deallocated or invalidated

--- a/ios/wrappers/inapp/ReactInAppEventListener.swift
+++ b/ios/wrappers/inapp/ReactInAppEventListener.swift
@@ -1,3 +1,4 @@
+import CioInternalCommon
 import CioMessagingInApp
 
 /**
@@ -7,6 +8,13 @@ import CioMessagingInApp
 public class ReactInAppEventListener: InAppEventListener {
     // Shared instance for global access
     public static let shared = ReactInAppEventListener()
+
+    private init() {
+        // Registers in DI graph so it can be accessed by Expo without using direct imports and
+        // using common import and DI graph from native iOS SDK
+        DIGraphShared.shared.override(value: self, forType: InAppEventListener.self)
+    }
+
     // Event emitter function to send events to React Native layer
     private var eventEmitter: (([String: Any?]) -> Void)?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-reactnative",
-  "version": "4.6.0",
+  "version": "4.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-reactnative",
-      "version": "4.6.0",
+      "version": "4.8.1",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
part of: [MBL-1366](https://linear.app/customerio/issue/MBL-1366/fix-or-remove-react-native-ios-import-dependency-from-expo-plugin-auto)

### Summary

Ensures `ReactInAppEventListener` is set when React Native messaging in app module is initialized. This improves support for expo auto initialized behavior by avoiding direct, early references to React classes that could cause import issues.

### Changes

- Set `ReactInAppEventListener` during `initialize()` lifecycle of React Native messaging in app iOS module
- Updated listener's initialization to insert itself into shared dependency graph when accessed early, so it becomes accessible for auto initialization scenarios (e.g., Expo SDK starting before full UI render)

### Behavior

- In manual initialization setups, the listener is still registered during `CustomerIO.initialize()` as before
- In auto initialization, listener registration now happens in React Native module `initialize()` without requiring explicit JS trigger to improve reliability in cases where native SDK initializes before React components render
- Safe fallback: if native in app module hasn't been initialized yet, setting the listener will be ignored

### Notes

- No breaking changes for any customer
- The changes help avoid unnecessary imports and helps ensure Expo auto initialization setups don't miss in-app callbacks
- Generally safe since modules are lazily loaded after UI is mostly prepared