### PR TITLE
chore: Upgrade to Xcode 26

### DIFF
--- a/.github/workflows/build-sample-app.yml
+++ b/.github/workflows/build-sample-app.yml
@@ -238,9 +238,7 @@ jobs:
 
       - name: Setup ${{ inputs.platform_name }} environment for the ${{ inputs.platform }} sample app
         if: ${{ inputs.platform == 'ios' }}
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '16'
+        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-15+iOS-26
 
       - name: Build and upload ${{ inputs.platform_name }} ${{ inputs.app_name }} sample app via Fastlane
         id: build_app

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   deploy-cocoapods:
     name: Deploy SDK to Cocoapods 
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Checkout existing tag if manually running CI task  


### PR DESCRIPTION
Upgrades tooling used on CI to use Xcode 26 and mac-os 15

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes; main risk is CI/deployment failures due to runner image or Xcode environment differences.
> 
> **Overview**
> Updates CI tooling to target newer Apple build infrastructure.
> 
> The sample app workflow replaces the direct `setup-xcode` step with `customerio/mobile-ci-tools` `setup-ios` configured for *macOS 15 + iOS 26*.
> 
> The Cocoapods/npm deploy workflow bumps the GitHub Actions runner from `macos-12` to `macos-15`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b080330fcb01b92a00e8d9f7e9504b45c21dfc4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->