### PR TITLE
fix: expose in-app listener for expo

### DIFF
--- a/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/NativeMessagingInAppModuleImpl.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/NativeMessagingInAppModuleImpl.kt
@@ -19,7 +19,7 @@ object NativeMessagingInAppModuleImpl {
 
     private val inAppMessagingModule: ModuleMessagingInApp?
         get() = kotlin.runCatching { CustomerIO.instance().inAppMessaging() }.getOrNull()
-    internal val inAppEventListener = ReactInAppEventListener()
+    val inAppEventListener = ReactInAppEventListener()
 
     /**
      * Adds InAppMessaging module to native Android SDK based on configuration provided by customer


### PR DESCRIPTION
## Problem
  The `inAppEventListener` in `NativeMessagingInAppModuleImpl` was marked as `internal`, preventing external packages (like the Expo plugin) from accessing the shared singleton instance. This caused in-app messaging callbacks to fail in Expo apps because:
  1. The Expo plugin would create its own `ReactInAppEventListener` instance during SDK initialization
  2. The React Native module would set the event emitter on a different instance (the internal singleton)
  3. In-app events would fire on the Expo-created listener, which had no event emitter configured
  4. Result: No callbacks reached the JavaScript layer

  ## Solution
  Changed the visibility of `inAppEventListener` from `internal` to `public` in `NativeMessagingInAppModuleImpl.kt`.

  **File:** `android/src/main/java/io/customer/reactnative/sdk/messaginginapp/NativeMessagingInAppModuleImpl.kt`

  ```kotlin
  // Before
  internal val inAppEventListener = ReactInAppEventListener()

  // After
  val inAppEventListener = ReactInAppEventListener()
```

  ## Why This Approach?

This change follows the existing architectural pattern where `NativeMessagingInAppModuleImpl` acts as a facade for in-app messaging functionality. The listener is already a singleton managed by this object, and making it public allows external integrations (like Expo) to use the same instance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `inAppEventListener` public in `NativeMessagingInAppModuleImpl` so external integrations (e.g., Expo) can use the shared singleton for in-app callbacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc8fd41639fa85c19fac363c874ead5cf91cfadf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->