### PR TITLE
ci: fix iOS test build

### DIFF
--- a/.github/workflows/build-sample-app.yml
+++ b/.github/workflows/build-sample-app.yml
@@ -197,7 +197,7 @@ jobs:
         run: |
           ENV_FILE="Env.swift"
           cp "$ENV_FILE.sample" "$ENV_FILE"
-          sd 'CDP_API_KEY: String = ".*"' "CDP_API_KEY: String = \"${{ secrets[format('CUSTOMERIO_{0}_WORKSPACE_CDP_API_KEY', inputs.app_name)] }}\"" "$ENV_FILE"
+          sd 'CDP_API_KEY = ".*"' "CDP_API_KEY = \"${{ secrets[format('CUSTOMERIO_{0}_WORKSPACE_CDP_API_KEY', inputs.app_name)] }}\"" "$ENV_FILE"
 
       # Make sure to fetch dependencies only after updating version numbers and workspace credentials
 
@@ -240,7 +240,7 @@ jobs:
         if: ${{ inputs.platform == 'ios' }}
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '16'
 
       - name: Build and upload ${{ inputs.platform_name }} ${{ inputs.app_name }} sample app via Fastlane
         id: build_app

--- a/.github/workflows/build-test-sample-apps.yml
+++ b/.github/workflows/build-test-sample-apps.yml
@@ -62,7 +62,7 @@ jobs:
             platform: 'ios'
             platform_name: 'iOS'
             platform_name_upper: 'IOS'
-          - name: 'FCM'
+          - name: 'APN'
             cio-workspace-name: 'Mobile: React Native'
             platform: 'android'
             platform_name: 'Android'


### PR DESCRIPTION
### Changes

- Fixed `sd` command for replacing CDP API key in NSE `Env` file, the example `Env` was missing `: String`, causing silent failures for NSE keys
- Locked Xcode version to `16` instead of `latest-stable` to avoid build intermittent CI failures
- Updated Android test app to use `APN` workspace instead of `FCM`, since `APN` is main workspace used for testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes NSE Env.swift key replacement, pins Xcode to 16 for iOS builds, and switches Android test app matrix to APN.
> 
> - **CI Workflows**
>   - `/.github/workflows/build-sample-app.yml`:
>     - Fix `sd` pattern to replace `CDP_API_KEY` in `example/ios/NotificationServiceExtension/Env.swift`.
>     - Pin Xcode version to `16` for iOS builds.
>   - `/.github/workflows/build-test-sample-apps.yml`:
>     - Switch Android sample matrix entry to `name: 'APN'` (from FCM).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 638d89c7ebea763222ba1656c9d15b66c5394d94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->