### PR TITLE
chore: Create Cursor command to update native SDKs and test locally

### DIFF
--- a/.cursor/commands/update-native-sdks.md
+++ b/.cursor/commands/update-native-sdks.md
@@ -1,0 +1,34 @@
+# Update Customer.io native SDKs
+
+Update the Customer.io **iOS** and/or **Android** native SDK versions used by this React Native library.
+
+## Where versions are defined
+
+| Platform | File | What to change |
+|----------|------|----------------|
+| **iOS** | `package.json` | `cioNativeiOSSdkVersion` (and optionally `cioiOSFirebaseWrapperSdkVersion` if needed) |
+| **Android** | `android/gradle.properties` | `customerio.reactnative.cioSDKVersionAndroid=x.y.z` |
+
+- iOS version is read by `customerio-reactnative.podspec` and `customerio-reactnative-richpush.podspec` from `package.json`. Firebase wrapper version is read as `cioiOSFirebaseWrapperSdkVersion`.
+- Android version is read by `android/build.gradle` as `ext.cioAndroidSDKVersion` from `gradle.properties`.
+
+## Steps
+
+1. **Decide target versions**
+   - Check latest releases (optional):
+     - iOS: https://github.com/customerio/customerio-ios/releases
+     - Android: https://github.com/customerio/customerio-android/releases
+   - Use tag version without leading `v` (e.g. `4.1.3`, `4.15.2`).
+
+2. **Update iOS native SDK**
+   - In **`package.json`**, set:
+     - `"cioNativeiOSSdkVersion": "= X.Y.Z"` (e.g. `"= 4.1.3"`). Keep the `= ` prefix (CocoaPods “any compatible” style).
+   - Only change `cioiOSFirebaseWrapperSdkVersion` if the iOS SDK or docs require it.
+
+3. **Update Android native SDK**
+   - In **`android/gradle.properties`**, update the line:
+     - `customerio.reactnative.cioSDKVersionAndroid=<new version>` (e.g. `4.15.2`). Single `=`, no space.
+
+4. **Verify**
+   - From repo root:
+     - `npm ci`


### PR DESCRIPTION
Updates the **Customer.io iOS and Android** native SDK versions used by this React Native library.

## What it does

1. **Choose target versions**  
   Optionally check the latest releases on the [iOS](https://github.com/customerio/customerio-ios/releases) and [Android](https://github.com/customerio/customerio-android/releases) GitHub release pages. Use the tag version without a leading `v` (e.g. `4.1.3`, `4.15.2`).

2. **Update iOS**  
   In `package.json`:
   - Set `cioNativeiOSSdkVersion` to `"= X.Y.Z"` (e.g. `"= 4.1.3"`). Keep the `= ` prefix (CocoaPods style).
   - Change `cioiOSFirebaseWrapperSdkVersion` only if the iOS SDK or docs require it.

3. **Update Android**  
   In `android/gradle.properties`, set:
   - `customerio.reactnative.cioSDKVersionAndroid=<new version>` (e.g. `4.15.2`). Single `=`, no space.

4. **Verify**
   - Run `npm ci` from the repo root.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds documentation only; no runtime code or build logic changes.
> 
> **Overview**
> Adds a new Cursor command doc (`.cursor/commands/update-native-sdks.md`) describing how to bump the Customer.io iOS (`cioNativeiOSSdkVersion` / optional `cioiOSFirebaseWrapperSdkVersion` in `package.json`) and Android (`customerio.reactnative.cioSDKVersionAndroid` in `android/gradle.properties`) native SDK versions and verify the change locally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbcc23f75434e89b50241202477a42bed0fc5143. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->