### PR TITLE
chore: Build test screen for location module

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
   <application
     android:name=".MainApplication"

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -47,3 +47,6 @@ edgeToEdgeEnabled=false
 # This is useful for testing new features or bug fixes before they are released.
 # Set to 'local' to use the local version of the SDK.
 # cioSDKVersionAndroid=local
+
+# Enable Customer.io Location module for the example app (used to verify location wiring).
+customerio_location_enabled=true

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -6,17 +6,26 @@ load "/tmp/override_cio_sdk.rb"
 # end of internal Customer.io testing code
 # -------------
 
-# Resolve react_native_pods.rb with node to allow for hoisting
-require Pod::Executable.execute_command("node", ["-p",
-                                                 'require.resolve(
-    "react-native/scripts/react_native_pods.rb",
-    {paths: [process.argv[1]]},
-  )', __dir__]).strip
+# Resolve scripts with node to allow for hoisting
+def node_require(script)
+  require Pod::Executable.execute_command('node', ['-p',
+    "require.resolve(
+      '#{script}',
+      {paths: [process.argv[1]]},
+    )", __dir__]).strip
+end
+
+node_require('react-native/scripts/react_native_pods.rb')
+node_require('react-native-permissions/scripts/setup.rb')
 
 require_relative "../scripts/ios_project_setup_utils.rb"
 
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
+
+setup_permissions([
+  'LocationWhenInUse',
+])
 
 push_provider = (ENV["PUSH_PROVIDER"] || "apn").downcase
 
@@ -51,7 +60,7 @@ target app_target_name do
     :path => config[:reactNativePath],
     :app_path => "#{installation_root}/..",
   )
-  pod "customerio-reactnative/#{push_provider}", :path => cio_package_path
+  pod "customerio-reactnative", :path => cio_package_path, :subspecs => [push_provider, "location"]
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: push_provider)
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: push_provider)
 

--- a/example/ios/SampleApp/Info.plist
+++ b/example/ios/SampleApp/Info.plist
@@ -13,6 +13,8 @@
 	</dict>
 	<key>RCTNewArchEnabled</key>
 	<true/>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This app uses your location to test the Customer.io location module.</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>CFBundleURLTypes</key>

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-clipboard/clipboard": "^1.16.0",
+        "@react-native-community/geolocation": "^3.4.0",
         "@react-navigation/bottom-tabs": "^7.4.7",
         "@react-navigation/native": "^7.1.14",
         "@react-navigation/native-stack": "^7.3.20",
@@ -19,6 +20,7 @@
         "react-native-device-info": "^14.0.4",
         "react-native-flash-message": "^0.4.2",
         "react-native-get-random-values": "^1.11.0",
+        "react-native-permissions": "^5.0.0",
         "react-native-safe-area-context": "^5.6.0",
         "react-native-screens": "^4.11.1",
         "react-native-snackbar": "^2.9.0",
