### PR TITLE
fix: Honor top-level apiHost and cdnHost in CioConfig

### DIFF
--- a/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
@@ -84,6 +84,10 @@ class NativeCustomerIOModule(
                     ?.let { flushInterval(it) }
                 packageConfig.getTypedValue<Boolean>(Keys.Config.TRACK_APP_LIFECYCLE_EVENTS)
                     ?.let { trackApplicationLifecycleEvents(it) }
+                packageConfig.getTypedValue<String>(Keys.Config.API_HOST)
+                    ?.let { apiHost(it) }
+                packageConfig.getTypedValue<String>(Keys.Config.CDN_HOST)
+                    ?.let { cdnHost(it) }
 
                 // Configure push messaging module based on config provided by customer app
                 packageConfig.getTypedValue<Map<String, Any>>(key = "push").let { pushConfig ->

--- a/android/src/main/java/io/customer/reactnative/sdk/constant/Keys.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/constant/Keys.kt
@@ -12,6 +12,8 @@ internal object Keys {
         const val FLUSH_AT = "flushAt"
         const val FLUSH_INTERVAL = "flushInterval"
         const val SCREEN_VIEW_USE = "screenViewUse"
+        const val API_HOST = "apiHost"
+        const val CDN_HOST = "cdnHost"
         // Push messaging
         const val PUSH_CLICK_BEHAVIOR = "pushClickBehavior"
     }

--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -21,6 +21,8 @@ export type CioConfig = {
     migrationSiteId?: string;
     region?: CioRegion;
     logLevel?: CioLogLevel;
+    apiHost?: string;
+    cdnHost?: string;
     flushAt?: number;
     flushInterval?: number;
     screenViewUse?: ScreenView;

--- a/example/src/screens/internal-settings.tsx
+++ b/example/src/screens/internal-settings.tsx
@@ -4,28 +4,28 @@ import {
   LargeBoldText,
   TextField,
 } from '@components';
-import { InternalSettings, Storage } from '@services';
+import { Storage } from '@services';
 import React, { useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
 import { showMessage } from 'react-native-flash-message';
 
-const validateSettings = (config: InternalSettings) => {
-  if (!config.apiHost || !config.cdnHost) {
+type HostOverrides = {
+  apiHost?: string;
+  cdnHost?: string;
+};
+
+const validateSettings = (overrides: HostOverrides) => {
+  if (!overrides.apiHost || !overrides.cdnHost) {
     throw Error('CDN and API host values are missing');
-  } else if (!config.cdnHost) {
-    throw Error('CDB Host value is missing');
-  } else if (!config.apiHost) {
-    throw Error('API Host value is missing');
   }
 };
 
 export const InternalSettingsScreen = () => {
-  const [config, setConfig] = useState<InternalSettings>(
-    Storage.instance.getInternalDevConfig() || {
-      cdnHost: '',
-      apiHost: '',
-    }
-  );
+  const initialConfig = Storage.instance.getCioConfig();
+  const [config, setConfig] = useState<HostOverrides>({
+    apiHost: initialConfig?.apiHost ?? '',
+    cdnHost: initialConfig?.cdnHost ?? '',
+  });
 
   return (
     <ScrollView>
@@ -56,7 +56,11 @@ export const InternalSettingsScreen = () => {
           onPress={async () => {
             try {
               validateSettings(config);
-              Storage.instance.setInternalDevConfig(config);
+              await Storage.instance.setCioConfig({
+                ...Storage.instance.getCioConfig(),
+                apiHost: config.apiHost,
+                cdnHost: config.cdnHost,
+              });
 
               showMessage({
                 message: 'Internal Settings saved successfully',

--- a/example/src/services/storage.ts
+++ b/example/src/services/storage.ts
@@ -5,12 +5,8 @@ import { Env } from '../env';
 
 const USER_STORAGE_KEY = 'user';
 const CIO_CONFIG_STORAGE_KEY = 'cioConfig';
-export type InternalSettings = {
-  cdnHost: string;
-  apiHost: string;
-};
 
-type Config = Partial<CioConfig> & { qa?: InternalSettings };
+type Config = Partial<CioConfig>;
 
 const createDefaultConfig = (env: Env | null | undefined): Config => {
   return {
@@ -73,11 +69,7 @@ export class Storage {
   };
 
   readonly setCioConfig = async (cioConfig: CioConfig) => {
-    const config = cioConfig as Config;
-    this.config = {
-      ...config,
-      qa: config.qa ?? Storage.defaultConfig.qa,
-    };
+    this.config = cioConfig as Config;
     await AsyncStorage.setItem(
       CIO_CONFIG_STORAGE_KEY,
       JSON.stringify(this.config)
@@ -93,34 +85,11 @@ export class Storage {
   };
 
   readonly resetCioConfig = async () => {
-    if (this.config === null) {
-      this.config = Storage.defaultConfig;
-    } else {
-      this.config = {
-        ...this.config,
-        ...Storage.defaultConfig,
-        qa: this.config.qa,
-      };
-    }
-
-    await AsyncStorage.setItem(
-      CIO_CONFIG_STORAGE_KEY,
-      JSON.stringify(this.config)
-    );
-  };
-
-  readonly getInternalDevConfig = (): InternalSettings | undefined => {
-    return this.config?.qa ?? Storage.defaultConfig.qa;
-  };
-
-  readonly setInternalDevConfig = async (
-    internalSettings: InternalSettings
-  ) => {
-    if (this.config === null) {
-      this.config = { ...Storage.defaultConfig, qa: internalSettings };
-    } else {
-      this.config = { ...this.config, qa: internalSettings };
-    }
+    this.config = {
+      ...Storage.defaultConfig,
+      apiHost: this.config?.apiHost,
+      cdnHost: this.config?.cdnHost,
+    };
 
     await AsyncStorage.setItem(
       CIO_CONFIG_STORAGE_KEY,

--- a/ios/wrappers/utils/CioConfigUtils.swift
+++ b/ios/wrappers/utils/CioConfigUtils.swift
@@ -36,10 +36,8 @@ extension SDKConfigBuilder {
         Config.screenViewUse.ifNotNil(in: config, thenPassItTo: builder.screenViewUse) { ScreenView.getScreenView($0) }
         Config.trackApplicationLifecycleEvents.ifNotNil(in: config, thenPassItTo: builder.trackApplicationLifecycleEvents)
         Config.autoTrackDeviceAttributes.ifNotNil(in: config, thenPassItTo: builder.autoTrackDeviceAttributes)
-
-        let qaConfig = config["qa"] as? [String: Any?]
-        Config.apiHost.ifNotNil(in: qaConfig, thenPassItTo: builder.apiHost)
-        Config.cdnHost.ifNotNil(in: qaConfig, thenPassItTo: builder.cdnHost)
+        Config.apiHost.ifNotNil(in: config, thenPassItTo: builder.apiHost)
+        Config.cdnHost.ifNotNil(in: config, thenPassItTo: builder.cdnHost)
 
         return builder
     }

--- a/src/types/data-pipelines.ts
+++ b/src/types/data-pipelines.ts
@@ -40,6 +40,8 @@ export interface IdentifyParams {
  * @param migrationSiteId - Legacy site ID for migrating from tracking API
  * @param region - Data center region (US or EU)
  * @param logLevel - SDK logging verbosity level
+ * @param apiHost - Override the CDP API host. Use to route SDK traffic through a first-party proxy.
+ * @param cdnHost - Override the CDN host. Use to route SDK traffic through a first-party proxy.
  * @param flushAt - Number of events to batch before sending
  * @param flushInterval - Time interval (seconds) to flush events
  * @param screenViewUse - How to handle screen view tracking
@@ -55,6 +57,8 @@ export type CioConfig = {
   migrationSiteId?: string;
   region?: CioRegion;
   logLevel?: CioLogLevel;
+  apiHost?: string;
+  cdnHost?: string;
   flushAt?: number;
   flushInterval?: number;
   screenViewUse?: ScreenView;


### PR DESCRIPTION
## Problem

Customers follow the public [custom-host / proxy docs](https://customer.io/docs) and pass `apiHost` / `cdnHost` at the top level of the config they give to `CustomerIO.initialize(...)`. In `customerio-reactnative` 6.4.0 these values are silently dropped on both platforms:

- **iOS** only reads them from an undocumented nested `qa` object (`ios/wrappers/utils/CioConfigUtils.swift:40-42`). Top-level values are ignored.
- **Android** does not read them from any path — no constants in `Keys.kt`, never forwarded from `NativeCustomerIOModule.kt` to the `CustomerIOBuilder`, even though the native Android SDK has shipped public `apiHost()` / `cdnHost()` builder methods for multiple releases.
- **Public TS type** `CioConfig` does not declare either field, so customers hit a type error and have to pass them with `as any` — which then reaches native code that ignores them anyway.

End result: the proxy-hosting capability we document as supported has never worked on the RN SDK since the Fabric rewrite.

## What `qa` actually was

Not a public contract. It was an **example-app-only** override mechanism:

- Declared as a *local* type extension in the example app (`example/src/services/storage.ts`) — `type Config = Partial<CioConfig> & { qa?: InternalSettings }`.
- Set only via the example's "Internal Settings" screen and persisted across resets via `storage.ts`.
- Read only by iOS; silently dropped by Android — meaning internal QA host overrides **have never worked on Android**.
- Zero mentions in public docs, types, or CHANGELOG.

It's removed outright in this PR. No migration path needed: nothing outside the example app uses it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SDK initialization to pass through custom `apiHost`/`cdnHost` values on both iOS and Android, which can alter where network traffic is sent. Scope is small but affects configuration of core SDK connectivity.
> 
> **Overview**
> **Custom host overrides are now supported end-to-end.** `CioConfig` adds top-level `apiHost`/`cdnHost` (and the API report is updated) so consumers can pass proxy/custom hosts without `as any`.
> 
> On **Android**, the RN bridge now reads `apiHost`/`cdnHost` from config and forwards them into `CustomerIOBuilder`. On **iOS**, `SDKConfigBuilder.create(from:)` now reads these values from the top-level config (removing the prior undocumented nested `qa` lookup).
> 
> The example app’s “Internal Settings” storage flow is simplified to persist these values directly in the normal `cioConfig` (removing the extra `qa`/internal-settings config shape and related reset behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6bd4894919274b07f7f834828d24479591c6cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->