### PR TITLE
fix: Make location android dep api instead of implementation

### DIFF
--- a/android/cio-core.gradle
+++ b/android/cio-core.gradle
@@ -5,7 +5,7 @@ dependencies {
     // Location module is optional - customers enable it by adding
     // customerio_location_enabled=true in their gradle.properties
     if (project.cioLocationEnabled) {
-        implementation "io.customer.android:location:$cioAndroidSDKVersion"
+        api "io.customer.android:location:$cioAndroidSDKVersion"
     } else {
         compileOnly "io.customer.android:location:$cioAndroidSDKVersion"
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Gradle dependency visibility change; main impact is transitive dependency exposure for consumers when `customerio_location_enabled` is true.
> 
> **Overview**
> When `customerio_location_enabled` is enabled, the `io.customer.android:location` dependency is now declared as `api` instead of `implementation` in `android/cio-core.gradle`, making it transitively available to downstream consumers. The disabled path remains `compileOnly`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5f30ef77c0f265d310346b3920c605058970c05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->