### PR TITLE
feat: update native SDKs to iOS 4.5.0 and Android 4.18.0

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ customerio.reactnative.kotlinVersion=2.1.20
 customerio.reactnative.compileSdkVersion=36
 customerio.reactnative.targetSdkVersion=36
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=4.17.1
+customerio.reactnative.cioSDKVersionAndroid=4.18.0

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 4.4.3",
+  "cioNativeiOSSdkVersion": "= 4.5.0",
   "cioiOSFirebaseWrapperSdkVersion": "= 1.0.0",
   "files": [
     "src",


### PR DESCRIPTION
## What

Bumps the pinned native Customer.io SDK versions used by the React Native wrapper to the latest releases.

| Native SDK | Before | After |
| --- | --- | --- |
| iOS (`cioNativeiOSSdkVersion`) | 4.4.3 | **4.5.0** |
| Android (`cioSDKVersionAndroid`) | 4.17.1 | **4.18.0** |

iOS FCM wrapper (`cioiOSFirebaseWrapperSdkVersion`) stays at `1.0.0` — already the latest release.

## Why

[customerio-ios 4.5.0](https://github.com/customerio/customerio-ios/releases/tag/4.5.0) and [customerio-android 4.18.0](https://github.com/customerio/customerio-android/releases/tag/4.18.0) are the latest native releases.

## Files changed
- `package.json` — `cioNativeiOSSdkVersion` (consumed by the podspecs)
- `android/gradle.properties` — `customerio.reactnative.cioSDKVersionAndroid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only bumps to native dependency pins with no application logic changes; main risk is inheriting behavior from upstream native SDK releases.
> 
> **Overview**
> Updates the **pinned native Customer.io SDK versions** consumed by the React Native package: **iOS** `cioNativeiOSSdkVersion` in `package.json` goes from **4.4.3** to **4.5.0** (used by the CocoaPods specs), and **Android** `customerio.reactnative.cioSDKVersionAndroid` in `android/gradle.properties` goes from **4.17.1** to **4.18.0**. No JavaScript/TypeScript or bridge code changes—only dependency version constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb02c90e284c045c1c792291ed05d782c2e8af3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->