### PR TITLE
feat: add showScrollIndicators prop to inline in app message

### DIFF
--- a/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/InlineInAppMessageViewManager.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/InlineInAppMessageViewManager.kt
@@ -50,6 +50,11 @@ class InlineInAppMessageViewManager :
         view?.elementId = value
     }
 
+    @ReactProp(name = "showScrollIndicators", defaultBoolean = true)
+    override fun setShowScrollIndicators(view: ReactInlineInAppMessageView?, value: Boolean) {
+        view?.showScrollIndicators = value
+    }
+
     companion object {
         internal const val NAME = "InlineMessageNative"
     }

--- a/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/ReactInlineInAppMessageView.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/ReactInlineInAppMessageView.kt
@@ -2,6 +2,8 @@ package io.customer.reactnative.sdk.messaginginapp
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
+import android.view.ViewGroup
 import androidx.annotation.AttrRes
 import androidx.annotation.StyleRes
 import io.customer.messaginginapp.type.InAppMessage
@@ -27,6 +29,26 @@ class ReactInlineInAppMessageView @JvmOverloads constructor(
     init {
         initializeView()
         setActionListener(this)
+    }
+
+    var showScrollIndicators: Boolean = true
+        set(value) {
+            if (field == value) return
+            field = value
+            applyScrollIndicators(this)
+        }
+
+    override fun onViewAdded(child: View) {
+        super.onViewAdded(child)
+        applyScrollIndicators(child)
+    }
+
+    private fun applyScrollIndicators(view: View) {
+        view.isVerticalScrollBarEnabled = showScrollIndicators
+        view.isHorizontalScrollBarEnabled = showScrollIndicators
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) applyScrollIndicators(view.getChildAt(i))
+        }
     }
 
     override fun onActionClick(message: InAppMessage, actionValue: String, actionName: String) {

--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -14,6 +14,7 @@ import { TurboModule } from 'react-native';
 import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
 import type { ViewProps } from 'react-native';
 import { ViewStyle } from 'react-native';
+import type { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
 
 // @public
 export type CioConfig = {
@@ -204,13 +205,14 @@ export const InlineInAppMessageView: React_2.FC<InlineInAppMessageViewProps>;
 // Warning: (ae-forgotten-export) The symbol "NativeProps" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export interface InlineInAppMessageViewProps extends Omit<NativeProps, 'onSizeChange' | 'onStateChange' | 'onActionClick'> {
+export interface InlineInAppMessageViewProps extends Omit<NativeProps, 'onSizeChange' | 'onStateChange' | 'onActionClick' | 'showScrollIndicators'> {
     loadingComponent?: React_2.ReactNode;
     loadingContainerStyle?: ViewStyle;
     loadingIndicatorProps?: ActivityIndicatorProps & {
         minimumHeight?: number;
     };
     onActionClick?: (message: InAppMessage, actionValue: string, actionName: string) => void;
+    showScrollIndicators?: boolean;
 }
 
 // @public

--- a/ios/wrappers/inapp/inline/RCTInlineMessageNative.mm
+++ b/ios/wrappers/inapp/inline/RCTInlineMessageNative.mm
@@ -51,15 +51,22 @@ using namespace facebook::react;
   // On updates, diff against the parameter rather than _props so we never rely on
   // the ivar's runtime type.
   BOOL elementIdChanged = YES;
+  BOOL showScrollIndicatorsChanged = YES;
   if (oldProps) {
     const auto &oldViewProps = *std::static_pointer_cast<InlineMessageNativeProps const>(oldProps);
     elementIdChanged = oldViewProps.elementId != newViewProps.elementId;
+    showScrollIndicatorsChanged = oldViewProps.showScrollIndicators != newViewProps.showScrollIndicators;
   }
 
   if (elementIdChanged) {
     NSString *elementId = [NSString stringWithCString:newViewProps.elementId.c_str() encoding:NSUTF8StringEncoding];
     [self assertBridgeAvailable:@"updating elementId prop"];
     [self.bridge setElementId:elementId];
+  }
+
+  if (showScrollIndicatorsChanged) {
+    [self assertBridgeAvailable:@"updating showScrollIndicators prop"];
+    [self.bridge setShowScrollIndicators:newViewProps.showScrollIndicators];
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/ios/wrappers/inapp/inline/ReactInlineMessageView.h
+++ b/ios/wrappers/inapp/inline/ReactInlineMessageView.h
@@ -28,6 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Sets the element ID for the inline message
 - (void)setElementId:(NSString *)elementId;
 
+/// Sets container scroll indicators visibility
+- (void)setShowScrollIndicators:(BOOL)showScrollIndicators;
+
 /// Prepares the view for reuse in React Native lifecycle
 - (void)setupForReuse;
 

--- a/ios/wrappers/inapp/inline/ReactInlineMessageView.swift
+++ b/ios/wrappers/inapp/inline/ReactInlineMessageView.swift
@@ -1,6 +1,7 @@
 import CioMessagingInApp
 import Foundation
 import UIKit
+import WebKit
 
 /// React Native wrapper for inline message display with content view lifecycle management.
 ///
@@ -27,6 +28,14 @@ class ReactInlineMessageView: NSObject {
     func setElementId(_ elementId: String) {
         // Set element ID on the prepared content view
         contentView.elementId = elementId
+    }
+
+    private var showScrollIndicators: Bool = true
+
+    @objc
+    func setShowScrollIndicators(_ showScrollIndicators: Bool) {
+        self.showScrollIndicators = showScrollIndicators
+        applyScrollIndicators(in: contentView)
     }
 
     @objc
@@ -106,6 +115,7 @@ extension ReactInlineMessageView: InlineMessageBridgeViewDelegate {
     }
 
     func onMessageSizeChanged(width: CGFloat, height: CGFloat) {
+        applyScrollIndicators(in: contentView)
         sendOnSizeChangeEvent(width: width, height: height)
     }
 
@@ -114,11 +124,20 @@ extension ReactInlineMessageView: InlineMessageBridgeViewDelegate {
     }
 
     func onStartLoading(onComplete: @escaping () -> Void) {
+        applyScrollIndicators(in: contentView)
         sendOnStateChangeEvent(state: .loadingStarted)
         onComplete()
     }
 
     func onFinishLoading() {
         sendOnStateChangeEvent(state: .loadingFinished)
+    }
+
+    private func applyScrollIndicators(in view: UIView) {
+        if let webView = view as? WKWebView {
+            webView.scrollView.showsVerticalScrollIndicator = showScrollIndicators
+            webView.scrollView.showsHorizontalScrollIndicator = showScrollIndicators
+        }
+        view.subviews.forEach { applyScrollIndicators(in: $0) }
     }
 }

--- a/src/components/InlineInAppMessageView.tsx
+++ b/src/components/InlineInAppMessageView.tsx
@@ -22,7 +22,7 @@ import type { InAppMessage } from '../types';
 /** @public */
 export interface InlineInAppMessageViewProps extends Omit<
   NativeProps,
-  'onSizeChange' | 'onStateChange' | 'onActionClick'
+  'onSizeChange' | 'onStateChange' | 'onActionClick' | 'showScrollIndicators'
 > {
   /** Custom loading component to display while message is loading */
   loadingComponent?: React.ReactNode;
@@ -33,6 +33,8 @@ export interface InlineInAppMessageViewProps extends Omit<
   };
   /** Custom styles for the loading container */
   loadingContainerStyle?: ViewStyle;
+  /** Controls whether the inline message's scroll indicators are visible. (default: true) */
+  showScrollIndicators?: boolean;
   /** Callback triggered when a user clicks an action button in the inline message */
   onActionClick?: (
     message: InAppMessage,

--- a/src/specs/components/InlineMessageNativeComponent.ts
+++ b/src/specs/components/InlineMessageNativeComponent.ts
@@ -8,6 +8,7 @@ import type { HostComponent, ViewProps } from 'react-native';
 import type {
   DirectEventHandler,
   Double,
+  WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
@@ -46,6 +47,7 @@ export interface ActionClickEvent {
 export interface NativeProps extends ViewProps {
   /** Required element ID for retrieving inline message content. */
   elementId: string;
+  showScrollIndicators?: WithDefault<boolean, true>;
   onSizeChange: DirectEventHandler<SizeChangeEvent>;
   onStateChange?: DirectEventHandler<StateChangeEvent>;
   onActionClick?: DirectEventHandler<ActionClickEvent>;


### PR DESCRIPTION
Allow consumers to opt into hiding the WebView scroll indicators on the inline in-app message component. Defaults to true to preserve existing behavior; supports runtime toggling on both iOS and Android.

## Problem

`InlineInAppMessageView` renders its animated content inside a native `WKWebView` (iOS) / `WebView` (Android). When the message content initially renders within the component's bounds the scroll indicators are visual noise — they flash on load and then disappear, making the component look off. Hiding them is the correct UX for typical inline-message usage.
This was mainly replicated in Android. In smaller screen devices, sometimes, the scroll bar remains on screen indefinitely.


https://github.com/user-attachments/assets/a766b246-bf68-4033-8bf1-234ddc1f891f



However, hiding them unconditionally in the SDK has two problems:

1. It changes default behavior for every existing consumer without opt-in — a silent breaking change.
2. It removes any escape hatch for consumers who render oversized messages and *do* want the user to know the content is scrollable.

There was no prop to control this. The only path was to bake in a hardcoded value, which is not appropriate for a public SDK.

## Solution

Add a `showScrollIndicators?: boolean` prop to `InlineInAppMessageView`, defaulting to `true` (native default, zero regression for existing consumers). Consumers set `showScrollIndicators={false}` to opt into hiding.

The prop is wired end-to-end:

**1. Codegen spec** (`src/specs/components/InlineMessageNativeComponent.ts`)  

**2. Public TS component** (`src/components/InlineInAppMessageView.tsx`)  

**3. Android** (`ReactInlineInAppMessageView.kt` + `InlineInAppMessageViewManager.kt`)  

**4. iOS** (`ReactInlineMessageView.swift` + `.h` + `RCTInlineMessageNative.mm`)  

All setters are declarative — they apply the value in both directions, so toggling at runtime works without remounting the component.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional UI-only prop with a default of `true`, and the native changes are limited to toggling scroll indicator visibility without altering message loading or event semantics.
> 
> **Overview**
> Adds a new `showScrollIndicators?: boolean` prop to `InlineInAppMessageView` (defaulting to `true`) so consumers can hide WebView scroll bars for inline in-app messages.
> 
> Wires the prop end-to-end via RN Codegen (`WithDefault<boolean, true>`), updates the public TS props/API report, and applies the setting at runtime on **Android** by recursively enabling/disabling view scrollbars and on **iOS** by toggling `WKWebView.scrollView` indicator visibility (including during load/size-change callbacks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b1aeae0fa00d4cb716bd7c86348a421d46ebf72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->