### PR TITLE
fix: prevent TurboModule EventEmitter crashes on armeabi-v7a devices

### DIFF
--- a/android/src/newarch/io/customer/reactnative/sdk/logging/NativeCustomerIOLoggingModule.kt
+++ b/android/src/newarch/io/customer/reactnative/sdk/logging/NativeCustomerIOLoggingModule.kt
@@ -1,7 +1,5 @@
 package io.customer.reactnative.sdk.logging
 
-import android.os.Build
-import android.util.Log
 import com.facebook.react.bridge.ReactApplicationContext
 import io.customer.reactnative.sdk.NativeCustomerIOLoggingSpec
 import io.customer.reactnative.sdk.util.onlyForLegacyArch
@@ -9,84 +7,32 @@ import io.customer.reactnative.sdk.util.onlyForLegacyArch
 /**
  * React Native module implementation for Customer.io Logging Native SDK
  * using TurboModules with new architecture.
+ *
+ * Note: This module is not instantiated on armeabi-v7a architectures to prevent
+ * TurboModule EventEmitter crashes. See CustomerIOReactNativePackageImpl for details.
  */
 class NativeCustomerIOLoggingModule(
     reactContext: ReactApplicationContext,
 ) : NativeCustomerIOLoggingSpec(reactContext) {
     override fun getName(): String = NativeCustomerIOLoggingModuleImpl.NAME
 
-    // true if the app is currently running under armeabi/armeabi-v7a ABIs.
-    // We check only the first ABI in SUPPORTED_ABIS because the first one is most preferred ABI.
-    private val isABIArmeabi: Boolean by lazy {
-        Build.SUPPORTED_ABIS?.firstOrNull()
-            ?.lowercase()
-            ?.contains("armeabi") == true
-    }
-
-    /**
-     * Executes the given block and logs any uncaught exceptions using Android logger to protect
-     * against unexpected crashes and failures.
-     */
-    private fun runWithTryCatch(action: () -> Unit) {
-        try {
-            action()
-        } catch (ex: Exception) {
-            // Use Android logger to avoid cyclic calls from internal SDK logging
-            Log.e("[CIO]", "Error in NativeCustomerIOLoggingModule: ${ex.message}", ex)
-        }
-    }
-
-    /**
-     * Executes the given action only if the current ABI supports it.
-     * Skips execution on armeabi/armeabi-v7a to prevent C++ crashes on unsupported architectures.
-     */
-    private fun runOnSupportedAbi(action: () -> Unit) {
-        runWithTryCatch {
-            if (isABIArmeabi) {
-                // Skip execution on armeabi-v7a to avoid known native (C++) crashes on unsupported ABIs.
-                // This ensures stability on lower-end or legacy devices by preventing risky native calls.
-                return@runWithTryCatch
-            }
-
-            action()
-        }
-    }
-
     override fun initialize() {
-        runWithTryCatch {
-            super.initialize()
-            if (isABIArmeabi) {
-                Log.i(
-                    "[CIO]",
-                    "Native logging is disabled on armeabi/armeabi-v7a ABI to avoid native crashes (Supported ABIs: ${Build.SUPPORTED_ABIS?.joinToString()})"
-                )
-            }
-            runOnSupportedAbi {
-                NativeCustomerIOLoggingModuleImpl.setLogEventEmitter { data ->
-                    emitOnCioLogEvent(data)
-                }
-            }
+        super.initialize()
+        NativeCustomerIOLoggingModuleImpl.setLogEventEmitter { data ->
+            emitOnCioLogEvent(data)
         }
     }
 
     override fun invalidate() {
-        runOnSupportedAbi {
-            NativeCustomerIOLoggingModuleImpl.invalidate()
-        }
-        runWithTryCatch {
-            super.invalidate()
-        }
+        NativeCustomerIOLoggingModuleImpl.invalidate()
+        super.invalidate()
     }
 
     override fun addListener(eventName: String?) {
-        runOnSupportedAbi {
-            onlyForLegacyArch("addListener")
-        }
+        onlyForLegacyArch("addListener")
     }
 
     override fun removeListeners(count: Double) {
-        runOnSupportedAbi {
-            onlyForLegacyArch("removeListeners")
-        }
+        onlyForLegacyArch("removeListeners")
     }
 }


### PR DESCRIPTION
  **Problem**

  Customers reported crashes on `armeabi-v7a` devices (Samsung A13, etc.) during app initialization. Crash traces showed:

```
  #12 facebook::react::JavaTurboModule::setEventEmitterCallback
  #13 NativeCustomerIOMessagingInAppSpecJSI::NativeCustomerIOMessagingInAppSpecJSI [CONSTRUCTOR]
```
  Root cause: React Native's TurboModule EventEmitter has a C++ bug on 32-bit ARM (armeabi-v7a) where setEventEmitterCallback() crashes with an invalid JNI reference during
   module construction.

  Both `NativeCustomerIOLogging` and `NativeCustomerIOMessagingInApp` use EventEmitter in their specs, triggering this crash.

  What Was Possibly Missed in Previous Fix (c4067958), we added defensive code inside NativeCustomerIOLoggingModule.initialize():

```
  override fun initialize() {
      runWithTryCatch {
          super.initialize()  // ❌ Crash happens HERE in parent constructor
          if (isABIArmeabi) {
              // This code never executes - already crashed
          }
      }
  }
```

  Why it didn't work:
  1. `super.initialize()` calls parent class `NativeCustomerIOLoggingSpec(reactContext)`
  2. Parent class is C++ generated code that calls setEventEmitterCallback() in constructor
  3. Crash occurs in C++ before Kotlin code runs
  4. The defensive try-catch and ABI checks never execute

  ### The Fix

  Prevent module instantiation before the constructor is called:
```
  fun createNativeModule(reactContext: ReactApplicationContext, name: String): NativeModule? {
      // Check architecture BEFORE creating module
      if (isArmeabiArchitecture && name in EVENT_EMITTER_MODULES) {
          Log.w(TAG, "Module '$name' disabled on armeabi-v7a to prevent TurboModule EventEmitter crash")
          return null  // Module never created = no crash
      }

      return when (name) {
          "NativeCustomerIOLogging" -> NativeCustomerIOLoggingModule(reactContext)
          "NativeCustomerIOMessagingInApp" -> NativeMessagingInAppModule(reactContext)
          // ...
      }
  }
```

  ### How it works:
  - Architecture check happens before new NativeCustomerIOLoggingModule() is called
  - If armeabi-v7a detected, return null immediately
  - Module constructor never called → C++ constructor never called → no crash
  - React Native handles null gracefully (treats module as unavailable)


  Impact on armeabi-v7a devices:

  | Feature                          | Status     | Notes                                                 |
  |----------------------------------|------------|-------------------------------------------------------|
  | App crash                        | ✅ Fixed    | No more crashes on Samsung A13, etc.                  |
  | Core SDK (identify, track, etc.) | ✅ Works    | No impact                                             |
  | Push notifications               | ✅ Works    | No impact                                             |
  | In-app messages display          | ✅ Works    | Messages still shown natively                         |
  | In-app messages interaction      | ✅ Works    | Buttons, actions work natively                        |
  | Native SDK event tracking        | ✅ Works    | Customer.io backend analytics work                    |
  | Logging events to React Native   | ❌ Disabled | JS won't receive log events                           |
  | In-app events to React Native    | ❌ Disabled | JS won't receive messageShown, messageDismissed, etc. |

  Impact on other architectures (arm64-v8a, x86_64):
  - ✅ No changes - full functionality maintained
