### PR TITLE
fix: update native SDKs — iOS 4.5.3 (resolve duplicate event delivery bugs) and Android 4.18.2 (scope in-app polling to process lifecycle)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ customerio.reactnative.kotlinVersion=2.1.20
 customerio.reactnative.compileSdkVersion=36
 customerio.reactnative.targetSdkVersion=36
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=4.18.1
+customerio.reactnative.cioSDKVersionAndroid=4.18.2

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 4.5.1",
+  "cioNativeiOSSdkVersion": "= 4.5.3",
   "cioiOSFirebaseWrapperSdkVersion": "= 1.0.0",
   "files": [
     "src",


### PR DESCRIPTION
Bump bundled native SDKs to iOS 4.5.2 and Android 4.18.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin-only change with no wrapper code or API surface edits; residual risk is whatever changed inside the upstream native SDK patch releases.
> 
> **Overview**
> Bumps the **bundled Customer.io native SDK** versions this React Native package pulls in at build time, with no changes to the JS/TS public API in this diff.
> 
> **Android:** `customerio.reactnative.cioSDKVersionAndroid` goes from **4.18.1** → **4.18.2** in `android/gradle.properties` (consumed by `android/build.gradle` as the native dependency version).
> 
> **iOS:** `cioNativeiOSSdkVersion` goes from **4.5.1** → **4.5.3** in `package.json` (used by the CocoaPods specs for the main and rich-push pods). Apps get the newer native SDKs on the next `pod install` / Gradle resolve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1199414dbf47bb29c70865b8fc59c6de83fbb687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->