### PR TITLE
ci: fix android sample app release build

### DIFF
--- a/.github/workflows/build-release-sample-apps.yml
+++ b/.github/workflows/build-release-sample-apps.yml
@@ -35,7 +35,7 @@ jobs:
             echo "sdk_version=${{ inputs.sdk_version }}" >> $GITHUB_OUTPUT
           fi
 
-  build-sample-app:
+  build-sample-app-ios:
     needs: [determine-branch, determine-sdk-version]
     uses: ./.github/workflows/build-sample-app.yml
     with:
@@ -45,5 +45,18 @@ jobs:
       platform: "ios"
       platform_name: "iOS"
       platform_name_upper: "IOS"
+      sdk_version: ${{ needs.determine-sdk-version.outputs.resolved_version }}
+    secrets: inherit
+
+  build-sample-app-android:
+    needs: [determine-branch, determine-sdk-version]
+    uses: ./.github/workflows/build-sample-app.yml
+    with:
+      app_name: "APN"
+      branch_name: ${{ needs.determine-branch.outputs.branch_name }}
+      cio-workspace-name: "Mobile: React Native"
+      platform: "android"
+      platform_name: "Android"
+      platform_name_upper: "ANDROID"
       sdk_version: ${{ needs.determine-sdk-version.outputs.resolved_version }}
     secrets: inherit

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -5076,9 +5076,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "5.1.1",
+      "version": "5.2.0",
       "resolved": "file:../customerio-reactnative.tgz",
-      "integrity": "sha512-80mi1645H2uT3c5GqBe3VjXL62VnMvIfmTSAZ/lXAavXxSpFxeTYybIogKhgJQazo490JEK3ZBEr8AxLfLey3w==",
+      "integrity": "sha512-X7e18GTaOAtRySFo2b3yAMIlhHgyGOdaILt+9xKKNwoLE00FlG+tdRYIzRndKEsf9efBfMnsh8x0HEUzbtHsXg==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-reactnative",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-reactnative",
-      "version": "5.1.1",
+      "version": "5.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
### Summary

Resolves an issue where Android sample app was excluded from public release workflows, ensuring both iOS and Android builds are compiled correctly.

### Changes

- Updated `.github/workflows/build-release-sample-apps.yml` to include Android sample app in workflow
- Fixed the workflow so Android builds are properly triggered, and compiled, alongside iOS during releases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Android sample app to release workflow alongside iOS and bumps `customerio-reactnative` to 5.2.0 in lockfiles.
> 
> - **CI/CD**:
>   - Add `build-sample-app-android` job to `.github/workflows/build-release-sample-apps.yml`, running in parallel with `build-sample-app-ios`.
>   - Preserve SDK auto-resolution and branch detection; pass Android-specific `platform` settings.
> - **Dependencies**:
>   - Bump `customerio-reactnative` from `5.1.1` to `5.2.0` in `package-lock.json` and `example/package-lock.json` (updated integrity).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18103043580b845621e391f6d08f03e180f9f5c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->