@@ -3013,6 +3015,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@react-native-community/geolocation": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/geolocation/-/geolocation-3.4.0.tgz",
+      "integrity": "sha512-bzZH89/cwmpkPMKKveoC72C4JH0yF4St5Ceg/ZM9pA1SqX9MlRIrIrrOGZ/+yi++xAvFDiYfihtn9TvXWU9/rA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -10420,6 +10435,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react-native-permissions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-5.5.1.tgz",
+      "integrity": "sha512-nTKFoj47b6EXNqbbg+8VFwBWMpxF1/UTbrNBLpXkWpt005pH4BeFv/NwpcC1iNhToKBrxQD+5kI0z6+kTYoYWA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-safe-area-context": {

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "android": "react-native run-android",
-    "ios": "sh -c 'args=\"$*\"; sim=${args#*--simulator }; react-native run-ios --simulator=\"$sim\"' _",
+    "ios": "react-native run-ios",
     "pods": "bundle exec pod install --project-directory=ios",
     "lint": "eslint .",
     "start": "react-native start",
@@ -18,6 +18,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-clipboard/clipboard": "^1.16.0",
+    "@react-native-community/geolocation": "^3.4.0",
     "@react-navigation/bottom-tabs": "^7.4.7",
     "@react-navigation/native": "^7.1.14",
     "@react-navigation/native-stack": "^7.3.20",
@@ -27,6 +28,7 @@
     "react-native-device-info": "^14.0.4",
     "react-native-flash-message": "^0.4.2",
     "react-native-get-random-values": "^1.11.0",
+    "react-native-permissions": "^5.0.0",
     "react-native-safe-area-context": "^5.6.0",
     "react-native-screens": "^4.11.1",
     "react-native-snackbar": "^2.9.0",

--- a/example/src/navigation/props.ts
+++ b/example/src/navigation/props.ts
@@ -12,6 +12,7 @@ export const CustomDeviceAttrScreenName = 'Device Attributes' as const;
 export const InternalSettingsScreenName = 'Internal Settings' as const;
 export const InlineExamplesScreenName = 'Inline Examples' as const;
 export const InboxMessagesScreenName = 'Inbox Messages' as const;
+export const LocationScreenName = 'Location' as const;
 
 export type NavigationStackParamList = {
   [SettingsScreenName]: undefined;
@@ -24,6 +25,7 @@ export type NavigationStackParamList = {
   [InternalSettingsScreenName]: undefined;
   [InlineExamplesScreenName]: undefined;
   [InboxMessagesScreenName]: undefined;
+  [LocationScreenName]: undefined;
 };
 
 export type NavigationProps = NavigationProp<NavigationStackParamList>;

--- a/example/src/screens/content-navigator.tsx
+++ b/example/src/screens/content-navigator.tsx
@@ -5,6 +5,7 @@ import {
   InboxMessagesScreenName,
   InlineExamplesScreenName,
   InternalSettingsScreenName,
+  LocationScreenName,
   LoginScreenName,
   NavigationCallbackContext,
   NavigationStackParamList,
@@ -22,6 +23,7 @@ import {
   InboxMessagesScreen,
   InlineExamplesScreen,
   InternalSettingsScreen,
+  LocationScreen,
   LogingScreen,
   SettingsScreen,
   TrackScreen,
@@ -124,6 +126,15 @@ export const ContentNavigator = ({ appName }: { appName: string }) => {
           name={InboxMessagesScreenName}
           component={InboxMessagesScreen}
           options={{
+            headerBackButtonDisplayMode: 'minimal',
+            headerBackVisible: true,
+          }}
+        />
+        <Stack.Screen
+          name={LocationScreenName}
+          component={LocationScreen}
+          options={{
+            title: 'Location Test',
             headerBackButtonDisplayMode: 'minimal',
             headerBackVisible: true,
           }}

--- a/example/src/screens/home.tsx
+++ b/example/src/screens/home.tsx
@@ -4,6 +4,7 @@ import {
   CustomProfileAttrScreenName,
   InboxMessagesScreenName,
   InlineExamplesScreenName,
+  LocationScreenName,
   NavigationCallbackContext,
   NavigationScreenProps,
 } from '@navigation';
@@ -75,6 +76,10 @@ export const HomeScreen = ({
             onPress={() => {
               navigation.navigate(InboxMessagesScreenName);
             }}
+          />
+          <Button
+            title="Location (test)"
+            onPress={() => navigation.navigate(LocationScreenName)}
           />
         </View>
       </ScrollView>

--- a/example/src/screens/index.ts
+++ b/example/src/screens/index.ts
@@ -4,6 +4,7 @@ export * from './home';
 export * from './inbox-messages';
 export * from './inline-examples';
 export * from './internal-settings';
+export * from './location';
 export * from './login';
 export * from './settings';
 export * from './track';

--- a/example/src/screens/location.tsx
+++ b/example/src/screens/location.tsx
@@ -1,0 +1,376 @@
+import {
+  BodyText,
+  BoldText,
+  Button,
+  ButtonExperience,
+} from '@components';
+import { Colors } from '@colors';
+import { CustomerIO } from 'customerio-reactnative';
+import React, { useState } from 'react';
+import {
+  Alert,
+  Linking,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  View,
+} from 'react-native';
+import Geolocation from '@react-native-community/geolocation';
+import { request, PERMISSIONS, RESULTS } from 'react-native-permissions';
+import { systemWeights } from 'react-native-typography';
+import { showMessage } from 'react-native-flash-message';
+
+const LOCATION_PERMISSION =
+  Platform.OS === 'ios'
+    ? PERMISSIONS.IOS.LOCATION_WHEN_IN_USE
+    : PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION;
+
+const PRESETS: { label: string; lat: number; lng: number }[] = [
+  { label: 'New York', lat: 40.7128, lng: -74.006 },
+  { label: 'London', lat: 51.5074, lng: -0.1278 },
+  { label: 'Tokyo', lat: 35.6762, lng: 139.6503 },
+  { label: 'Sydney', lat: -33.8688, lng: 151.2093 },
+  { label: 'São Paulo', lat: -23.5505, lng: -46.6333 },
+  { label: '0, 0', lat: 0, lng: 0 },
+];
+
+const OrSeparator = () => (
+  <View style={styles.orRow}>
+    <View style={styles.orLine} />
+    <BodyText style={styles.orText}>OR</BodyText>
+    <View style={styles.orLine} />
+  </View>
+);
+
+const SectionCard = ({
+  children,
+  style,
+}: {
+  children: React.ReactNode;
+  style?: object;
+}) => <View style={[styles.sectionCard, style]}>{children}</View>;
+
+function showLocationPermissionAlert() {
+  Alert.alert(
+    'Location Permission Required',
+    'Please enable location access in Settings to use this feature.',
+    [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Open Settings', onPress: () => Linking.openSettings() },
+    ]
+  );
+}
+
+export const LocationScreen = () => {
+  const [latitude, setLatitude] = useState('');
+  const [longitude, setLongitude] = useState('');
+  const [lastSetLocation, setLastSetLocation] = useState<{
+    lat: number;
+    lng: number;
+    source: string;
+  } | null>(null);
+  const [sdkRequestingLabel, setSdkRequestingLabel] = useState(false);
+  const [useCurrentLocationLoading, setUseCurrentLocationLoading] = useState(false);
+
+  const setLocation = (lat: number, lng: number, source: string) => {
+    try {
+      CustomerIO.location.setLastKnownLocation(lat, lng);
+      setLastSetLocation({ lat, lng, source });
+      setSdkRequestingLabel(false);
+      showMessage({
+        message: `Location set successfully (${source})`,
+        type: 'success',
+      });
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const handlePreset = (lat: number, lng: number, presetName: string) => {
+    setLocation(lat, lng, presetName);
+  };
+
+  const handleManualSet = () => {
+    const latText = latitude.trim();
+    const lonText = longitude.trim();
+    if (!latText || !lonText) {
+      showMessage({
+        message: 'Please enter valid coordinates',
+        type: 'warning',
+      });
+      return;
+    }
+    const lat = parseFloat(latText);
+    const lng = parseFloat(lonText);
+    if (Number.isNaN(lat) || Number.isNaN(lng)) {
+      showMessage({
+        message: 'Please enter valid coordinates',
+        type: 'warning',
+      });
+      return;
+    }
+    if (lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+      showMessage({
+        message: 'Latitude must be -90..90, longitude -180..180',
+        type: 'warning',
+      });
+      return;
+    }
+    setLocation(lat, lng, 'Manual');
+  };
+
+  /** Option 2: Request permission, then SDK fetches location once. */
+  const handleRequestSdkLocationUpdate = async () => {
+    try {
+      const result = await request(LOCATION_PERMISSION);
+      if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
+        setSdkRequestingLabel(true);
+        CustomerIO.location.requestLocationUpdate();
+        showMessage({
+          message: 'SDK requested location update',
+          type: 'success',
+        });
+      } else if (result === RESULTS.DENIED || result === RESULTS.BLOCKED) {
+        showLocationPermissionAlert();
+      } else {
+        showMessage({
+          message: 'Location is not available on this device.',
+          type: 'info',
+        });
+      }
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  /** Option 3: Request permission, get device location, then setLastKnownLocation. */
+  const handleUseCurrentLocation = async () => {
+    try {
+      const result = await request(LOCATION_PERMISSION);
+      if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
+        setUseCurrentLocationLoading(true);
+        Geolocation.getCurrentPosition(
+          (position) => {
+            const lat = position.coords.latitude;
+            const lng = position.coords.longitude;
+            setUseCurrentLocationLoading(false);
+            setLocation(lat, lng, 'Device');
+          },
+          (error) => {
+            setUseCurrentLocationLoading(false);
+            showMessage({
+              message: `Failed to get location: ${error.message}`,
+              type: 'danger',
+            });
+          },
+          { enableHighAccuracy: false, timeout: 15000, maximumAge: 10000 }
+        );
+      } else if (result === RESULTS.DENIED || result === RESULTS.BLOCKED) {
+        showLocationPermissionAlert();
+      } else {
+        showMessage({
+          message: 'Location is not available on this device.',
+          type: 'info',
+        });
+      }
+    } catch (e) {
+      setUseCurrentLocationLoading(false);
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const statusText = sdkRequestingLabel
+    ? 'Requesting location once (SDK)...'
+    : lastSetLocation
+      ? `Last set: ${lastSetLocation.lat.toFixed(4)}, ${lastSetLocation.lng.toFixed(4)} (${lastSetLocation.source})`
+      : 'No location set yet';
+
+  return (
+    <ScrollView contentContainerStyle={styles.scrollContent}>
+      <View style={styles.container}>
+        {/* OPTION 1: QUICK PRESETS */}
+        <SectionCard>
+          <BodyText style={styles.sectionHeading}>
+            OPTION 1: QUICK PRESETS
+          </BodyText>
+          <View style={styles.presetGrid}>
+            {PRESETS.map(({ label, lat, lng }) => (
+              <Button
+                key={label}
+                title={label}
+                experience={ButtonExperience.normal}
+                onPress={() => handlePreset(lat, lng, label)}
+                style={styles.presetButton}
+              />
+            ))}
+          </View>
+          <BodyText style={styles.hint}>Tap a city to set its coordinates</BodyText>
+        </SectionCard>
+
+        <OrSeparator />
+
+        {/* OPTION 2: SDK LOCATION */}
+        <SectionCard>
+          <BodyText style={styles.sectionHeading}>
+            OPTION 2: SDK LOCATION
+          </BodyText>
+          <Button
+            title="Request location once (SDK)"
+            experience={ButtonExperience.normal}
+            onPress={handleRequestSdkLocationUpdate}
+          />
+          <BodyText style={styles.hint}>
+            Ask for permission if needed, then SDK fetches location once. The SDK
+            stops any in-flight request when the app goes to background.
+          </BodyText>
+        </SectionCard>
+
+        <OrSeparator />
+
+        {/* OPTION 3: MANUALLY SET FROM DEVICE */}
+        <SectionCard>
+          <BodyText style={styles.sectionHeading}>
+            OPTION 3: MANUALLY SET FROM DEVICE
+          </BodyText>
+          <Button
+            title={useCurrentLocationLoading ? '📍  Fetching...' : '📍  Use Current Location'}
+            experience={ButtonExperience.normal}
+            onPress={handleUseCurrentLocation}
+            style={styles.useCurrentButton}
+            disabled={useCurrentLocationLoading}
+          />
+          <BodyText style={styles.hint}>
+            Fetches coordinates from device (GPS, Wi‑Fi, or cell) and sends them
+            to the SDK via setLastKnownLocation. Label shows source when known
+            (e.g. Simulated).
+          </BodyText>
+        </SectionCard>
+
+        <OrSeparator />
+
+        {/* OPTION 4: MANUAL ENTRY */}
+        <SectionCard>
+          <BodyText style={styles.sectionHeading}>
+            OPTION 4: MANUAL ENTRY
+          </BodyText>
+          <View style={styles.fieldBlock}>
+            <BoldText style={styles.fieldLabel}>Latitude</BoldText>
+            <TextInput
+              style={styles.fieldInput}
+              value={latitude}
+              onChangeText={setLatitude}
+              keyboardType="numeric"
+              placeholder="e.g., 40.7128"
+              placeholderTextColor={Colors.bodySecondaryText}
+              editable
+            />
+          </View>
+          <View style={styles.fieldBlock}>
+            <BoldText style={styles.fieldLabel}>Longitude</BoldText>
+            <TextInput
+              style={styles.fieldInput}
+              value={longitude}
+              onChangeText={setLongitude}
+              keyboardType="numeric"
+              placeholder="e.g., -74.0060"
+              placeholderTextColor={Colors.bodySecondaryText}
+              editable
+            />
+          </View>
+          <View style={styles.setLocationButtonWrap}>
+            <Button
+              title="Set Location"
+              experience={ButtonExperience.callToAction}
+              onPress={handleManualSet}
+            />
+          </View>
+          <BodyText style={styles.hint}>Enter custom coordinates</BodyText>
+        </SectionCard>
+
+        {/* Status */}
+        <View style={styles.statusCard}>
+          <BodyText style={styles.statusText}>{statusText}</BodyText>
+        </View>
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    paddingBottom: 24,
+  },
+  container: {
+    padding: 16,
+    gap: 0,
+  },
+  orRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 16,
+    gap: 12,
+  },
+  orLine: {
+    flex: 1,
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: Colors.bodyText,
+  },
+  orText: {
+    opacity: 0.8,
+  },
+  sectionCard: {
+    padding: 16,
+    borderRadius: 8,
+    backgroundColor: Colors.bodySecondaryBg,
+    gap: 12,
+  },
+  sectionHeading: {
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  presetGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  presetButton: {
+    minWidth: '30%',
+    flex: 1,
+  },
+  useCurrentButton: {
+    alignSelf: 'stretch',
+  },
+  hint: {
+    opacity: 0.9,
+    marginTop: 4,
+  },
+  setLocationButtonWrap: {
+    alignSelf: 'center',
+    minWidth: 160,
+  },
+  fieldBlock: {
+    marginBottom: 4,
+  },
+  fieldLabel: {
+    marginBottom: 6,
+  },
+  fieldInput: {
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.secondaryBg,
+    color: Colors.bodyText,
+    paddingVertical: 6,
+    ...systemWeights.regular,
+  },
+  statusCard: {
+    marginTop: 24,
+    padding: 16,
+    borderRadius: 8,
+    backgroundColor: Colors.bodySecondaryBg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  statusText: {
+    textAlign: 'center',
+  },
+});

--- a/example/src/services/storage.ts
+++ b/example/src/services/storage.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { User } from '@utils';
-import { CioConfig, CioLogLevel, CioRegion } from 'customerio-reactnative';
+import { CioConfig, CioLocationTrackingMode, CioLogLevel, CioRegion } from 'customerio-reactnative';
 import { Env } from '../env';
 
 const USER_STORAGE_KEY = 'user';
@@ -21,6 +21,9 @@ const createDefaultConfig = (env: Env | null | undefined): Config => {
     region: CioRegion.US,
     logLevel: CioLogLevel.Debug,
     trackApplicationLifecycleEvents: true,
+    location: {
+      trackingMode: CioLocationTrackingMode.OnAppStart,
+    },
   };
 };
 


### PR DESCRIPTION
👇 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new location permissions and wiring on both iOS and Android, which can impact privacy/compliance and runtime permission flows, but is isolated to the example app/test UI.
> 
> **Overview**
> Adds a new in-app **Location test** screen to the example app that can set Customer.io’s last known location via presets/manual entry, request a one-time SDK location update, or fetch device coordinates using `@react-native-community/geolocation` + `react-native-permissions`.
> 
> Wires the screen into navigation from Home, enables the Customer.io location module by default (including default `location.trackingMode`), and updates platform setup: Android manifest location permissions + Gradle flag, iOS Podfile permissions setup + SDK `location` subspec, and an iOS `NSLocationWhenInUseUsageDescription` entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe53ad05dd59ac3e28cdefb0254640678f5b25a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->