### PR TITLE
feat: support for Android 16

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 customerio.reactnative.kotlinVersion=2.1.20
-customerio.reactnative.compileSdkVersion=33
-customerio.reactnative.targetSdkVersion=33
+customerio.reactnative.compileSdkVersion=36
+customerio.reactnative.targetSdkVersion=36
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=4.12.1
+customerio.reactnative.cioSDKVersionAndroid=4.13.0

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,8 +2,8 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 35
-        targetSdkVersion = 35
+        compileSdkVersion = 36
+        targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.1.20"
     }

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -4422,9 +4422,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "4.11.0",
+      "version": "5.0.1",
       "resolved": "file:../customerio-reactnative.tgz",
-      "integrity": "sha512-0buiCp9LuXN5hHHE2oUEhyH+h8nqCTFMi2fkwV8Ye/WhBrIQEy6wYSrWiqrQqN9zs4hojOsEAn7rwgdddBmd8Q==",
+      "integrity": "sha512-AAq7DyIat2aWCD9/ZvvCFramBIHygMwkRuMcxn5nmwqPXdlWHQqLnk6pZnGpeAW98UpywMSklYzF8WRoQj7pWg==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-reactnative",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-reactnative",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
### Summary

This PR includes all necessary dependency updates, build configurations updates and improvements required to add support for Android `16` (API level `36`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Android compile/target SDK to 36 and bumps Customer.io Android SDK and React Native package versions.
> 
> - **Android build config**:
>   - Update `compileSdkVersion` and `targetSdkVersion` to `36` in `android/gradle.properties` and `example/android/build.gradle`.
>   - Bump `customerio.reactnative.cioSDKVersionAndroid` to `4.13.0`.
> - **Packages**:
>   - Bump root `customerio-reactnative` package version to `5.0.1` in `package-lock.json`.
>   - Update `customerio-reactnative` in `example/package-lock.json` from `4.11.0` to `5.0.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bd90dc2ac9342a4301e0b40af31cd6770e38155. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->