### PR TITLE
chore: update native SDKs to Android 4.18.1 and iOS 4.5.1

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ customerio.reactnative.kotlinVersion=2.1.20
 customerio.reactnative.compileSdkVersion=36
 customerio.reactnative.targetSdkVersion=36
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=4.18.0
+customerio.reactnative.cioSDKVersionAndroid=4.18.1

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 4.5.0",
+  "cioNativeiOSSdkVersion": "= 4.5.1",
   "cioiOSFirebaseWrapperSdkVersion": "= 1.0.0",
   "files": [
     "src",


### PR DESCRIPTION
Bumps the pinned native SDK versions to the latest releases: Android `4.18.0` → `4.18.1` and iOS `4.5.0` → `4.5.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level dependency pin updates with no wrapper logic changes; main risk is inheriting whatever fixes or regressions exist in the new native SDK patch releases.
> 
> **Overview**
> Bumps the **pinned Customer.io native SDK** versions consumers pull in at build time: Android **4.18.0 → 4.18.1** via `customerio.reactnative.cioSDKVersionAndroid` in `android/gradle.properties`, and iOS **4.5.0 → 4.5.1** via `cioNativeiOSSdkVersion` in `package.json` (used by the CocoaPods specs).
> 
> There are **no React Native / TypeScript API or wrapper code changes**—only these version pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb59f3b45fda002d6a2a8980914cc887b2959336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->