### PR TITLE
chore: enable geofence in the example app

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <!-- Required for geofence transition delivery while the app is backgrounded (API 29+) -->
+  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+  <!-- Lets geofence monitoring resume after device reboot -->
+  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
   <application
     android:name=".MainApplication"

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -50,3 +50,7 @@ edgeToEdgeEnabled=false
 
 # Enable Customer.io Location module for the example app (used to verify location wiring).
 customerio_location_enabled=true
+
+# Enable Customer.io Geofence module for the example app. Geofence implies Location,
+# so enabling it also pulls in the Location module.
+customerio_geofence_enabled=true

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -25,6 +25,7 @@ prepare_react_native_project!
 
 setup_permissions([
   'LocationWhenInUse',
+  'LocationAlways',
 ])
 
 push_provider = (ENV["PUSH_PROVIDER"] || "apn").downcase
@@ -60,7 +61,7 @@ target app_target_name do
     :path => config[:reactNativePath],
     :app_path => "#{installation_root}/..",
   )
-  pod "customerio-reactnative", :path => cio_package_path, :subspecs => [push_provider, "location"]
+  pod "customerio-reactnative", :path => cio_package_path, :subspecs => [push_provider, "location", "geofence"]
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: push_provider)
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: push_provider)
 

--- a/example/ios/SampleApp/AppDelegate.swift
+++ b/example/ios/SampleApp/AppDelegate.swift
@@ -5,6 +5,10 @@ import ReactAppDependencyProvider
 
 import UserNotifications
 
+#if canImport(CioLocationGeofence)
+import CioLocationGeofence
+#endif
+
 #if USE_FCM
 import FirebaseMessaging
 import FirebaseCore
@@ -36,6 +40,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
+    #if canImport(CioLocationGeofence)
+    // Geofence cold-wake delivery: iOS can launch the app into the background for a
+    // geofence transition without starting the JS runtime, so the SDK can't rely on
+    // CustomerIO.initialize running. Bootstrapping here wires up region monitoring and
+    // flushes queued transitions on every launch; it is safe alongside normal init.
+    GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)
+    #endif
+
     let delegate = ReactNativeDelegate()
     let factory = RCTReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()

--- a/example/ios/SampleApp/Info.plist
+++ b/example/ios/SampleApp/Info.plist
@@ -15,6 +15,12 @@
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app uses your location to test the Customer.io location module.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app uses your location in the background to test the Customer.io geofence module.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>CFBundleURLTypes</key>

--- a/example/src/screens/location.tsx
+++ b/example/src/screens/location.tsx
@@ -6,9 +6,10 @@ import {
 } from '@components';
 import { Colors } from '@colors';
 import { CustomerIO } from 'customerio-reactnative';
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
+  AppState,
   Linking,
   Platform,
   ScrollView,
@@ -17,7 +18,7 @@ import {
   View,
 } from 'react-native';
 import Geolocation from '@react-native-community/geolocation';
-import { request, PERMISSIONS, RESULTS } from 'react-native-permissions';
+import { check, request, PERMISSIONS, RESULTS } from 'react-native-permissions';
 import { systemWeights } from 'react-native-typography';
 import { showMessage } from 'react-native-flash-message';
 
@@ -25,6 +26,24 @@ const LOCATION_PERMISSION =
   Platform.OS === 'ios'
     ? PERMISSIONS.IOS.LOCATION_WHEN_IN_USE
     : PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION;
