### PR TITLE
chore: register geofence module and treat geofence as implying location

### DIFF
--- a/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
@@ -8,6 +8,7 @@ import io.customer.datapipelines.config.ScreenView
 import io.customer.reactnative.sdk.constant.Keys
 import io.customer.reactnative.sdk.extension.getTypedValue
 import io.customer.reactnative.sdk.extension.toMap
+import io.customer.reactnative.sdk.geofence.NativeGeofenceModule
 import io.customer.reactnative.sdk.location.NativeLocationModule
 import io.customer.reactnative.sdk.messaginginapp.NativeMessagingInAppModule
 import io.customer.reactnative.sdk.messagingpush.NativeMessagingPushModule
@@ -104,12 +105,28 @@ class NativeCustomerIOModule(
                         region = region
                     )
                 }
-                // Configure location module if enabled via gradle property
+                // Configure location module. Geofence implies location, so register location
+                // (with the app's config if given, otherwise defaults) whenever location or
+                // geofence is enabled, since geofence relies on the location module's fixes.
+                // CIO_LOCATION_ENABLED is already true for geofence-enabled builds.
                 if (BuildConfig.CIO_LOCATION_ENABLED) {
-                    packageConfig.getTypedValue<Map<String, Any>>(key = "location")?.let { locationConfig ->
+                    val locationConfig = packageConfig.getTypedValue<Map<String, Any>>(key = "location")
+                    val geofenceConfigured = BuildConfig.CIO_GEOFENCE_ENABLED &&
+                        packageConfig.getTypedValue<Map<String, Any>>(key = "geofence") != null
+                    if (locationConfig != null || geofenceConfigured) {
                         NativeLocationModule.addNativeModuleFromConfig(
                             builder = this,
-                            config = locationConfig
+                            config = locationConfig ?: emptyMap()
+                        )
+                    }
+                }
+                // Configure geofence module if enabled via gradle property; it runs
+                // automatically once registered and relies on the location module above.
+                if (BuildConfig.CIO_GEOFENCE_ENABLED) {
+                    packageConfig.getTypedValue<Map<String, Any>>(key = "geofence")?.let { geofenceConfig ->
+                        NativeGeofenceModule.addNativeModuleFromConfig(
+                            builder = this,
+                            config = geofenceConfig
                         )
                     }
                 }

--- a/android/src/main/java/io/customer/reactnative/sdk/geofence/NativeGeofenceModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/geofence/NativeGeofenceModule.kt
@@ -1,0 +1,30 @@
+package io.customer.reactnative.sdk.geofence
+
+import io.customer.geofence.GeofenceModuleConfig
+import io.customer.geofence.ModuleGeofence
+import io.customer.sdk.CustomerIOBuilder
+
+/**
+ * Registers the optional geofence module with the native Android SDK.
+ *
+ * Geofence has no app-facing methods — it runs automatically once registered — so this is
+ * not a TurboModule. The reference to [ModuleGeofence] is isolated here so the geofence
+ * dependency is only loaded when the module is enabled and bundled. Geofence depends on the
+ * location module, which the caller registers alongside it.
+ */
+internal object NativeGeofenceModule {
+    /**
+     * Adds the geofence module to the native Android SDK.
+     *
+     * @param builder instance of CustomerIOBuilder to add the geofence module.
+     * @param config configuration provided by the customer app for the geofence module.
+     */
+    fun addNativeModuleFromConfig(
+        builder: CustomerIOBuilder,
+        @Suppress("UNUSED_PARAMETER") config: Map<String, Any>
+    ) {
+        builder.addCustomerIOModule(
+            ModuleGeofence(GeofenceModuleConfig.Builder().build())
+        )
+    }
+}

--- a/ios/wrappers/NativeCustomerIO.swift
+++ b/ios/wrappers/NativeCustomerIO.swift
@@ -49,8 +49,23 @@ public class NativeCustomerIO: NSObject {
             let sdkConfigBuilder = try SDKConfigBuilder.create(from: config)
 
             #if CIO_LOCATION_ENABLED
-            if let locationModule = NativeLocation.module(from: config) {
+            // Geofence implies location: register the location module whenever location
+            // config is provided or geofence is enabled, since geofence relies on the
+            // location module's fixes.
+            #if CIO_GEOFENCE_ENABLED
+            let geofenceConfigured = config["geofence"] != nil
+            #else
+            let geofenceConfigured = false
+            #endif
+            if let locationModule = NativeLocation.module(from: config, geofenceEnabled: geofenceConfigured) {
                 _ = sdkConfigBuilder.addModule(locationModule)
+            }
+            #endif
+
+            #if CIO_GEOFENCE_ENABLED
+            // Geofence runs automatically once registered; relies on the location module above.
+            if let geofenceModule = NativeGeofence.module(from: config) {
+                _ = sdkConfigBuilder.addModule(geofenceModule)
             }
             #endif
 

--- a/ios/wrappers/geofence/NativeGeofence.swift
+++ b/ios/wrappers/geofence/NativeGeofence.swift
@@ -1,0 +1,20 @@
+#if CIO_GEOFENCE_ENABLED
+import CioLocationGeofence
+
+/// Registers the optional geofence module with the native iOS SDK.
+///
+/// Geofence has no app-facing methods — it runs automatically once registered — so this
+/// only parses the opt-in config and builds the module. The reference to `GeofenceModule`
+/// is isolated here so it is only compiled when the geofence subspec is installed. Geofence
+/// depends on the location module, which the caller registers alongside it.
+@objc(NativeCustomerIOGeofence)
+public class NativeGeofence: NSObject {
+
+    /// Returns a `GeofenceModule` when the app opts into geofence via the `geofence` config.
+    /// Geofence runs automatically once registered and has no options yet.
+    static func module(from config: [String: Any]) -> GeofenceModule? {
+        guard config["geofence"] != nil else { return nil }
+        return GeofenceModule()
+    }
+}
+#endif

--- a/ios/wrappers/location/NativeLocation.swift
+++ b/ios/wrappers/location/NativeLocation.swift
@@ -6,11 +6,13 @@ import CoreLocation
 @objc(NativeCustomerIOLocation)
 public class NativeLocation: NSObject {
 
-    /// Parses the root config and returns a `LocationModule` if location config is present.
-    /// Keeps config parsing within the location module.
-    static func module(from config: [String: Any]) -> LocationModule? {
-        guard let locationConfig = config["location"] as? [String: Any] else { return nil }
-        let trackingModeValue = locationConfig["trackingMode"] as? String
+    /// Parses the root config and returns a `LocationModule` when location config is present
+    /// or when geofence is enabled (geofence depends on the location module). Keeps config
+    /// parsing within the location module. Defaults to `manual` tracking when no config is given.
+    static func module(from config: [String: Any], geofenceEnabled: Bool = false) -> LocationModule? {
+        let locationConfig = config["location"] as? [String: Any]
+        guard locationConfig != nil || geofenceEnabled else { return nil }
+        let trackingModeValue = locationConfig?["trackingMode"] as? String
         let mode: LocationTrackingMode
         switch trackingModeValue?.uppercased() {
         case "OFF":


### PR DESCRIPTION
## Summary

Registers the native geofence module during SDK initialization and treats **geofence-enabled as Location-enabled**.

- When the app provides the `geofence` config, registers the native geofence module (which runs automatically) **and** the Location module it depends on — using the app's `location` config if given, otherwise defaults.
- Geofence-enabled now implies the full Location module, including its JS API, on both platforms:
  - **Android** — Location is registered/exposed under `CIO_LOCATION_ENABLED || CIO_GEOFENCE_ENABLED`.
  - **iOS** — the `geofence` podspec subspec also defines `-DCIO_LOCATION_ENABLED` (in PR #605), so the Location wrapper compiles whenever geofence is enabled.

Geofence itself exposes no app-facing methods. Mirrors the verified Flutter SDK wiring and the native `ModuleGeofence` / `GeofenceModule` APIs.

## Ticket

[MBL-1785 — React Native: add geofencing support](https://linear.app/customerio/issue/MBL-1785/react-native-add-geofencing-support)

## PR stack

1. #605 — geofence module base (build wiring + opt-in surface)
2. 👉 **This PR** — register geofence module + geofence implies Location · base: `mbl-1785-geofence-module-base` (PR #605)

_Sample-app enablement will follow in a separate PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SDK initialization and optional module wiring for location/geofence on both platforms; mis-registration could affect location behavior for geofence-only apps, but scope is limited to opt-in config and compile flags.
> 
> **Overview**
> Registers the native **geofence** module during Customer.io SDK init on Android and iOS when the app includes a `geofence` key in the init config, via new `NativeGeofenceModule` / `NativeGeofence` wrappers that attach `ModuleGeofence` / `GeofenceModule` (no JS API; runs after registration).
> 
> **Geofence now implies location:** the location module is registered not only when `location` config is present, but also when geofence is opted in—using the app’s `location` settings when provided, otherwise defaults (e.g. manual tracking on iOS / `MANUAL` on Android). Geofence registration is gated on `CIO_GEOFENCE_ENABLED` and presence of `geofence` config; location registration uses the expanded condition so geofence can depend on location fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3e1abe770f99ac33349f511e17151b278a1a1e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->