### PR TITLE
fix: Downgrade okhttp version to 4.x

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ customerio.reactnative.kotlinVersion=2.1.20
 customerio.reactnative.compileSdkVersion=36
 customerio.reactnative.targetSdkVersion=36
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=4.15.1
+customerio.reactnative.cioSDKVersionAndroid=4.15.2


### PR DESCRIPTION
This PR fixes errors caused by OkHttp v5
- Duplicate metadata
- Some RN/Flutter dependencies still depend on v4 for some internal classes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version bump in build configuration; risk is limited to potential dependency/behavior changes introduced in `4.15.2`.
> 
> **Overview**
> Bumps the configured Customer.io Android SDK version (`customerio.reactnative.cioSDKVersionAndroid`) from `4.15.1` to `4.15.2` in `android/gradle.properties`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3215075a59296db3dc272fc97c8f172b65bba6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->