### PR TITLE
chore: add geofence module base

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 ext.cioLocationEnabled = rootProject.findProperty("customerio_location_enabled")?.toBoolean() ?: false
+ext.cioGeofenceEnabled = rootProject.findProperty("customerio_geofence_enabled")?.toBoolean() ?: false
 
 android {
   namespace = 'io.customer.reactnative.sdk'
@@ -33,7 +34,10 @@ android {
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
-    buildConfigField "boolean", "CIO_LOCATION_ENABLED", "${project.cioLocationEnabled}"
+    // Geofence implies Location, so the Location flag is on whenever geofence is enabled
+    // (mirrors the iOS geofence subspec, which also defines CIO_LOCATION_ENABLED).
+    buildConfigField "boolean", "CIO_LOCATION_ENABLED", "${project.cioLocationEnabled || project.cioGeofenceEnabled}"
+    buildConfigField "boolean", "CIO_GEOFENCE_ENABLED", "${project.cioGeofenceEnabled}"
     consumerProguardFiles 'consumer-rules.pro'
   }
 

--- a/android/cio-core.gradle
+++ b/android/cio-core.gradle
@@ -3,10 +3,18 @@ dependencies {
     api "io.customer.android:messaging-push-fcm:$cioAndroidSDKVersion"
     api "io.customer.android:messaging-in-app:$cioAndroidSDKVersion"
     // Location module is optional - customers enable it by adding
-    // customerio_location_enabled=true in their gradle.properties
-    if (project.cioLocationEnabled) {
+    // customerio_location_enabled=true in their gradle.properties.
+    // Geofence implies Location: enabling geofence pulls in location too.
+    if (project.cioLocationEnabled || project.cioGeofenceEnabled) {
         api "io.customer.android:location:$cioAndroidSDKVersion"
     } else {
         compileOnly "io.customer.android:location:$cioAndroidSDKVersion"
+    }
+    // Geofence module is optional - customers enable it by adding
+    // customerio_geofence_enabled=true in their gradle.properties
+    if (project.cioGeofenceEnabled) {
+        api "io.customer.android:geofence:$cioAndroidSDKVersion"
+    } else {
+        compileOnly "io.customer.android:geofence:$cioAndroidSDKVersion"
     }
 }

--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -39,6 +39,7 @@ export type CioConfig = {
     location?: {
         trackingMode?: CioLocationTrackingMode;
     };
+    geofence?: {};
 };
 
 // @public
@@ -86,6 +87,8 @@ export type CustomAttributes = Record<string, any>;
 export class CustomerIO {
     static readonly clearIdentify: () => Promise<any>;
     static readonly deleteDeviceToken: () => Promise<void>;
+    // (undocumented)
+    static readonly geofence: CustomerIOGeofence;
     static readonly identify: (input?: IdentifyParams) => Promise<any>;
     // (undocumented)
     static readonly inAppMessaging: CustomerIOInAppMessaging;
@@ -106,6 +109,10 @@ export class CustomerIO {
         deviceToken: string;
         event: MetricEvent;
     }) => Promise<void>;
+}
+
+// @public
+export class CustomerIOGeofence {
 }
 
 // Warning: (ae-forgotten-export) The symbol "NativeInAppSpec" needs to be exported by the entry point index.d.ts

--- a/customerio-reactnative.podspec
+++ b/customerio-reactnative.podspec
@@ -57,4 +57,14 @@ Pod::Spec.new do |s|
       'OTHER_SWIFT_FLAGS' => '$(inherited) -DCIO_LOCATION_ENABLED'
     }
   end
+
+  # Geofence module is optional - customers must opt in by adding this subspec.
+  # It pulls in Location transitively (CustomerIO/LocationGeofence depends on it).
+  # Geofence implies Location, so this subspec also enables the Location wrapper code.
+  s.subspec "geofence" do |ss|
+    ss.dependency "CustomerIO/LocationGeofence", package["cioNativeiOSSdkVersion"]
+    ss.pod_target_xcconfig = {
+      'OTHER_SWIFT_FLAGS' => '$(inherited) -DCIO_GEOFENCE_ENABLED -DCIO_LOCATION_ENABLED'
+    }
+  end
 end