+
+const BACKGROUND_LOCATION_PERMISSION =
+  Platform.OS === 'ios'
+    ? PERMISSIONS.IOS.LOCATION_ALWAYS
+    : PERMISSIONS.ANDROID.ACCESS_BACKGROUND_LOCATION;
+
+/**
+ * Background-location permission state, mirroring the native sample apps.
+ * `null` until first queried.
+ */
+type LocationStatus =
+  | 'notDetermined'
+  | 'foregroundOnly'
+  | 'backgroundGranted'
+  | 'denied';
+
+const isGrantedStatus = (status: LocationStatus | null) =>
+  status === 'foregroundOnly' || status === 'backgroundGranted';
 
 const PRESETS: { label: string; lat: number; lng: number }[] = [
   { label: 'New York', lat: 40.7128, lng: -74.006 },
@@ -34,14 +53,6 @@ const PRESETS: { label: string; lat: number; lng: number }[] = [
   { label: 'São Paulo', lat: -23.5505, lng: -46.6333 },
   { label: '0, 0', lat: 0, lng: 0 },
 ];
-
-const OrSeparator = () => (
-  <View style={styles.orRow}>
-    <View style={styles.orLine} />
-    <BodyText style={styles.orText}>OR</BodyText>
-    <View style={styles.orLine} />
-  </View>
-);
 
 const SectionCard = ({
   children,
@@ -73,6 +84,69 @@ export const LocationScreen = () => {
   const [sdkRequestingLabel, setSdkRequestingLabel] = useState(false);
   const [useCurrentLocationLoading, setUseCurrentLocationLoading] = useState(false);
 
+  // Drives the state-aware Background Location button (mirrors the native samples).
+  const [locationStatus, setLocationStatus] = useState<LocationStatus | null>(null);
+  const locationStatusRef = useRef<LocationStatus | null>(null);
+  // Sequence guard: mount, AppState resume, and permission handlers can refresh
+  // concurrently — drop a stale completion so it can't overwrite a newer result.
+  const refreshSeqRef = useRef(0);
+
+  // Reads current permissions and updates the button state. Returns the resolved
+  // status, or null if this run was superseded by a newer one (or errored).
+  const refreshLocationStatus = useCallback(async (): Promise<
+    LocationStatus | null
+  > => {
+    const seq = ++refreshSeqRef.current;
+    try {
+      const foreground = await check(LOCATION_PERMISSION);
+      const background = await check(BACKGROUND_LOCATION_PERMISSION);
+      // Drop a superseded completion so it can't overwrite a newer refresh.
+      if (seq !== refreshSeqRef.current) return null;
+      let status: LocationStatus;
+      if (background === RESULTS.GRANTED) {
+        status = 'backgroundGranted';
+      } else if (
+        foreground === RESULTS.GRANTED ||
+        foreground === RESULTS.LIMITED
+      ) {
+        status = 'foregroundOnly';
+      } else if (foreground === RESULTS.BLOCKED) {
+        status = 'denied';
+      } else {
+        status = 'notDetermined';
+      }
+      locationStatusRef.current = status;
+      setLocationStatus(status);
+      return status;
+    } catch (e) {
+      // Only surface the error if this run is still the latest.
+      if (seq === refreshSeqRef.current) {
+        showMessage({ message: (e as Error).message, type: 'danger' });
+      }
+      return null;
+    }
+  }, []);
+
+  // Query on mount; re-query on resume so the button reflects changes made in
+  // Settings, and fetch if a grant happened there. In-app grants fetch directly
+  // from their handlers, so this only covers the return-from-Settings path.
+  useEffect(() => {
+    refreshLocationStatus();
+    const subscription = AppState.addEventListener('change', async (state) => {
+      if (state !== 'active') return;
+      const previous = locationStatusRef.current;
+      const status = await refreshLocationStatus();
+      // Fetch only when gaining access from a non-granted state — not on a downgrade
+      // between granted states (e.g. revoking "Always" back to "When in Use" in Settings).
+      // The SDK's auto-fetch hook runs once per process, so a grant made in Settings
+      // needs an explicit request to register geofences this session.
+      if (status && isGrantedStatus(status) && !isGrantedStatus(previous)) {
+        CustomerIO.location.requestLocationUpdate();
+      }
+    });
+    return () => subscription.remove();
+  }, [refreshLocationStatus]);
+
   const setLocation = (lat: number, lng: number, source: string) => {
     try {
       CustomerIO.location.setLastKnownLocation(lat, lng);
@@ -95,19 +169,13 @@ export const LocationScreen = () => {
     const latText = latitude.trim();
     const lonText = longitude.trim();
     if (!latText || !lonText) {
-      showMessage({
-        message: 'Please enter valid coordinates',
-        type: 'warning',
-      });
+      showMessage({ message: 'Please enter valid coordinates', type: 'warning' });
       return;
     }
     const lat = parseFloat(latText);
     const lng = parseFloat(lonText);
     if (Number.isNaN(lat) || Number.isNaN(lng)) {
-      showMessage({
-        message: 'Please enter valid coordinates',
-        type: 'warning',
-      });
+      showMessage({ message: 'Please enter valid coordinates', type: 'warning' });
       return;
     }
     if (lat < -90 || lat > 90 || lng < -180 || lng > 180) {
@@ -120,17 +188,112 @@ export const LocationScreen = () => {
     setLocation(lat, lng, 'Manual');
   };
 
-  /** Option 2: Request permission, then SDK fetches location once. */
+  const backgroundButtonLabel = (() => {
+    switch (locationStatus) {
+      case 'foregroundOnly':
+        return Platform.OS === 'ios'
+          ? "Upgrade to 'Always'"
+          : 'Allow all the time';
+      case 'backgroundGranted':
+        return Platform.OS === 'ios' ? 'Always — granted' : 'Background — granted';
+      case 'denied':
+        return 'Open Settings';
+      default:
+        return 'Grant location access';
+    }
+  })();
+
+  const backgroundButtonEnabled = locationStatus !== 'backgroundGranted';
+
+  const showOpenSettingsDialog = () => {
+    Alert.alert(
+      'Location Permission Required',
+      'Location permission is denied. Please enable it from app settings.',
+      [
+        { text: 'Open Settings', onPress: () => Linking.openSettings() },
+        { text: 'OK', style: 'cancel' },
+      ]
+    );
+  };
+
+  /** Escalate to background ("Always"/"Allow all the time") after foreground is granted. */
+  const requestBackgroundLocation = async () => {
+    try {
+      const result = await request(BACKGROUND_LOCATION_PERMISSION);
+      await refreshLocationStatus();
+      if (result === RESULTS.GRANTED) {
+        // Fetch so geofences register now (auto-fetch already ran this process).
+        CustomerIO.location.requestLocationUpdate();
+        showMessage({
+          message: 'Background location granted — fetching location to start geofence',
+          type: 'success',
+        });
+      } else if (result === RESULTS.BLOCKED) {
+        showOpenSettingsDialog();
+      } else {
+        // iOS resolves the "Always" prompt asynchronously; the button updates on
+        // resume, which fetches if granted. Point the user to Settings otherwise.
+        showMessage({
+          message:
+            'Requesting background location — enable "Always" in Settings if no prompt appears',
+          type: 'info',
+        });
+      }
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const showBackgroundRationale = () => {
+    Alert.alert(
+      'Allow background location?',
+      'Geofence transitions only fire while the app is backgrounded if you grant ' +
+        '"Always" / "Allow all the time". If no prompt appears, use Open Settings.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Open Settings', onPress: () => Linking.openSettings() },
+        { text: 'Continue', onPress: () => requestBackgroundLocation() },
+      ]
+    );
+  };
+
+  /** State-aware Background Location action, matching the native sample apps. */
+  const handleBackgroundLocationTap = async () => {
+    switch (locationStatus) {
+      case 'foregroundOnly':
+        showBackgroundRationale();
+        return;
+      case 'backgroundGranted':
+        return;
+      case 'denied':
+        Linking.openSettings();
+        return;
+      default: {
+        // notDetermined: request foreground first, then escalate to background.
+        const result = await request(LOCATION_PERMISSION);
+        await refreshLocationStatus();
+        if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
+          // Foreground granted — fetch so geofences register, then offer background.
+          CustomerIO.location.requestLocationUpdate();
+          showBackgroundRationale();
+        } else if (result === RESULTS.BLOCKED) {
+          showOpenSettingsDialog();
+        } else {
+          showMessage({ message: 'Location permission denied', type: 'info' });
+        }
+      }
+    }
+  };
+
+  /** Request permission, then SDK fetches location once. */
   const handleRequestSdkLocationUpdate = async () => {
     try {
       const result = await request(LOCATION_PERMISSION);
+      await refreshLocationStatus();
       if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
         setSdkRequestingLabel(true);
         CustomerIO.location.requestLocationUpdate();
-        showMessage({
-          message: 'SDK requested location update',
-          type: 'success',
-        });
+        showMessage({ message: 'SDK requested location update', type: 'success' });
       } else if (result === RESULTS.DENIED || result === RESULTS.BLOCKED) {
         showLocationPermissionAlert();
       } else {
@@ -144,10 +307,11 @@ export const LocationScreen = () => {
     }
   };
 
-  /** Option 3: Request permission, get device location, then setLastKnownLocation. */
+  /** Request permission, get device location, then setLastKnownLocation. */
   const handleUseCurrentLocation = async () => {
     try {
       const result = await request(LOCATION_PERMISSION);
+      await refreshLocationStatus();
       if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
         setUseCurrentLocationLoading(true);
         Geolocation.getCurrentPosition(
@@ -189,11 +353,40 @@ export const LocationScreen = () => {
   return (
     <ScrollView contentContainerStyle={styles.scrollContent}>
       <View style={styles.container}>
-        {/* OPTION 1: QUICK PRESETS */}
+        {/* Background Location (geofence permission) */}
         <SectionCard>
-          <BodyText style={styles.sectionHeading}>
-            OPTION 1: QUICK PRESETS
+          <BodyText style={styles.sectionHeading}>Background Location</BodyText>
+          <Button
+            title={backgroundButtonLabel}
+            experience={ButtonExperience.callToAction}
+            onPress={handleBackgroundLocationTap}
+            disabled={!backgroundButtonEnabled}
+          />
+          <BodyText style={styles.hint}>
+            Geofence runs automatically once enabled, but needs background
+            ("Always" / "Allow all the time") location to deliver transitions
+            while the app is closed. This grants foreground access first, then
+            escalates to background.
           </BodyText>
+        </SectionCard>
+
+        {/* SDK Location */}
+        <SectionCard>
+          <BodyText style={styles.sectionHeading}>SDK Location</BodyText>
+          <Button
+            title="Request location once (SDK)"
+            experience={ButtonExperience.normal}
+            onPress={handleRequestSdkLocationUpdate}
+          />
+          <BodyText style={styles.hint}>
+            Ask for permission if needed, then SDK fetches location once. The SDK
+            stops any in-flight request when the app goes to background.
+          </BodyText>
+        </SectionCard>
+
+        {/* Quick Presets */}
+        <SectionCard>
+          <BodyText style={styles.sectionHeading}>Quick Presets</BodyText>
           <View style={styles.presetGrid}>
             {PRESETS.map(({ label, lat, lng }) => (
               <Button
@@ -208,31 +401,9 @@ export const LocationScreen = () => {
           <BodyText style={styles.hint}>Tap a city to set its coordinates</BodyText>
         </SectionCard>
 
-        <OrSeparator />
-
-        {/* OPTION 2: SDK LOCATION */}
+        {/* Use Current Location */}
         <SectionCard>
-          <BodyText style={styles.sectionHeading}>
-            OPTION 2: SDK LOCATION
-          </BodyText>
-          <Button
-            title="Request location once (SDK)"
-            experience={ButtonExperience.normal}
-            onPress={handleRequestSdkLocationUpdate}
-          />
-          <BodyText style={styles.hint}>
-            Ask for permission if needed, then SDK fetches location once. The SDK
-            stops any in-flight request when the app goes to background.
-          </BodyText>
-        </SectionCard>
-
-        <OrSeparator />
-
-        {/* OPTION 3: MANUALLY SET FROM DEVICE */}
-        <SectionCard>
-          <BodyText style={styles.sectionHeading}>
-            OPTION 3: MANUALLY SET FROM DEVICE
-          </BodyText>
+          <BodyText style={styles.sectionHeading}>Use Current Location</BodyText>
           <Button
             title={useCurrentLocationLoading ? '📍  Fetching...' : '📍  Use Current Location'}
             experience={ButtonExperience.normal}
@@ -242,18 +413,13 @@ export const LocationScreen = () => {
           />
           <BodyText style={styles.hint}>
             Fetches coordinates from device (GPS, Wi‑Fi, or cell) and sends them
-            to the SDK via setLastKnownLocation. Label shows source when known
-            (e.g. Simulated).
+            to the SDK via setLastKnownLocation.
           </BodyText>
         </SectionCard>
 
-        <OrSeparator />
-
-        {/* OPTION 4: MANUAL ENTRY */}
+        {/* Manual Entry */}
         <SectionCard>
-          <BodyText style={styles.sectionHeading}>
-            OPTION 4: MANUAL ENTRY
-          </BodyText>
+          <BodyText style={styles.sectionHeading}>Manual Entry</BodyText>
           <View style={styles.fieldBlock}>
             <BoldText style={styles.fieldLabel}>Latitude</BoldText>
             <TextInput
@@ -303,21 +469,7 @@ const styles = StyleSheet.create({
   },
   container: {
     padding: 16,
-    gap: 0,
-  },
-  orRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginVertical: 16,
-    gap: 12,
-  },
-  orLine: {
-    flex: 1,
-    height: StyleSheet.hairlineWidth,
-    backgroundColor: Colors.bodyText,
-  },
-  orText: {
-    opacity: 0.8,
+    gap: 16,
   },
   sectionCard: {
     padding: 16,
@@ -363,7 +515,7 @@ const styles = StyleSheet.create({
     ...systemWeights.regular,
   },
   statusCard: {
-    marginTop: 24,
+    marginTop: 8,
     padding: 16,
     borderRadius: 8,
     backgroundColor: Colors.bodySecondaryBg,

--- a/example/src/services/storage.ts
+++ b/example/src/services/storage.ts
@@ -20,6 +20,9 @@ const createDefaultConfig = (env: Env | null | undefined): Config => {
     location: {
       trackingMode: CioLocationTrackingMode.OnAppStart,
     },
+    // Opt into geofence monitoring. Runs automatically once enabled and implies the
+    // Location module above.
+    geofence: {},
   };
 };
 
@@ -49,8 +52,10 @@ export class Storage {
     );
 
     this.user = userJsonPayload ? JSON.parse(userJsonPayload) : null;
+    // Merge persisted config over defaults so newly added default keys (e.g. the
+    // geofence opt-in) are present for installs saved before those keys existed.
     this.config = cioConfigJsonPayload
-      ? JSON.parse(cioConfigJsonPayload)
+      ? { ...Storage.defaultConfig, ...JSON.parse(cioConfigJsonPayload) }
       : null;
   };
 


### PR DESCRIPTION
## Summary

Enables geofence in the example app and aligns the Location screen with the native/Flutter sample apps:

- Build flags: `customerio_geofence_enabled=true` (Android) + `geofence` podspec subspec (iOS)
- Background-location + boot permissions (Android manifest), iOS background-location usage string + `UIBackgroundModes: location`
- iOS cold-wake `GeofenceModule.bootstrapForBackgroundDelivery` in the AppDelegate
- `geofence: {}` in the initialize config
- A **state-aware background-location permission flow** on the Location screen (foreground → background escalation, lifecycle re-query on resume, `requestLocationUpdate()` on a new grant) that mirrors the native sample apps, via `react-native-permissions`

## Ticket

[MBL-1785 — React Native: add geofencing support](https://linear.app/customerio/issue/MBL-1785/react-native-add-geofencing-support)

## PR stack

1. #605 — geofence module base
2. #606 — register geofence module + geofence implies Location
3. #607 — iOS `allowBackgroundDelivery` config
4. 👉 **This PR** — enable geofence in the example app · base: `mbl-1785-geofence-background-delivery` (#607)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the example app (permissions, sample UI, and demo init)—no production SDK behavior changes in this diff.
> 
> **Overview**
> Turns on **geofence** in the React Native example app so engineers can exercise background geofence delivery end-to-end, aligned with the native sample apps.
> 
> **Build & native wiring:** Android gets `customerio_geofence_enabled=true` plus `ACCESS_BACKGROUND_LOCATION` and `RECEIVE_BOOT_COMPLETED`. iOS adds the `geofence` pod subspec, `LocationAlways` in the Podfile permissions setup, always-on location usage copy, `UIBackgroundModes` → `location`, and **`GeofenceModule.bootstrapForBackgroundDelivery`** in `AppDelegate` so cold-wake geofence events work before JS initializes.
> 
> **SDK config:** Default Customer.io init now includes **`geofence: {}`**, and persisted config is **merged over defaults** so older saved configs pick up the new geofence opt-in.
> 
> **Location screen:** Adds a **state-aware Background Location** flow (foreground → background escalation, labels per platform, Settings when denied) with permission re-check on **AppState** resume and **`CustomerIO.location.requestLocationUpdate()`** when access is newly granted (e.g. from Settings). Section layout is simplified (no “OPTION N” separators).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31f59d1d181c59a66cd0f5fb92092dfd9fd317e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->