### PR TITLE
fix: include firebase wrapper in notification service FCM podspec

### DIFF
--- a/customerio-reactnative-richpush.podspec
+++ b/customerio-reactnative-richpush.podspec
@@ -34,5 +34,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'fcm' do |ss|
     ss.dependency "CustomerIO/MessagingPushFCM", package["cioNativeiOSSdkVersion"]
+    # Customer.io Firebase Wrapper - provides Firebase integration
+    ss.dependency "CioFirebaseWrapper", package["cioiOSFirebaseWrapperSdkVersion"]
   end
 end

--- a/example/ios/NotificationServiceExtension/NotificationService.swift
+++ b/example/ios/NotificationServiceExtension/NotificationService.swift
@@ -1,6 +1,7 @@
 import UserNotifications
 #if USE_FCM
 import CioMessagingPushFCM
+import CioFirebaseWrapper
 typealias PushInitializer = MessagingPushFCM
 #else
 


### PR DESCRIPTION
### Summary
Adds `CioFirebaseWrapper` dependency to `customerio-reactnative-richpush.podspec` which is used by the Notification Service Extension and FCM consumers.

In the [setup push notifications guide](https://docs.customer.io/integrations/sdk/react-native/push-notifications/push/?codelang=FCM%2FObjective-C#), `CioFirebaseWrapper` was being imported inadvertently, the dependency was not present on the `.podspec` that is used by the Extension.

<img width="1211" height="413" alt="Screenshot 2025-11-20 at 13 39 13" src="https://github.com/user-attachments/assets/48acc7f9-b5a4-42d1-afe5-21cfa3df57cc" />


In the [4x -> 5.0.0 migration guide](https://docs.customer.io/integrations/sdk/react-native/whats-new/5.x-upgrade/#troubleshooting), it is also indicated that:
`Check imports: Ensure you’ve added import CioFirebaseWrapper to all files that import CioMessagingPushFCM` -> the Notification Service is one of them.

In order to comply with the setup/troubleshoot guide and to ensure that the user does not have any build errors, the `.podspec` now includes the `CioFirebaseWrapper` dependency.



### Changes
Added `CioFirebaseWrapper` dependency to `customerio-reactnative-richpush.podspec` under `FCM`.
Added `CioFirebaseWrapper` import to the Notification Service of the sample iOS app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `CioFirebaseWrapper` to the FCM rich push podspec and imports it in the sample Notification Service for FCM builds.
> 
> - **Podspec (`customerio-reactnative-richpush.podspec`)**:
>   - FCM subspec: add dependency `CioFirebaseWrapper` using `package["cioiOSFirebaseWrapperSdkVersion"]`.
> - **Example iOS app**:
>   - `example/ios/NotificationServiceExtension/NotificationService.swift`: when `USE_FCM`, add `import CioFirebaseWrapper`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f52114fde1c81243adf3e9f075358b60161ef44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->