--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -1,3 +1,4 @@
+import { CustomerIOGeofence } from './customerio-geofence';
 import { CustomerIOInAppMessaging } from './customerio-inapp';
 import { CustomerIOLocation } from './customerio-location';
 import { CustomerIOPushMessaging } from './customerio-push';
@@ -178,6 +179,7 @@ export class CustomerIO {
    */
   static readonly isInitialized = () => _initialized;
 
+  static readonly geofence = new CustomerIOGeofence();
   static readonly inAppMessaging = new CustomerIOInAppMessaging();
   static readonly location = new CustomerIOLocation();
   static readonly pushMessaging = new CustomerIOPushMessaging();

--- a/src/customerio-geofence.ts
+++ b/src/customerio-geofence.ts
@@ -1,0 +1,12 @@
+/**
+ * Public entry point for the optional Geofence module.
+ *
+ * Geofence runs automatically once enabled — there are no app-facing methods yet.
+ * Apps opt in by passing a `geofence` config to `initialize` and enabling the module
+ * at build time: set `customerio_geofence_enabled=true` in `gradle.properties` (Android)
+ * or add the `geofence` subspec to your Podfile (iOS). Enabling geofence also enables
+ * the Location module, which geofence depends on.
+ *
+ * @public
+ */
+export class CustomerIOGeofence {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
  * This file serves as the entry point for the module customerio-reactnative.
  */
 export * from './customerio-cdp';
+export * from './customerio-geofence';
 export * from './customerio-inapp';
 export * from './customerio-location';
 export * from './customerio-push';

--- a/src/types/data-pipelines.ts
+++ b/src/types/data-pipelines.ts
@@ -76,6 +76,12 @@ export type CioConfig = {
     /** Location tracking mode. Defaults to 'manual' if location config is provided. */
     trackingMode?: CioLocationTrackingMode;
   };
+  /**
+   * Geofence configuration. Providing this opts the app into geofence monitoring,
+   * which runs automatically once enabled and has no options yet. Enabling geofence
+   * also enables the Location module, which geofence depends on.
+   */
+  geofence?: {};
 };
 
 /**


### PR DESCRIPTION
## Summary

Wires the optional geofence module into the SDK **without enabling any behavior yet**:

- **Android** — adds the `customerio_geofence_enabled` gradle property + `CIO_GEOFENCE_ENABLED` BuildConfig field, and pulls in the `geofence` dependency (plus `location`, which geofence implies).
- **iOS** — adds the `geofence` podspec subspec → `CustomerIO/LocationGeofence`. Because geofence implies Location, this subspec also enables the Location wrapper code.
- **JS** — adds the `geofence` opt-in config key and the exported `CustomerIOGeofence` class.

Geofence has no app-facing methods — it runs automatically once registered. Native registration is handled in the next PR, so this change is inert until then.

Modeled on the existing Location module and mirrors the Flutter SDK's geofence module base.

## Ticket

[MBL-1785 — React Native: add geofencing support](https://linear.app/customerio/issue/MBL-1785/react-native-add-geofencing-support)

## PR stack

1. 👉 **This PR** — geofence module base (build wiring + opt-in surface) · base: `feature/geofence-on-device`
2. #606 — register geofence module + geofence implies Location

_Sample-app enablement will follow in a separate PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time flags and optional dependencies only; no native geofence registration or runtime logic in this PR, so default installs are unchanged.
> 
> **Overview**
> Adds **optional geofence** support to the React Native SDK using the same opt-in pattern as Location, without turning on runtime behavior yet (native registration is a follow-up PR).
> 
> **Android** introduces `customerio_geofence_enabled`, `CIO_GEOFENCE_ENABLED` in BuildConfig, and conditional `api` vs `compileOnly` for the native `geofence` artifact. Enabling geofence also forces **Location** on (`CIO_LOCATION_ENABLED` and the location dependency when either location or geofence is enabled).
> 
> **iOS** adds a `geofence` CocoaPods subspec on `CustomerIO/LocationGeofence` with `-DCIO_GEOFENCE_ENABLED` and `-DCIO_LOCATION_ENABLED`.
> 
> **JavaScript** exposes `geofence?: {}` on `CioConfig`, exports an empty `CustomerIOGeofence` class, and wires `CustomerIO.geofence` on the main entry point (no app-facing methods yet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92c51ca890c0b36a385edfcd41d42a42a2173146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->