### PR TITLE
fix: update Customer.io native SDKs (iOS 4.4.3, Android 4.17.1)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ customerio.reactnative.kotlinVersion=2.1.20
 customerio.reactnative.compileSdkVersion=36
 customerio.reactnative.targetSdkVersion=36
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=4.17.0
+customerio.reactnative.cioSDKVersionAndroid=4.17.1

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 4.4.1",
+  "cioNativeiOSSdkVersion": "= 4.4.3",
   "cioiOSFirebaseWrapperSdkVersion": "= 1.0.0",
   "files": [
     "src",


### PR DESCRIPTION
## Summary
- Bump pinned native iOS SDK from `4.4.1` to `4.4.3` in `package.json` (`cioNativeiOSSdkVersion`, consumed by the podspecs).
- Bump pinned native Android SDK from `4.17.0` to `4.17.1` in `android/gradle.properties` (`customerio.reactnative.cioSDKVersionAndroid`, consumed by `android/cio-core.gradle`).

Latest releases as of 2026-05-20:
- customerio-ios: [`4.4.3`](https://github.com/customerio/customerio-ios/releases/tag/4.4.3) (2026-05-08)
- customerio-android: [`4.17.1`](https://github.com/customerio/customerio-android/releases/tag/4.17.1) (2026-05-18)

The iOS Firebase wrapper version (`cioiOSFirebaseWrapperSdkVersion = 1.0.0`) is unchanged.

## Test plan
- [ ] CI: green (build + tests on both platforms)
- [ ] Example app resolves the new pods/AARs and launches cleanly
- [ ] Smoke-test core flows: identify, track event, in-app, push (APN + FCM)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bumps only, but may introduce upstream behavior changes or build incompatibilities from the updated native iOS/Android Customer.io SDKs.
> 
> **Overview**
> Updates the pinned Customer.io native SDK dependencies used by this React Native package: iOS `customerio-ios` from `4.4.1` to `4.4.3` (via `cioNativeiOSSdkVersion` in `package.json`) and Android from `4.17.0` to `4.17.1` (via `customerio.reactnative.cioSDKVersionAndroid` in `android/gradle.properties`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e904ea88c9848d15dd61d38e5ea84ecd0fd4f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->