### PR TITLE
chore: add iOS allowBackgroundDelivery config for geofence

### DIFF
--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -40,6 +40,9 @@ export type CioConfig = {
         trackingMode?: CioLocationTrackingMode;
     };
     geofence?: {};
+    ios?: {
+        allowBackgroundDelivery?: boolean;
+    };
 };
 
 // @public

--- a/ios/wrappers/NativeCustomerIO.swift
+++ b/ios/wrappers/NativeCustomerIO.swift
@@ -69,6 +69,15 @@ public class NativeCustomerIO: NSObject {
             }
             #endif
 
+            // Customer value wins; default on when the geofence module is added, off otherwise.
+            #if CIO_GEOFENCE_ENABLED
+            let geofenceAdded = config["geofence"] != nil
+            #else
+            let geofenceAdded = false
+            #endif
+            let allowBackgroundDelivery = (config["ios"] as? [String: Any])?["allowBackgroundDelivery"] as? Bool
+            _ = sdkConfigBuilder.allowBackgroundDelivery(allowBackgroundDelivery ?? geofenceAdded)
+
             let builtConfig = sdkConfigBuilder.build()
 
             // Only CustomerIO.initialize must run on the main thread (e.g. for Location module).

--- a/src/types/data-pipelines.ts
+++ b/src/types/data-pipelines.ts
@@ -82,6 +82,14 @@ export type CioConfig = {
    * also enables the Location module, which geofence depends on.
    */
   geofence?: {};
+  /** iOS-only SDK configuration. Has no effect on Android. */
+  ios?: {
+    /**
+     * Whether geofence transitions are delivered in real time on a background cold-wake.
+     * When unset, defaults to on if the geofence module is enabled, off otherwise.
+     */
+    allowBackgroundDelivery?: boolean;
+  };
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds an iOS-only `ios.allowBackgroundDelivery` config option, wired to the native `SDKConfigBuilder.allowBackgroundDelivery`. When the customer doesn't set it, background delivery is on if the geofence module is added, off otherwise; an explicit value always wins. Android has no equivalent native option and ignores the key.

Mirrors the Flutter SDK's equivalent change.

## Ticket

[MBL-1785 — React Native: add geofencing support](https://linear.app/customerio/issue/MBL-1785/react-native-add-geofencing-support)

## PR stack

1. #605 — geofence module base
2. #606 — register geofence module + geofence implies Location
3. 👉 **This PR** — iOS `allowBackgroundDelivery` config · base: `mbl-1785-geofence-module-code` (#606)

_Self-contained: if not wanted, it can be closed and the sample-app PR re-based onto #606 with no other changes. Sample-app enablement follows in a separate PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes iOS SDK initialization behavior for background geofence delivery; misconfiguration could affect geofence event timing, though explicit config and sensible defaults limit blast radius.
> 
> **Overview**
> Adds an **iOS-only** `ios.allowBackgroundDelivery` field on `CioConfig`, documented as controlling whether geofence transitions are delivered in real time on a background cold-wake. Android ignores this key.
> 
> During native iOS `initialize`, the bridge now calls `SDKConfigBuilder.allowBackgroundDelivery` using the customer value when set; otherwise it defaults to **on** when `geofence` is present in config and **off** when it is not. Public API types and the API Extractor report are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 613229441819f348d6f83363e5f327676cbb4086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->