### PR TITLE
chore: update native SDKs to versions with geofence support

### DIFF
--- a/.github/workflows/build-sample-app.yml
+++ b/.github/workflows/build-sample-app.yml
@@ -96,6 +96,7 @@ jobs:
           PUBLIC_BUILDS_GROUP: public
           # Input variables
           CURRENT_BRANCH: ${{ github.ref }}
+          PR_HEAD_BRANCH: ${{ github.head_ref }}
         run: |
           # Initialize with the default distribution group
           distribution_groups=("$ALL_BUILDS_GROUP")
@@ -103,6 +104,10 @@ jobs:
           # Append distribution groups based on branch and context if the app is primary
           if [[ "$IS_PRIMARY_APP" == "true" ]]; then
             [[ "$CURRENT_BRANCH" == "refs/heads/feature/"* ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
+            # TEMP (geofence pre-release): also publish this PR's builds to the feature-branch
+            # channel so peers can test geofence before native iOS 4.7.0 / Android 4.20.0 ship.
+            # Reverted with the rest of the geofence test wiring once native goes live.
+            [[ "$PR_HEAD_BRANCH" == "mbl-1785-geofence-final" ]] && distribution_groups+=("$FEATURE_BUILDS_GROUP")
             [[ "$CURRENT_BRANCH" == "refs/heads/main" ]] && distribution_groups+=("$NEXT_BUILDS_GROUP")
             [[ -n "${{ inputs.sdk_version }}" ]] && distribution_groups+=("$PUBLIC_BUILDS_GROUP")
           fi

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ def getExtOrIntegerDefault(name) {
 }
 
 ext.cioLocationEnabled = rootProject.findProperty("customerio_location_enabled")?.toBoolean() ?: false
+ext.cioGeofenceEnabled = rootProject.findProperty("customerio_geofence_enabled")?.toBoolean() ?: false
 
 android {
   namespace = 'io.customer.reactnative.sdk'
@@ -33,7 +34,10 @@ android {
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
-    buildConfigField "boolean", "CIO_LOCATION_ENABLED", "${project.cioLocationEnabled}"
+    // Geofence implies Location, so the Location flag is on whenever geofence is enabled
+    // (mirrors the iOS geofence subspec, which also defines CIO_LOCATION_ENABLED).
+    buildConfigField "boolean", "CIO_LOCATION_ENABLED", "${project.cioLocationEnabled || project.cioGeofenceEnabled}"
+    buildConfigField "boolean", "CIO_GEOFENCE_ENABLED", "${project.cioGeofenceEnabled}"
     consumerProguardFiles 'consumer-rules.pro'
   }
 

--- a/android/cio-core.gradle
+++ b/android/cio-core.gradle
@@ -3,10 +3,18 @@ dependencies {
     api "io.customer.android:messaging-push-fcm:$cioAndroidSDKVersion"
     api "io.customer.android:messaging-in-app:$cioAndroidSDKVersion"
     // Location module is optional - customers enable it by adding
-    // customerio_location_enabled=true in their gradle.properties
-    if (project.cioLocationEnabled) {
+    // customerio_location_enabled=true in their gradle.properties.
+    // Geofence implies Location: enabling geofence pulls in location too.
+    if (project.cioLocationEnabled || project.cioGeofenceEnabled) {
         api "io.customer.android:location:$cioAndroidSDKVersion"
     } else {
         compileOnly "io.customer.android:location:$cioAndroidSDKVersion"
+    }
+    // Geofence module is optional - customers enable it by adding
+    // customerio_geofence_enabled=true in their gradle.properties
+    if (project.cioGeofenceEnabled) {
+        api "io.customer.android:geofence:$cioAndroidSDKVersion"
+    } else {
+        compileOnly "io.customer.android:geofence:$cioAndroidSDKVersion"
     }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ customerio.reactnative.kotlinVersion=2.1.20
 customerio.reactnative.compileSdkVersion=36
 customerio.reactnative.targetSdkVersion=36
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=4.18.2
+customerio.reactnative.cioSDKVersionAndroid=4.20.0

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
+import io.customer.reactnative.sdk.geofence.NativeGeofenceModule
 import io.customer.reactnative.sdk.location.NativeLocationModule
 import io.customer.reactnative.sdk.logging.NativeCustomerIOLoggingModule
 import io.customer.reactnative.sdk.messaginginapp.InlineInAppMessageViewManager
@@ -35,6 +36,9 @@ class CustomerIOReactNativePackage : BaseReactPackage() {
             NativeCustomerIOModule.NAME -> NativeCustomerIOModule(reactContext = reactContext)
             NativeLocationModule.NAME -> if (BuildConfig.CIO_LOCATION_ENABLED) {
                 NativeLocationModule(reactContext)
+            } else null
+            NativeGeofenceModule.NAME -> if (BuildConfig.CIO_GEOFENCE_ENABLED) {
+                NativeGeofenceModule(reactContext)
             } else null
             NativeMessagingInAppModule.NAME -> NativeMessagingInAppModule(reactContext)
             NativeMessagingPushModule.NAME -> NativeMessagingPushModule(reactContext)
@@ -72,6 +76,7 @@ class CustomerIOReactNativePackage : BaseReactPackage() {
             NativeCustomerIOLoggingModule.NAME,
             NativeCustomerIOModule.NAME,
             NativeLocationModule.NAME,
+            NativeGeofenceModule.NAME,
             NativeMessagingInAppModule.NAME,
             NativeMessagingPushModule.NAME,
         )

--- a/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
@@ -8,6 +8,7 @@ import io.customer.datapipelines.config.ScreenView
 import io.customer.reactnative.sdk.constant.Keys
 import io.customer.reactnative.sdk.extension.getTypedValue
 import io.customer.reactnative.sdk.extension.toMap
+import io.customer.reactnative.sdk.geofence.NativeGeofenceModule
 import io.customer.reactnative.sdk.location.NativeLocationModule
 import io.customer.reactnative.sdk.messaginginapp.NativeMessagingInAppModule
 import io.customer.reactnative.sdk.messagingpush.NativeMessagingPushModule
@@ -104,12 +105,28 @@ class NativeCustomerIOModule(
                         region = region
                     )
                 }
-                // Configure location module if enabled via gradle property
+                // Configure location module. Geofence implies location, so register location
+                // (with the app's config if given, otherwise defaults) whenever location or
+                // geofence is enabled, since geofence relies on the location module's fixes.
+                // CIO_LOCATION_ENABLED is already true for geofence-enabled builds.
                 if (BuildConfig.CIO_LOCATION_ENABLED) {
-                    packageConfig.getTypedValue<Map<String, Any>>(key = "location")?.let { locationConfig ->
+                    val locationConfig = packageConfig.getTypedValue<Map<String, Any>>(key = "location")
+                    val geofenceConfigured = BuildConfig.CIO_GEOFENCE_ENABLED &&
+                        packageConfig.getTypedValue<Map<String, Any>>(key = "geofence") != null
+                    if (locationConfig != null || geofenceConfigured) {
                         NativeLocationModule.addNativeModuleFromConfig(
                             builder = this,
-                            config = locationConfig
+                            config = locationConfig ?: emptyMap()
+                        )
+                    }
+                }
+                // Configure geofence module if enabled via gradle property; it runs
+                // automatically once registered and relies on the location module above.
+                if (BuildConfig.CIO_GEOFENCE_ENABLED) {
+                    packageConfig.getTypedValue<Map<String, Any>>(key = "geofence")?.let { geofenceConfig ->
+                        NativeGeofenceModule.addNativeModuleFromConfig(
+                            builder = this,
+                            config = geofenceConfig
                         )
                     }
                 }

--- a/android/src/main/java/io/customer/reactnative/sdk/geofence/NativeGeofenceModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/geofence/NativeGeofenceModule.kt
@@ -1,0 +1,30 @@
+package io.customer.reactnative.sdk.geofence
+
+import io.customer.geofence.GeofenceModuleConfig
+import io.customer.geofence.ModuleGeofence
+import io.customer.sdk.CustomerIOBuilder
+
+/**
+ * Registers the optional geofence module with the native Android SDK.
+ *
+ * Geofence has no app-facing methods — it runs automatically once registered — so this is
+ * not a TurboModule. The reference to [ModuleGeofence] is isolated here so the geofence
+ * dependency is only loaded when the module is enabled and bundled. Geofence depends on the
+ * location module, which the caller registers alongside it.
+ */
+internal object NativeGeofenceModule {
+    /**
+     * Adds the geofence module to the native Android SDK.
+     *
+     * @param builder instance of CustomerIOBuilder to add the geofence module.
+     * @param config configuration provided by the customer app for the geofence module.
+     */
+    fun addNativeModuleFromConfig(
+        builder: CustomerIOBuilder,
+        @Suppress("UNUSED_PARAMETER") config: Map<String, Any>
+    ) {
+        builder.addCustomerIOModule(
+            ModuleGeofence(GeofenceModuleConfig.Builder().build())
+        )
+    }
+}

--- a/android/src/main/java/io/customer/reactnative/sdk/geofence/NativeGeofenceModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/geofence/NativeGeofenceModule.kt
@@ -1,30 +1,65 @@
 package io.customer.reactnative.sdk.geofence
 
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.annotations.ReactModule
+import io.customer.geofence.GeofenceLocationMode
 import io.customer.geofence.GeofenceModuleConfig
 import io.customer.geofence.ModuleGeofence
+import io.customer.reactnative.sdk.NativeCustomerIOGeofenceSpec
+import io.customer.reactnative.sdk.extension.getTypedValue
 import io.customer.sdk.CustomerIOBuilder
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.Logger
 
 /**
- * Registers the optional geofence module with the native Android SDK.
+ * React Native module implementation for Customer.io Geofence Native SDK
+ * using TurboModules with new architecture.
  *
- * Geofence has no app-facing methods — it runs automatically once registered — so this is
- * not a TurboModule. The reference to [ModuleGeofence] is isolated here so the geofence
- * dependency is only loaded when the module is enabled and bundled. Geofence depends on the
- * location module, which the caller registers alongside it.
+ * The reference to [ModuleGeofence] is isolated in this file so the geofence dependency is
+ * only loaded when the module is enabled and bundled. Geofence depends on the location
+ * module, which the caller registers alongside it.
  */
-internal object NativeGeofenceModule {
-    /**
-     * Adds the geofence module to the native Android SDK.
-     *
-     * @param builder instance of CustomerIOBuilder to add the geofence module.
-     * @param config configuration provided by the customer app for the geofence module.
-     */
-    fun addNativeModuleFromConfig(
-        builder: CustomerIOBuilder,
-        @Suppress("UNUSED_PARAMETER") config: Map<String, Any>
-    ) {
-        builder.addCustomerIOModule(
-            ModuleGeofence(GeofenceModuleConfig.Builder().build())
-        )
+@ReactModule(name = NativeGeofenceModule.NAME)
+class NativeGeofenceModule(
+    private val reactContext: ReactApplicationContext,
+) : NativeCustomerIOGeofenceSpec(reactContext) {
+    private val logger: Logger
+        get() = SDKComponent.logger
+
+    private fun getModuleGeofence() = runCatching {
+        ModuleGeofence.instance()
+    }.onFailure {
+        logger.error("Geofence module is not initialized. Ensure geofence config is provided during SDK initialization.")
+    }.getOrNull()
+
+    override fun refreshFromCurrentLocation() {
+        getModuleGeofence()?.refreshFromCurrentLocation()
+    }
+
+    companion object {
+        const val NAME = "NativeCustomerIOGeofence"
+
+        /**
+         * Adds the geofence module to the native Android SDK based on the configuration
+         * provided by the customer app.
+         *
+         * @param builder instance of CustomerIOBuilder to add the geofence module.
+         * @param config configuration provided by the customer app for the geofence module.
+         */
+        internal fun addNativeModuleFromConfig(
+            builder: CustomerIOBuilder,
+            config: Map<String, Any>
+        ) {
+            val locationModeValue = config.getTypedValue<String>("locationMode")
+            // Uppercase before matching so casing can't diverge from iOS (which uppercases too);
+            // enumValueOf is case-sensitive. Unknown values fall back to the SDK default.
+            val locationMode = locationModeValue?.let { value ->
+                runCatching { enumValueOf<GeofenceLocationMode>(value.uppercase()) }.getOrNull()
+            }
+
+            val configBuilder = GeofenceModuleConfig.Builder()
+            locationMode?.let { configBuilder.setLocationMode(it) }
+            builder.addCustomerIOModule(ModuleGeofence(configBuilder.build()))
+        }
     }
 }

--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -40,6 +40,9 @@ export type CioConfig = {
         trackingMode?: CioLocationTrackingMode;
     };
     geofence?: {};
+    ios?: {
+        allowBackgroundDelivery?: boolean;
+    };
 };
 
 // @public

--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -39,6 +39,7 @@ export type CioConfig = {
     location?: {
         trackingMode?: CioLocationTrackingMode;
     };
+    geofence?: {};
 };
 
 // @public
@@ -86,6 +87,8 @@ export type CustomAttributes = Record<string, any>;
 export class CustomerIO {
     static readonly clearIdentify: () => Promise<any>;
     static readonly deleteDeviceToken: () => Promise<void>;
+    // (undocumented)
+    static readonly geofence: CustomerIOGeofence;
     static readonly identify: (input?: IdentifyParams) => Promise<any>;
     // (undocumented)
     static readonly inAppMessaging: CustomerIOInAppMessaging;
@@ -106,6 +109,10 @@ export class CustomerIO {
         deviceToken: string;
         event: MetricEvent;
     }) => Promise<void>;
+}
+
+// @public
+export class CustomerIOGeofence {
 }
 
 // Warning: (ae-forgotten-export) The symbol "NativeInAppSpec" needs to be exported by the entry point index.d.ts

--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -39,11 +39,19 @@ export type CioConfig = {
     location?: {
         trackingMode?: CioLocationTrackingMode;
     };
-    geofence?: {};
+    geofence?: {
+        locationMode?: CioGeofenceLocationMode;
+    };
     ios?: {
         allowBackgroundDelivery?: boolean;
     };
 };
+
+// @public
+export enum CioGeofenceLocationMode {
+    Automatic = "AUTOMATIC",
+    Manual = "MANUAL"
+}
 
 // @public
 export enum CioLocationTrackingMode {
@@ -114,8 +122,11 @@ export class CustomerIO {
     }) => Promise<void>;
 }
 
+// Warning: (ae-forgotten-export) The symbol "NativeGeofenceSpec" needs to be exported by the entry point index.d.ts
+//
 // @public
-export class CustomerIOGeofence {
+export class CustomerIOGeofence implements NativeGeofenceSpec {
+    refreshFromCurrentLocation(): void;
 }
 
 // Warning: (ae-forgotten-export) The symbol "NativeInAppSpec" needs to be exported by the entry point index.d.ts

--- a/customerio-reactnative.podspec
+++ b/customerio-reactnative.podspec
@@ -57,4 +57,14 @@ Pod::Spec.new do |s|
       'OTHER_SWIFT_FLAGS' => '$(inherited) -DCIO_LOCATION_ENABLED'
     }
   end
+
+  # Geofence module is optional - customers must opt in by adding this subspec.
+  # It pulls in Location transitively (CustomerIO/LocationGeofence depends on it).
+  # Geofence implies Location, so this subspec also enables the Location wrapper code.
+  s.subspec "geofence" do |ss|
+    ss.dependency "CustomerIO/LocationGeofence", package["cioNativeiOSSdkVersion"]
+    ss.pod_target_xcconfig = {
+      'OTHER_SWIFT_FLAGS' => '$(inherited) -DCIO_GEOFENCE_ENABLED -DCIO_LOCATION_ENABLED'
+    }
+  end
 end

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <!-- Required for geofence transition delivery while the app is backgrounded (API 29+) -->
+  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+  <!-- Lets geofence monitoring resume after device reboot -->
+  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
   <application
     android:name=".MainApplication"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -23,7 +23,7 @@ allprojects {
    repositories {
       google()  // Google's Maven repository
       mavenLocal() // Only required for using locally deployed versions of the SDK
-      maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' } // Only required for using SNAPSHOT versions of the SDK
+      maven { url 'https://central.sonatype.com/repository/maven-snapshots/' } // Only required for using SNAPSHOT versions of the SDK
    }
 }
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -46,7 +46,9 @@ edgeToEdgeEnabled=false
 # Customer.io SDK allows overriding the default SDK version.
 # This is useful for testing new features or bug fixes before they are released.
 # Set to 'local' to use the local version of the SDK.
-# cioSDKVersionAndroid=local
+# TEMP: geofence is not yet released; point at the feature-branch snapshot so the
+# example can be built and tested. Revert once the native SDKs ship.
+cioSDKVersionAndroid=feature-geofence-on-device-SNAPSHOT
 
 # Enable Customer.io Location module for the example app (used to verify location wiring).
 customerio_location_enabled=true

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -50,3 +50,7 @@ edgeToEdgeEnabled=false
 
 # Enable Customer.io Location module for the example app (used to verify location wiring).
 customerio_location_enabled=true
+
+# Enable Customer.io Geofence module for the example app. Geofence implies Location,
+# so enabling it also pulls in the Location module.
+customerio_geofence_enabled=true

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -25,6 +25,7 @@ prepare_react_native_project!
 
 setup_permissions([
   'LocationWhenInUse',
+  'LocationAlways',
 ])
 
 push_provider = (ENV["PUSH_PROVIDER"] || "apn").downcase
@@ -60,7 +61,7 @@ target app_target_name do
     :path => config[:reactNativePath],
     :app_path => "#{installation_root}/..",
   )
-  pod "customerio-reactnative", :path => cio_package_path, :subspecs => [push_provider, "location"]
+  pod "customerio-reactnative", :path => cio_package_path, :subspecs => [push_provider, "location", "geofence"]
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: push_provider)
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: push_provider)
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,7 +1,11 @@
 # -------------
 # This code only used internally for Customer.io testing
+# TEMP (geofence pre-release): build the example against the native iOS SDK on this
+# branch. Points at 'main' now that geofence is merged there; for a future unreleased
+# feature, change only this one branch name. Revert this block once native ships.
+cio_ios_sdk_branch = 'main'
 require 'open-uri'
-IO.copy_stream(URI.open('https://raw.githubusercontent.com/customerio/customerio-ios/main/scripts/cocoapods_override_sdk.rb'), "/tmp/override_cio_sdk.rb")
+IO.copy_stream(URI.open("https://raw.githubusercontent.com/customerio/customerio-ios/#{cio_ios_sdk_branch}/scripts/cocoapods_override_sdk.rb"), "/tmp/override_cio_sdk.rb")
 load "/tmp/override_cio_sdk.rb"
 # end of internal Customer.io testing code
 # -------------
@@ -63,7 +67,11 @@ target app_target_name do
   )
   pod "customerio-reactnative", :path => cio_package_path, :subspecs => [push_provider, "location", "geofence"]
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: push_provider)
-  # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: push_provider)
+  # TEMP: geofence is not yet released; build against the native branch above. Revert once the native SDK ships.
+  install_non_production_ios_sdk_git_branch(branch_name: cio_ios_sdk_branch, is_app_extension: false, push_service: push_provider)
+  # TEMP: the umbrella CustomerIO/LocationGeofence subspec isn't on the released trunk spec yet,
+  # so resolve it from the native branch's podspec explicitly. Revert once the native SDK ships.
+  pod 'CustomerIO/LocationGeofence', :git => 'https://github.com/customerio/customerio-ios.git', :branch => cio_ios_sdk_branch
 
   post_install do |installer|
     react_native_post_install(

--- a/example/ios/SampleApp/AppDelegate.swift
+++ b/example/ios/SampleApp/AppDelegate.swift
@@ -5,6 +5,10 @@ import ReactAppDependencyProvider
 
 import UserNotifications
 
+#if canImport(CioLocationGeofence)
+import CioLocationGeofence
+#endif
+
 #if USE_FCM
 import FirebaseMessaging
 import FirebaseCore
@@ -36,6 +40,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
+    #if canImport(CioLocationGeofence)
+    // Geofence cold-wake delivery: iOS can launch the app into the background for a
+    // geofence transition without starting the JS runtime, so the SDK can't rely on
+    // CustomerIO.initialize running. Bootstrapping here wires up region monitoring and
+    // flushes queued transitions on every launch; it is safe alongside normal init.
+    GeofenceModule.bootstrapForBackgroundDelivery(launchOptions: launchOptions)
+    #endif
+
     let delegate = ReactNativeDelegate()
     let factory = RCTReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()

--- a/example/ios/SampleApp/Info.plist
+++ b/example/ios/SampleApp/Info.plist
@@ -15,6 +15,12 @@
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app uses your location to test the Customer.io location module.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app uses your location in the background to test the Customer.io geofence module.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>location</string>
+	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>CFBundleURLTypes</key>

--- a/example/src/components/single-select.tsx
+++ b/example/src/components/single-select.tsx
@@ -10,6 +10,8 @@ type SingleSelectProps<T extends Key> = {
   selectedValue: T;
   onValueChange: (value: T) => void;
   label?: string;
+  /** Stack the label above the options and stretch the options to fill the width. */
+  fullWidth?: boolean;
 };
 
 export const SingleSelect = <T extends Key>({
@@ -17,18 +19,25 @@ export const SingleSelect = <T extends Key>({
   selectedValue,
   onValueChange,
   label,
+  fullWidth,
 }: SingleSelectProps<T>) => {
   const [value, setValue] = useState(selectedValue);
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, fullWidth && styles.containerFullWidth]}>
       {label && <BoldText style={styles.label}>{label}</BoldText>}
-      <View style={styles.selectionItems}>
+      <View
+        style={[
+          styles.selectionItems,
+          fullWidth && styles.selectionItemsFullWidth,
+        ]}
+      >
         {data.map((item, index) => (
           <TouchableOpacity
             key={item.value}
             style={[
               styles.itemContainer,
+              fullWidth && styles.itemContainerFullWidth,
               item.value === value && styles.selectedItemContainer,
               index === 0 && styles.firstItemContainer,
               index === data.length - 1 && styles.lastItemContainer,
@@ -62,15 +71,28 @@ const styles = StyleSheet.create({
     gap: 8,
   },
 
+  containerFullWidth: {
+    flexDirection: 'column',
+    alignItems: 'stretch',
+  },
+
   selectionItems: {
     flexDirection: 'row',
     alignItems: 'center',
     flexWrap: 'wrap',
   },
 
+  selectionItemsFullWidth: {
+    flexWrap: 'nowrap',
+  },
+
   itemContainer: {
     padding: 8,
     backgroundColor: Colors.secondaryBg,
+  },
+
+  itemContainerFullWidth: {
+    flex: 1,
   },
 
   selectedItemContainer: {

--- a/example/src/screens/location.tsx
+++ b/example/src/screens/location.tsx
@@ -6,9 +6,10 @@ import {
 } from '@components';
 import { Colors } from '@colors';
 import { CustomerIO } from 'customerio-reactnative';
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
+  AppState,
   Linking,
   Platform,
   ScrollView,
@@ -17,7 +18,7 @@ import {
   View,
 } from 'react-native';
 import Geolocation from '@react-native-community/geolocation';
-import { request, PERMISSIONS, RESULTS } from 'react-native-permissions';
+import { check, request, PERMISSIONS, RESULTS } from 'react-native-permissions';
 import { systemWeights } from 'react-native-typography';
 import { showMessage } from 'react-native-flash-message';
 
@@ -25,6 +26,24 @@ const LOCATION_PERMISSION =
   Platform.OS === 'ios'
     ? PERMISSIONS.IOS.LOCATION_WHEN_IN_USE
     : PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION;
+
+const BACKGROUND_LOCATION_PERMISSION =
+  Platform.OS === 'ios'
+    ? PERMISSIONS.IOS.LOCATION_ALWAYS
+    : PERMISSIONS.ANDROID.ACCESS_BACKGROUND_LOCATION;
+
+/**
+ * Background-location permission state, mirroring the native sample apps.
+ * `null` until first queried.
+ */
+type LocationStatus =
+  | 'notDetermined'
+  | 'foregroundOnly'
+  | 'backgroundGranted'
+  | 'denied';
+
+const isGrantedStatus = (status: LocationStatus | null) =>
+  status === 'foregroundOnly' || status === 'backgroundGranted';
 
 const PRESETS: { label: string; lat: number; lng: number }[] = [
   { label: 'New York', lat: 40.7128, lng: -74.006 },
@@ -34,14 +53,6 @@ const PRESETS: { label: string; lat: number; lng: number }[] = [
   { label: 'São Paulo', lat: -23.5505, lng: -46.6333 },
   { label: '0, 0', lat: 0, lng: 0 },
 ];
-
-const OrSeparator = () => (
-  <View style={styles.orRow}>
-    <View style={styles.orLine} />
-    <BodyText style={styles.orText}>OR</BodyText>
-    <View style={styles.orLine} />
-  </View>
-);
 
 const SectionCard = ({
   children,
@@ -73,6 +84,69 @@ export const LocationScreen = () => {
   const [sdkRequestingLabel, setSdkRequestingLabel] = useState(false);
   const [useCurrentLocationLoading, setUseCurrentLocationLoading] = useState(false);
 
+  // Drives the state-aware Background Location button (mirrors the native samples).
+  const [locationStatus, setLocationStatus] = useState<LocationStatus | null>(null);
+  const locationStatusRef = useRef<LocationStatus | null>(null);
+  // Sequence guard: mount, AppState resume, and permission handlers can refresh
+  // concurrently — drop a stale completion so it can't overwrite a newer result.
+  const refreshSeqRef = useRef(0);
+
+  // Reads current permissions and updates the button state. Returns the resolved
+  // status, or null if this run was superseded by a newer one (or errored).
+  const refreshLocationStatus = useCallback(async (): Promise<
+    LocationStatus | null
+  > => {
+    const seq = ++refreshSeqRef.current;
+    try {
+      const foreground = await check(LOCATION_PERMISSION);
+      const background = await check(BACKGROUND_LOCATION_PERMISSION);
+      // Drop a superseded completion so it can't overwrite a newer refresh.
+      if (seq !== refreshSeqRef.current) return null;
+      let status: LocationStatus;
+      if (background === RESULTS.GRANTED) {
+        status = 'backgroundGranted';
+      } else if (
+        foreground === RESULTS.GRANTED ||
+        foreground === RESULTS.LIMITED
+      ) {
+        status = 'foregroundOnly';
+      } else if (foreground === RESULTS.BLOCKED) {
+        status = 'denied';
+      } else {
+        status = 'notDetermined';
+      }
+      locationStatusRef.current = status;
+      setLocationStatus(status);
+      return status;
+    } catch (e) {
+      // Only surface the error if this run is still the latest.
+      if (seq === refreshSeqRef.current) {
+        showMessage({ message: (e as Error).message, type: 'danger' });
+      }
+      return null;
+    }
+  }, []);
+
+  // Query on mount; re-query on resume so the button reflects changes made in
+  // Settings, and fetch if a grant happened there. In-app grants fetch directly
+  // from their handlers, so this only covers the return-from-Settings path.
+  useEffect(() => {
+    refreshLocationStatus();
+    const subscription = AppState.addEventListener('change', async (state) => {
+      if (state !== 'active') return;
+      const previous = locationStatusRef.current;
+      const status = await refreshLocationStatus();
+      // Fetch only when gaining access from a non-granted state — not on a downgrade
+      // between granted states (e.g. revoking "Always" back to "When in Use" in Settings).
+      // The SDK's auto-fetch hook runs once per process, so a grant made in Settings
+      // needs an explicit request to register geofences this session.
+      if (status && isGrantedStatus(status) && !isGrantedStatus(previous)) {
+        CustomerIO.location.requestLocationUpdate();
+      }
+    });
+    return () => subscription.remove();
+  }, [refreshLocationStatus]);
+
   const setLocation = (lat: number, lng: number, source: string) => {
     try {
       CustomerIO.location.setLastKnownLocation(lat, lng);
@@ -95,19 +169,13 @@ export const LocationScreen = () => {
     const latText = latitude.trim();
     const lonText = longitude.trim();
     if (!latText || !lonText) {
-      showMessage({
-        message: 'Please enter valid coordinates',
-        type: 'warning',
-      });
+      showMessage({ message: 'Please enter valid coordinates', type: 'warning' });
       return;
     }
     const lat = parseFloat(latText);
     const lng = parseFloat(lonText);
     if (Number.isNaN(lat) || Number.isNaN(lng)) {
-      showMessage({
-        message: 'Please enter valid coordinates',
-        type: 'warning',
-      });
+      showMessage({ message: 'Please enter valid coordinates', type: 'warning' });
       return;
     }
     if (lat < -90 || lat > 90 || lng < -180 || lng > 180) {
@@ -120,17 +188,112 @@ export const LocationScreen = () => {
     setLocation(lat, lng, 'Manual');
   };
 
-  /** Option 2: Request permission, then SDK fetches location once. */
+  const backgroundButtonLabel = (() => {
+    switch (locationStatus) {
+      case 'foregroundOnly':
+        return Platform.OS === 'ios'
+          ? "Upgrade to 'Always'"
+          : 'Allow all the time';
+      case 'backgroundGranted':
+        return Platform.OS === 'ios' ? 'Always — granted' : 'Background — granted';
+      case 'denied':
+        return 'Open Settings';
+      default:
+        return 'Grant location access';
+    }
+  })();
+
+  const backgroundButtonEnabled = locationStatus !== 'backgroundGranted';
+
+  const showOpenSettingsDialog = () => {
+    Alert.alert(
+      'Location Permission Required',
+      'Location permission is denied. Please enable it from app settings.',
+      [
+        { text: 'Open Settings', onPress: () => Linking.openSettings() },
+        { text: 'OK', style: 'cancel' },
+      ]
+    );
+  };
+
+  /** Escalate to background ("Always"/"Allow all the time") after foreground is granted. */
+  const requestBackgroundLocation = async () => {
+    try {
+      const result = await request(BACKGROUND_LOCATION_PERMISSION);
+      await refreshLocationStatus();
+      if (result === RESULTS.GRANTED) {
+        // Fetch so geofences register now (auto-fetch already ran this process).
+        CustomerIO.location.requestLocationUpdate();
+        showMessage({
+          message: 'Background location granted — fetching location to start geofence',
+          type: 'success',
+        });
+      } else if (result === RESULTS.BLOCKED) {
+        showOpenSettingsDialog();
+      } else {
+        // iOS resolves the "Always" prompt asynchronously; the button updates on
+        // resume, which fetches if granted. Point the user to Settings otherwise.
+        showMessage({
+          message:
+            'Requesting background location — enable "Always" in Settings if no prompt appears',
+          type: 'info',
+        });
+      }
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const showBackgroundRationale = () => {
+    Alert.alert(
+      'Allow background location?',
+      'Geofence transitions only fire while the app is backgrounded if you grant ' +
+        '"Always" / "Allow all the time". If no prompt appears, use Open Settings.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Open Settings', onPress: () => Linking.openSettings() },
+        { text: 'Continue', onPress: () => requestBackgroundLocation() },
+      ]
+    );
+  };
+
+  /** State-aware Background Location action, matching the native sample apps. */
+  const handleBackgroundLocationTap = async () => {
+    switch (locationStatus) {
+      case 'foregroundOnly':
+        showBackgroundRationale();
+        return;
+      case 'backgroundGranted':
+        return;
+      case 'denied':
+        Linking.openSettings();
+        return;
+      default: {
+        // notDetermined: request foreground first, then escalate to background.
+        const result = await request(LOCATION_PERMISSION);
+        await refreshLocationStatus();
+        if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
+          // Foreground granted — fetch so geofences register, then offer background.
+          CustomerIO.location.requestLocationUpdate();
+          showBackgroundRationale();
+        } else if (result === RESULTS.BLOCKED) {
+          showOpenSettingsDialog();
+        } else {
+          showMessage({ message: 'Location permission denied', type: 'info' });
+        }
+      }
+    }
+  };
+
+  /** Request permission, then SDK fetches location once. */
   const handleRequestSdkLocationUpdate = async () => {
     try {
       const result = await request(LOCATION_PERMISSION);
+      await refreshLocationStatus();
       if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
         setSdkRequestingLabel(true);
         CustomerIO.location.requestLocationUpdate();
-        showMessage({
-          message: 'SDK requested location update',
-          type: 'success',
-        });
+        showMessage({ message: 'SDK requested location update', type: 'success' });
       } else if (result === RESULTS.DENIED || result === RESULTS.BLOCKED) {
         showLocationPermissionAlert();
       } else {
@@ -144,10 +307,11 @@ export const LocationScreen = () => {
     }
   };
 
-  /** Option 3: Request permission, get device location, then setLastKnownLocation. */
+  /** Request permission, get device location, then setLastKnownLocation. */
   const handleUseCurrentLocation = async () => {
     try {
       const result = await request(LOCATION_PERMISSION);
+      await refreshLocationStatus();
       if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
         setUseCurrentLocationLoading(true);
         Geolocation.getCurrentPosition(
@@ -189,11 +353,40 @@ export const LocationScreen = () => {
   return (
     <ScrollView contentContainerStyle={styles.scrollContent}>
       <View style={styles.container}>
-        {/* OPTION 1: QUICK PRESETS */}
+        {/* Background Location (geofence permission) */}
         <SectionCard>
-          <BodyText style={styles.sectionHeading}>
-            OPTION 1: QUICK PRESETS
+          <BodyText style={styles.sectionHeading}>Background Location</BodyText>
+          <Button
+            title={backgroundButtonLabel}
+            experience={ButtonExperience.callToAction}
+            onPress={handleBackgroundLocationTap}
+            disabled={!backgroundButtonEnabled}
+          />
+          <BodyText style={styles.hint}>
+            Geofence runs automatically once enabled, but needs background
+            ("Always" / "Allow all the time") location to deliver transitions
+            while the app is closed. This grants foreground access first, then
+            escalates to background.
           </BodyText>
+        </SectionCard>
+
+        {/* SDK Location */}
+        <SectionCard>
+          <BodyText style={styles.sectionHeading}>SDK Location</BodyText>
+          <Button
+            title="Request location once (SDK)"
+            experience={ButtonExperience.normal}
+            onPress={handleRequestSdkLocationUpdate}
+          />
+          <BodyText style={styles.hint}>
+            Ask for permission if needed, then SDK fetches location once. The SDK
+            stops any in-flight request when the app goes to background.
+          </BodyText>
+        </SectionCard>
+
+        {/* Quick Presets */}
+        <SectionCard>
+          <BodyText style={styles.sectionHeading}>Quick Presets</BodyText>
           <View style={styles.presetGrid}>
             {PRESETS.map(({ label, lat, lng }) => (
               <Button
@@ -208,31 +401,9 @@ export const LocationScreen = () => {
           <BodyText style={styles.hint}>Tap a city to set its coordinates</BodyText>
         </SectionCard>
 
-        <OrSeparator />
-
-        {/* OPTION 2: SDK LOCATION */}
+        {/* Use Current Location */}
         <SectionCard>
-          <BodyText style={styles.sectionHeading}>
-            OPTION 2: SDK LOCATION
-          </BodyText>
-          <Button
-            title="Request location once (SDK)"
-            experience={ButtonExperience.normal}
-            onPress={handleRequestSdkLocationUpdate}
-          />
-          <BodyText style={styles.hint}>
-            Ask for permission if needed, then SDK fetches location once. The SDK
-            stops any in-flight request when the app goes to background.
-          </BodyText>
-        </SectionCard>
-
-        <OrSeparator />
-
-        {/* OPTION 3: MANUALLY SET FROM DEVICE */}
-        <SectionCard>
-          <BodyText style={styles.sectionHeading}>
-            OPTION 3: MANUALLY SET FROM DEVICE
-          </BodyText>
+          <BodyText style={styles.sectionHeading}>Use Current Location</BodyText>
           <Button
             title={useCurrentLocationLoading ? '📍  Fetching...' : '📍  Use Current Location'}
             experience={ButtonExperience.normal}
@@ -242,18 +413,13 @@ export const LocationScreen = () => {
           />
           <BodyText style={styles.hint}>
             Fetches coordinates from device (GPS, Wi‑Fi, or cell) and sends them
-            to the SDK via setLastKnownLocation. Label shows source when known
-            (e.g. Simulated).
+            to the SDK via setLastKnownLocation.
           </BodyText>
         </SectionCard>
 
-        <OrSeparator />
-
-        {/* OPTION 4: MANUAL ENTRY */}
+        {/* Manual Entry */}
         <SectionCard>
-          <BodyText style={styles.sectionHeading}>
-            OPTION 4: MANUAL ENTRY
-          </BodyText>
+          <BodyText style={styles.sectionHeading}>Manual Entry</BodyText>
           <View style={styles.fieldBlock}>
             <BoldText style={styles.fieldLabel}>Latitude</BoldText>
             <TextInput
@@ -303,21 +469,7 @@ const styles = StyleSheet.create({
   },
   container: {
     padding: 16,
-    gap: 0,
-  },
-  orRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginVertical: 16,
-    gap: 12,
-  },
-  orLine: {
-    flex: 1,
-    height: StyleSheet.hairlineWidth,
-    backgroundColor: Colors.bodyText,
-  },
-  orText: {
-    opacity: 0.8,
+    gap: 16,
   },
   sectionCard: {
     padding: 16,
@@ -363,7 +515,7 @@ const styles = StyleSheet.create({
     ...systemWeights.regular,
   },
   statusCard: {
-    marginTop: 24,
+    marginTop: 8,
     padding: 16,
     borderRadius: 8,
     backgroundColor: Colors.bodySecondaryBg,

--- a/example/src/screens/location.tsx
+++ b/example/src/screens/location.tsx
@@ -141,7 +141,7 @@ export const LocationScreen = () => {
       // The SDK's auto-fetch hook runs once per process, so a grant made in Settings
       // needs an explicit request to register geofences this session.
       if (status && isGrantedStatus(status) && !isGrantedStatus(previous)) {
-        CustomerIO.location.requestLocationUpdate();
+        CustomerIO.geofence.refreshFromCurrentLocation();
       }
     });
     return () => subscription.remove();
@@ -222,8 +222,8 @@ export const LocationScreen = () => {
       const result = await request(BACKGROUND_LOCATION_PERMISSION);
       await refreshLocationStatus();
       if (result === RESULTS.GRANTED) {
-        // Fetch so geofences register now (auto-fetch already ran this process).
-        CustomerIO.location.requestLocationUpdate();
+        // Refresh geofences from the current location now (silent — no analytics event).
+        CustomerIO.geofence.refreshFromCurrentLocation();
         showMessage({
           message: 'Background location granted — fetching location to start geofence',
           type: 'success',
@@ -273,8 +273,8 @@ export const LocationScreen = () => {
         const result = await request(LOCATION_PERMISSION);
         await refreshLocationStatus();
         if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
-          // Foreground granted — fetch so geofences register, then offer background.
-          CustomerIO.location.requestLocationUpdate();
+          // Foreground granted — refresh geofences from current location, then offer background.
+          CustomerIO.geofence.refreshFromCurrentLocation();
           showBackgroundRationale();
         } else if (result === RESULTS.BLOCKED) {
           showOpenSettingsDialog();

--- a/example/src/screens/location.tsx
+++ b/example/src/screens/location.tsx
@@ -42,8 +42,10 @@ type LocationStatus =
   | 'backgroundGranted'
   | 'denied';
 
-const isGrantedStatus = (status: LocationStatus | null) =>
-  status === 'foregroundOnly' || status === 'backgroundGranted';
+// Higher = more access. Used to fetch only when the permission level increases
+// (e.g. gaining "Always" in Settings), never on a downgrade between states.
+const grantRank = (status: LocationStatus | null) =>
+  status === 'backgroundGranted' ? 2 : status === 'foregroundOnly' ? 1 : 0;
 
 const PRESETS: { label: string; lat: number; lng: number }[] = [
   { label: 'New York', lat: 40.7128, lng: -74.006 },
@@ -136,11 +138,11 @@ export const LocationScreen = () => {
       if (state !== 'active') return;
       const previous = locationStatusRef.current;
       const status = await refreshLocationStatus();
-      // Fetch only when gaining access from a non-granted state — not on a downgrade
-      // between granted states (e.g. revoking "Always" back to "When in Use" in Settings).
-      // The SDK's auto-fetch hook runs once per process, so a grant made in Settings
-      // needs an explicit request to register geofences this session.
-      if (status && isGrantedStatus(status) && !isGrantedStatus(previous)) {
+      // Fetch whenever the permission level increased (a grant made in Settings),
+      // including foregroundOnly → backgroundGranted; skip downgrades between states
+      // (e.g. revoking "Always" back to "When in Use"). The SDK's auto-fetch hook runs
+      // once per process, so a grant made in Settings needs an explicit request.
+      if (status && grantRank(status) > grantRank(previous)) {
         CustomerIO.geofence.refreshFromCurrentLocation();
       }
     });
@@ -195,7 +197,9 @@ export const LocationScreen = () => {
           ? "Upgrade to 'Always'"
           : 'Allow all the time';
       case 'backgroundGranted':
-        return Platform.OS === 'ios' ? 'Always — granted' : 'Background — granted';
+        return Platform.OS === 'ios'
+          ? '✓ Always — granted'
+          : '✓ Background — granted';
       case 'denied':
         return 'Open Settings';
       default:
@@ -220,8 +224,16 @@ export const LocationScreen = () => {
   const requestBackgroundLocation = async () => {
     try {
       const result = await request(BACKGROUND_LOCATION_PERMISSION);
-      await refreshLocationStatus();
-      if (result === RESULTS.GRANTED) {
+      const next = await refreshLocationStatus();
+      // A concurrent refresh (e.g. AppState resume on return from Settings) superseded
+      // this read and owns the outcome — don't act on the stale request payload.
+      if (next === null) {
+        return;
+      }
+      // The freshly-read status is the single source of truth: request() can lag
+      // behind the OS (e.g. "Always" enabled in Settings), and it can also report
+      // GRANTED when the fresh check still reads foregroundOnly — so trust `next`.
+      if (next === 'backgroundGranted') {
         // Refresh geofences from the current location now (silent — no analytics event).
         CustomerIO.geofence.refreshFromCurrentLocation();
         showMessage({
@@ -248,10 +260,10 @@ export const LocationScreen = () => {
     Alert.alert(
       'Allow background location?',
       'Geofence transitions only fire while the app is backgrounded if you grant ' +
-        '"Always" / "Allow all the time". If no prompt appears, use Open Settings.',
+        '"Always" / "Allow all the time". Continue and choose it when prompted — or ' +
+        'in Settings if no prompt appears.',
       [
         { text: 'Cancel', style: 'cancel' },
-        { text: 'Open Settings', onPress: () => Linking.openSettings() },
         { text: 'Continue', onPress: () => requestBackgroundLocation() },
       ]
     );
@@ -270,6 +282,10 @@ export const LocationScreen = () => {
         return;
       default: {
         // notDetermined: request foreground first, then escalate to background.
+        // The in-app foreground prompt makes request()'s result authoritative here
+        // (unlike the background/Settings path); a concurrent AppState refresh can
+        // supersede a status read, so branch on the result to avoid skipping the
+        // background rationale.
         const result = await request(LOCATION_PERMISSION);
         await refreshLocationStatus();
         if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
@@ -361,6 +377,7 @@ export const LocationScreen = () => {
             experience={ButtonExperience.callToAction}
             onPress={handleBackgroundLocationTap}
             disabled={!backgroundButtonEnabled}
+            style={backgroundButtonEnabled ? undefined : styles.buttonDone}
           />
           <BodyText style={styles.hint}>
             Geofence runs automatically once enabled, but needs background
@@ -377,6 +394,7 @@ export const LocationScreen = () => {
             title="Request location once (SDK)"
             experience={ButtonExperience.normal}
             onPress={handleRequestSdkLocationUpdate}
+            style={styles.secondaryButton}
           />
           <BodyText style={styles.hint}>
             Ask for permission if needed, then SDK fetches location once. The SDK
@@ -394,7 +412,7 @@ export const LocationScreen = () => {
                 title={label}
                 experience={ButtonExperience.normal}
                 onPress={() => handlePreset(lat, lng, label)}
-                style={styles.presetButton}
+                style={[styles.presetButton, styles.secondaryButton]}
               />
             ))}
           </View>
@@ -408,7 +426,7 @@ export const LocationScreen = () => {
             title={useCurrentLocationLoading ? '📍  Fetching...' : '📍  Use Current Location'}
             experience={ButtonExperience.normal}
             onPress={handleUseCurrentLocation}
-            style={styles.useCurrentButton}
+            style={[styles.useCurrentButton, styles.secondaryButton]}
             disabled={useCurrentLocationLoading}
           />
           <BodyText style={styles.hint}>
@@ -480,6 +498,15 @@ const styles = StyleSheet.create({
   sectionHeading: {
     fontWeight: '700',
     marginBottom: 4,
+  },
+  // Granted state: keep the CTA color but dim it so it reads as done, not actionable.
+  buttonDone: {
+    opacity: 0.55,
+  },
+  // Secondary buttons: darker fill so they stay visible against the card (which
+  // shares the default 'normal' button color).
+  secondaryButton: {
+    backgroundColor: Colors.bodyBg,
   },
   presetGrid: {
     flexDirection: 'row',

--- a/example/src/screens/settings.tsx
+++ b/example/src/screens/settings.tsx
@@ -10,6 +10,7 @@ import {
 import { Storage } from '@services';
 import {
   CioConfig,
+  CioLocationTrackingMode,
   CioLogLevel,
   CioRegion,
   CustomerIO,
@@ -56,6 +57,28 @@ export const SettingsScreen = () => {
           }}
           selectedValue={config.region ?? CioRegion.US}
           label="Region"
+        />
+
+        <SingleSelect<CioLocationTrackingMode>
+          data={[
+            { label: 'Off', value: CioLocationTrackingMode.Off },
+            { label: 'Manual', value: CioLocationTrackingMode.Manual },
+            {
+              label: 'On App Start',
+              value: CioLocationTrackingMode.OnAppStart,
+            },
+          ]}
+          onValueChange={(trackingMode) => {
+            setConfig({
+              ...config,
+              location: { ...config.location, trackingMode },
+            });
+          }}
+          selectedValue={
+            config.location?.trackingMode ?? CioLocationTrackingMode.OnAppStart
+          }
+          label="Location Tracking Mode"
+          fullWidth
         />
 
         <Switch

--- a/example/src/screens/settings.tsx
+++ b/example/src/screens/settings.tsx
@@ -75,7 +75,7 @@ export const SettingsScreen = () => {
             });
           }}
           selectedValue={
-            config.location?.trackingMode ?? CioLocationTrackingMode.OnAppStart
+            config.location?.trackingMode ?? CioLocationTrackingMode.Manual
           }
           label="Location Tracking Mode"
           fullWidth

--- a/example/src/services/storage.ts
+++ b/example/src/services/storage.ts
@@ -20,6 +20,9 @@ const createDefaultConfig = (env: Env | null | undefined): Config => {
     location: {
       trackingMode: CioLocationTrackingMode.OnAppStart,
     },
+    // Opt into geofence monitoring. Runs automatically once enabled and implies the
+    // Location module above.
+    geofence: {},
   };
 };
 
@@ -49,8 +52,10 @@ export class Storage {
     );
 
     this.user = userJsonPayload ? JSON.parse(userJsonPayload) : null;
+    // Merge persisted config over defaults so newly added default keys (e.g. the
+    // geofence opt-in) are present for installs saved before those keys existed.
     this.config = cioConfigJsonPayload
-      ? JSON.parse(cioConfigJsonPayload)
+      ? { ...Storage.defaultConfig, ...JSON.parse(cioConfigJsonPayload) }
       : null;
   };
 

--- a/example/src/services/storage.ts
+++ b/example/src/services/storage.ts
@@ -18,7 +18,7 @@ const createDefaultConfig = (env: Env | null | undefined): Config => {
     logLevel: CioLogLevel.Debug,
     trackApplicationLifecycleEvents: true,
     location: {
-      trackingMode: CioLocationTrackingMode.OnAppStart,
+      trackingMode: CioLocationTrackingMode.Manual,
     },
     // Opt into geofence monitoring. Runs automatically once enabled and implies the
     // Location module above.

--- a/ios/wrappers/NativeCustomerIO.swift
+++ b/ios/wrappers/NativeCustomerIO.swift
@@ -69,6 +69,15 @@ public class NativeCustomerIO: NSObject {
             }
             #endif
 
+            // Customer value wins; default on when the geofence module is added, off otherwise.
+            #if CIO_GEOFENCE_ENABLED
+            let geofenceAdded = config["geofence"] != nil
+            #else
+            let geofenceAdded = false
+            #endif
+            let allowBackgroundDelivery = (config["ios"] as? [String: Any])?["allowBackgroundDelivery"] as? Bool
+            _ = sdkConfigBuilder.allowBackgroundDelivery(allowBackgroundDelivery ?? geofenceAdded)
+
             let builtConfig = sdkConfigBuilder.build()
 
             // Only CustomerIO.initialize must run on the main thread (e.g. for Location module).

--- a/ios/wrappers/NativeCustomerIO.swift
+++ b/ios/wrappers/NativeCustomerIO.swift
@@ -49,8 +49,23 @@ public class NativeCustomerIO: NSObject {
             let sdkConfigBuilder = try SDKConfigBuilder.create(from: config)
 
             #if CIO_LOCATION_ENABLED
-            if let locationModule = NativeLocation.module(from: config) {
+            // Geofence implies location: register the location module whenever location
+            // config is provided or geofence is enabled, since geofence relies on the
+            // location module's fixes.
+            #if CIO_GEOFENCE_ENABLED
+            let geofenceConfigured = config["geofence"] != nil
+            #else
+            let geofenceConfigured = false
+            #endif
+            if let locationModule = NativeLocation.module(from: config, geofenceEnabled: geofenceConfigured) {
                 _ = sdkConfigBuilder.addModule(locationModule)
+            }
+            #endif
+
+            #if CIO_GEOFENCE_ENABLED
+            // Geofence runs automatically once registered; relies on the location module above.
+            if let geofenceModule = NativeGeofence.module(from: config) {
+                _ = sdkConfigBuilder.addModule(geofenceModule)
             }
             #endif
 

--- a/ios/wrappers/geofence/NativeGeofence.mm
+++ b/ios/wrappers/geofence/NativeGeofence.mm
@@ -1,0 +1,46 @@
+#import <React/RCTBridgeModule.h>
+#import <RNCustomerIOSpec/RNCustomerIOSpec.h>
+
+// Objective-C wrapper for new architecture TurboModule implementation
+@interface RCTNativeCustomerIOGeofence : NSObject <NativeCustomerIOGeofenceSpec>
+// Bridge to Swift implementation for cross-language compatibility
+@property(nonatomic, strong) id<NativeCustomerIOGeofenceSpec> swiftBridge;
+@end
+
+@implementation RCTNativeCustomerIOGeofence
+
+RCT_EXPORT_MODULE()
+
+// Create TurboModule instance for new architecture JSI integration
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params {
+  return std::make_shared<facebook::react::NativeCustomerIOGeofenceSpecJSI>(params);
+}
+
+- (instancetype)init {
+  if (self = [super init]) {
+    // Use runtime class lookup - NativeGeofence class only exists when the CioLocationGeofence subspec is installed
+    Class swiftClass = NSClassFromString(@"NativeCustomerIOGeofence");
+    if (swiftClass) {
+      _swiftBridge = [[swiftClass alloc] init];
+    }
+  }
+  return self;
+}
+
+// Module initialization can happen on background thread
++ (BOOL)requiresMainQueueSetup {
+  return NO;
+}
+
+- (void)refreshFromCurrentLocation {
+  if (!_swiftBridge) return;
+  [_swiftBridge refreshFromCurrentLocation];
+}
+
+// Export class factory function for React Native component registration
+Class<RCTBridgeModule> NativeCustomerIOGeofenceCls(void) {
+  return RCTNativeCustomerIOGeofence.class;
+}
+
+@end

--- a/ios/wrappers/geofence/NativeGeofence.swift
+++ b/ios/wrappers/geofence/NativeGeofence.swift
@@ -1,0 +1,20 @@
+#if CIO_GEOFENCE_ENABLED
+import CioLocationGeofence
+
+/// Registers the optional geofence module with the native iOS SDK.
+///
+/// Geofence has no app-facing methods — it runs automatically once registered — so this
+/// only parses the opt-in config and builds the module. The reference to `GeofenceModule`
+/// is isolated here so it is only compiled when the geofence subspec is installed. Geofence
+/// depends on the location module, which the caller registers alongside it.
+@objc(NativeCustomerIOGeofence)
+public class NativeGeofence: NSObject {
+
+    /// Returns a `GeofenceModule` when the app opts into geofence via the `geofence` config.
+    /// Geofence runs automatically once registered and has no options yet.
+    static func module(from config: [String: Any]) -> GeofenceModule? {
+        guard config["geofence"] != nil else { return nil }
+        return GeofenceModule()
+    }
+}
+#endif

--- a/ios/wrappers/geofence/NativeGeofence.swift
+++ b/ios/wrappers/geofence/NativeGeofence.swift
@@ -1,20 +1,27 @@
 #if CIO_GEOFENCE_ENABLED
+import CioDataPipelines
 import CioLocationGeofence
 
-/// Registers the optional geofence module with the native iOS SDK.
-///
-/// Geofence has no app-facing methods — it runs automatically once registered — so this
-/// only parses the opt-in config and builds the module. The reference to `GeofenceModule`
-/// is isolated here so it is only compiled when the geofence subspec is installed. Geofence
-/// depends on the location module, which the caller registers alongside it.
+/// Registers the optional geofence module with the native iOS SDK and exposes its app-facing
+/// methods. The reference to `GeofenceModule` is isolated here so it is only compiled when the
+/// geofence subspec is installed. Geofence depends on the location module, which the caller
+/// registers alongside it.
 @objc(NativeCustomerIOGeofence)
 public class NativeGeofence: NSObject {
 
-    /// Returns a `GeofenceModule` when the app opts into geofence via the `geofence` config.
-    /// Geofence runs automatically once registered and has no options yet.
+    /// Returns a `GeofenceModule` when the app opts into geofence via the `geofence` config,
+    /// applying the optional `locationMode` (defaults to `.automatic`).
     static func module(from config: [String: Any]) -> GeofenceModule? {
-        guard config["geofence"] != nil else { return nil }
-        return GeofenceModule()
+        guard let geofenceConfig = config["geofence"] as? [String: Any] else { return nil }
+        let locationModeValue = geofenceConfig["locationMode"] as? String
+        let locationMode: GeofenceLocationMode =
+            locationModeValue?.uppercased() == "MANUAL" ? .manual : .automatic
+        return GeofenceModule(config: GeofenceModuleConfig(locationMode: locationMode))
+    }
+
+    @objc
+    func refreshFromCurrentLocation() {
+        CustomerIO.geofence.refreshFromCurrentLocation()
     }
 }
 #endif

--- a/ios/wrappers/location/NativeLocation.swift
+++ b/ios/wrappers/location/NativeLocation.swift
@@ -6,11 +6,13 @@ import CoreLocation
 @objc(NativeCustomerIOLocation)
 public class NativeLocation: NSObject {
 
-    /// Parses the root config and returns a `LocationModule` if location config is present.
-    /// Keeps config parsing within the location module.
-    static func module(from config: [String: Any]) -> LocationModule? {
-        guard let locationConfig = config["location"] as? [String: Any] else { return nil }
-        let trackingModeValue = locationConfig["trackingMode"] as? String
+    /// Parses the root config and returns a `LocationModule` when location config is present
+    /// or when geofence is enabled (geofence depends on the location module). Keeps config
+    /// parsing within the location module. Defaults to `manual` tracking when no config is given.
+    static func module(from config: [String: Any], geofenceEnabled: Bool = false) -> LocationModule? {
+        let locationConfig = config["location"] as? [String: Any]
+        guard locationConfig != nil || geofenceEnabled else { return nil }
+        let trackingModeValue = locationConfig?["trackingMode"] as? String
         let mode: LocationTrackingMode
         switch trackingModeValue?.uppercased() {
         case "OFF":

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 4.5.3",
+  "cioNativeiOSSdkVersion": "= 4.7.0",
   "cioiOSFirebaseWrapperSdkVersion": "= 1.0.0",
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 4.7.0",
+  "cioNativeiOSSdkVersion": "= 4.6.1",
   "cioiOSFirebaseWrapperSdkVersion": "= 1.0.0",
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
         "NativeCustomerIOLogging": "RCTNativeCustomerIOLogging",
         "NativeCustomerIO": "RCTNativeCustomerIO",
         "NativeCustomerIOLocation": "RCTNativeCustomerIOLocation",
+        "NativeCustomerIOGeofence": "RCTNativeCustomerIOGeofence",
         "NativeCustomerIOMessagingInApp": "RCTNativeMessagingInApp",
         "NativeCustomerIOMessagingPush": "RCTNativeMessagingPush"
       }

--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -1,3 +1,4 @@
+import { CustomerIOGeofence } from './customerio-geofence';
 import { CustomerIOInAppMessaging } from './customerio-inapp';
 import { CustomerIOLocation } from './customerio-location';
 import { CustomerIOPushMessaging } from './customerio-push';
@@ -178,6 +179,7 @@ export class CustomerIO {
    */
   static readonly isInitialized = () => _initialized;
 
+  static readonly geofence = new CustomerIOGeofence();
   static readonly inAppMessaging = new CustomerIOInAppMessaging();
   static readonly location = new CustomerIOLocation();
   static readonly pushMessaging = new CustomerIOPushMessaging();

--- a/src/customerio-geofence.ts
+++ b/src/customerio-geofence.ts
@@ -1,0 +1,12 @@
+/**
+ * Public entry point for the optional Geofence module.
+ *
+ * Geofence runs automatically once enabled — there are no app-facing methods yet.
+ * Apps opt in by passing a `geofence` config to `initialize` and enabling the module
+ * at build time: set `customerio_geofence_enabled=true` in `gradle.properties` (Android)
+ * or add the `geofence` subspec to your Podfile (iOS). Enabling geofence also enables
+ * the Location module, which geofence depends on.
+ *
+ * @public
+ */
+export class CustomerIOGeofence {}

--- a/src/customerio-geofence.ts
+++ b/src/customerio-geofence.ts
@@ -1,12 +1,56 @@
+import { type TurboModule } from 'react-native';
+import {
+  default as NativeModule,
+  type Spec as CodegenSpec,
+} from './specs/modules/NativeCustomerIOGeofence';
+
+/**
+ * Ensures all methods defined in codegen spec are implemented by the public module
+ *
+ * @internal
+ */
+interface NativeGeofenceSpec extends Omit<CodegenSpec, keyof TurboModule> {}
+
+// Geofence is an optional module — NativeModule may be null when geofence is not enabled.
+// Methods silently no-op when the native module is unavailable, with a one-time dev warning.
+let hasWarnedNotEnabled = false;
+const withNativeModule = (fn: (native: CodegenSpec) => void): void => {
+  if (NativeModule) {
+    fn(NativeModule);
+  } else if (__DEV__ && !hasWarnedNotEnabled) {
+    hasWarnedNotEnabled = true;
+    console.warn(
+      'Customer.io: Geofence module is not enabled. ' +
+        'To use geofence features, set customerio_geofence_enabled=true in ' +
+        'gradle.properties (Android) or add the geofence subspec to your Podfile (iOS).'
+    );
+  }
+};
+
 /**
  * Public entry point for the optional Geofence module.
  *
- * Geofence runs automatically once enabled — there are no app-facing methods yet.
- * Apps opt in by passing a `geofence` config to `initialize` and enabling the module
- * at build time: set `customerio_geofence_enabled=true` in `gradle.properties` (Android)
- * or add the `geofence` subspec to your Podfile (iOS). Enabling geofence also enables
- * the Location module, which geofence depends on.
+ * Geofence runs automatically once enabled. Apps opt in by passing a `geofence` config to
+ * `initialize` and enabling the module at build time: set `customerio_geofence_enabled=true`
+ * in `gradle.properties` (Android) or add the `geofence` subspec to your Podfile (iOS).
+ * Enabling geofence also enables the Location module, which geofence depends on.
  *
  * @public
  */
-export class CustomerIOGeofence {}
+export class CustomerIOGeofence implements NativeGeofenceSpec {
+  /**
+   * Requests a one-shot location fix and refreshes the nearby geofence set from it,
+   * without sending a location analytics event (unlike
+   * `CustomerIO.location.requestLocationUpdate()`) and without caching the fix.
+   *
+   * Call this after the host app has been granted location permission — the SDK never
+   * requests permission itself. It is the primary way to drive geofencing when the module
+   * is configured with `MANUAL` location mode; with the default `AUTOMATIC` the SDK acquires
+   * location on its own and this only forces an immediate refresh.
+   *
+   * No-ops if the geofence module is not enabled or a user has not been identified.
+   */
+  refreshFromCurrentLocation(): void {
+    return withNativeModule((native) => native.refreshFromCurrentLocation());
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
  * This file serves as the entry point for the module customerio-reactnative.
  */
 export * from './customerio-cdp';
+export * from './customerio-geofence';
 export * from './customerio-inapp';
 export * from './customerio-location';
 export * from './customerio-push';

--- a/src/specs/modules/NativeCustomerIOGeofence.ts
+++ b/src/specs/modules/NativeCustomerIOGeofence.ts
@@ -1,0 +1,14 @@
+import { TurboModuleRegistry, type TurboModule } from 'react-native';
+
+/**
+ * Native module specification for CustomerIO Geofence React Native SDK
+ *
+ * @see NativeCustomerIO.ts for detailed documentation on TurboModule patterns,
+ * Codegen compatibility, and type safety approach.
+ */
+
+export interface Spec extends TurboModule {
+  refreshFromCurrentLocation(): void;
+}
+
+export default TurboModuleRegistry.get<Spec>('NativeCustomerIOGeofence');

--- a/src/types/data-pipelines.ts
+++ b/src/types/data-pipelines.ts
@@ -82,6 +82,14 @@ export type CioConfig = {
    * also enables the Location module, which geofence depends on.
    */
   geofence?: {};
+  /** iOS-only SDK configuration. Has no effect on Android. */
+  ios?: {
+    /**
+     * Whether geofence transitions are delivered in real time on a background cold-wake.
+     * When unset, defaults to on if the geofence module is enabled, off otherwise.
+     */
+    allowBackgroundDelivery?: boolean;
+  };
 };
 
 /**

--- a/src/types/data-pipelines.ts
+++ b/src/types/data-pipelines.ts
@@ -76,6 +76,12 @@ export type CioConfig = {
     /** Location tracking mode. Defaults to 'manual' if location config is provided. */
     trackingMode?: CioLocationTrackingMode;
   };
+  /**
+   * Geofence configuration. Providing this opts the app into geofence monitoring,
+   * which runs automatically once enabled and has no options yet. Enabling geofence
+   * also enables the Location module, which geofence depends on.
+   */
+  geofence?: {};
 };
 
 /**

--- a/src/types/data-pipelines.ts
+++ b/src/types/data-pipelines.ts
@@ -78,10 +78,18 @@ export type CioConfig = {
   };
   /**
    * Geofence configuration. Providing this opts the app into geofence monitoring,
-   * which runs automatically once enabled and has no options yet. Enabling geofence
-   * also enables the Location module, which geofence depends on.
+   * which runs automatically once enabled. Enabling geofence also enables the
+   * Location module, which geofence depends on.
    */
-  geofence?: {};
+  geofence?: {
+    /**
+     * How the SDK acquires location fixes for geofence monitoring. Defaults to
+     * `AUTOMATIC` (the SDK acquires location itself on identify and app launch). Use
+     * `MANUAL` to drive refreshes yourself via
+     * `CustomerIO.geofence.refreshFromCurrentLocation()`.
+     */
+    locationMode?: CioGeofenceLocationMode;
+  };
   /** iOS-only SDK configuration. Has no effect on Android. */
   ios?: {
     /**
@@ -147,6 +155,18 @@ export enum CioLocationTrackingMode {
   Manual = 'MANUAL',
   /** SDK auto-captures location once per app launch when the app becomes active. */
   OnAppStart = 'ON_APP_START',
+}
+
+/**
+ * How the Geofence module acquires location fixes.
+ *
+ * @public
+ */
+export enum CioGeofenceLocationMode {
+  /** SDK acquires location itself (on identify and app launch). Default. */
+  Automatic = 'AUTOMATIC',
+  /** Host drives refreshes via `CustomerIO.geofence.refreshFromCurrentLocation()`. */
+  Manual = 'MANUAL',
 }
 
 /**


### PR DESCRIPTION
## Summary

Points the wrapper at the released native SDKs that ship geofence:
- `android/gradle.properties`: `cioSDKVersionAndroid` → `4.20.0`
- `package.json`: `cioNativeiOSSdkVersion` → `= 4.7.0`

> **Targets `feature/geofence-on-device`, not `main`. Nothing is released here.**

## What changed since review ✅

Native geofence is now **released** — Android [`4.20.0`](https://github.com/customerio/customerio-android/releases/tag/4.20.0) and iOS [`4.7.0`](https://github.com/customerio/customerio-ios/releases/tag/4.7.0) — so the temporary pre-release scaffolding this PR carried is gone, exactly as the merge plan described.

**Dropped (was Commit 2):** the snapshot Maven repo, the `feature-geofence-on-device-SNAPSHOT` example pin, the `customerio-ios` git-branch pods / CocoaPods override, the temporary `= 4.6.1` iOS pin, and the `feature-branch` Firebase CI line. The example app and CI now build against the released SDKs like any other change.

What's left is the single version-bump commit that was always the keeper — the two-commit / do-not-squash caveat no longer applies.

## Verification
- Android `4.20.0` on Maven Central, including the `io.customer.android:geofence` artifact the wrapper's `compileOnly`/`api` dependency needs.
- iOS `4.7.0` publishes the `CustomerIO/LocationGeofence` umbrella subspec that the wrapper's `geofence` subspec depends on, so it resolves from trunk with no git pod.

## Ticket
[MBL-1785 — React Native: add geofencing support](https://linear.app/customerio/issue/MBL-1785/react-native-add-geofencing-support)

## PR stack
1. #605 — geofence module base
2. #606 — register geofence module + geofence implies Location
3. #607 — iOS `allowBackgroundDelivery` config
4. #608 — enable geofence in the example app
5. 👉 **This PR** — native SDK version pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)
