### PR TITLE
chore: add location tracking mode to sample app settings

### DIFF
--- a/example/src/components/single-select.tsx
+++ b/example/src/components/single-select.tsx
@@ -10,6 +10,8 @@ type SingleSelectProps<T extends Key> = {
   selectedValue: T;
   onValueChange: (value: T) => void;
   label?: string;
+  /** Stack the label above the options and stretch the options to fill the width. */
+  fullWidth?: boolean;
 };
 
 export const SingleSelect = <T extends Key>({
@@ -17,18 +19,25 @@ export const SingleSelect = <T extends Key>({
   selectedValue,
   onValueChange,
   label,
+  fullWidth,
 }: SingleSelectProps<T>) => {
   const [value, setValue] = useState(selectedValue);
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, fullWidth && styles.containerFullWidth]}>
       {label && <BoldText style={styles.label}>{label}</BoldText>}
-      <View style={styles.selectionItems}>
+      <View
+        style={[
+          styles.selectionItems,
+          fullWidth && styles.selectionItemsFullWidth,
+        ]}
+      >
         {data.map((item, index) => (
           <TouchableOpacity
             key={item.value}
             style={[
               styles.itemContainer,
+              fullWidth && styles.itemContainerFullWidth,
               item.value === value && styles.selectedItemContainer,
               index === 0 && styles.firstItemContainer,
               index === data.length - 1 && styles.lastItemContainer,
@@ -62,15 +71,28 @@ const styles = StyleSheet.create({
     gap: 8,
   },
 
+  containerFullWidth: {
+    flexDirection: 'column',
+    alignItems: 'stretch',
+  },
+
   selectionItems: {
     flexDirection: 'row',
     alignItems: 'center',
     flexWrap: 'wrap',
   },
 
+  selectionItemsFullWidth: {
+    flexWrap: 'nowrap',
+  },
+
   itemContainer: {
     padding: 8,
     backgroundColor: Colors.secondaryBg,
+  },
+
+  itemContainerFullWidth: {
+    flex: 1,
   },
 
   selectedItemContainer: {

--- a/example/src/screens/settings.tsx
+++ b/example/src/screens/settings.tsx
@@ -10,6 +10,7 @@ import {
 import { Storage } from '@services';
 import {
   CioConfig,
+  CioLocationTrackingMode,
   CioLogLevel,
   CioRegion,
   CustomerIO,
@@ -56,6 +57,28 @@ export const SettingsScreen = () => {
           }}
           selectedValue={config.region ?? CioRegion.US}
           label="Region"
+        />
+
+        <SingleSelect<CioLocationTrackingMode>
+          data={[
+            { label: 'Off', value: CioLocationTrackingMode.Off },
+            { label: 'Manual', value: CioLocationTrackingMode.Manual },
+            {
+              label: 'On App Start',
+              value: CioLocationTrackingMode.OnAppStart,
+            },
+          ]}
+          onValueChange={(trackingMode) => {
+            setConfig({
+              ...config,
+              location: { ...config.location, trackingMode },
+            });
+          }}
+          selectedValue={
+            config.location?.trackingMode ?? CioLocationTrackingMode.OnAppStart
+          }
+          label="Location Tracking Mode"
+          fullWidth
         />
 
         <Switch


### PR DESCRIPTION
## Summary

Adds a **Location Tracking Mode** selector (Off / Manual / On App Start) to the example app's Settings screen, writing to `location.trackingMode`. The sample already defaulted location tracking to `On App Start`, but there was no way to view or change it from the UI.

- Defaults to `On App Start` (the sample app's existing default; note this differs from the SDK default of `Manual`).
- Adds an opt-in `fullWidth` prop to the shared `SingleSelect` component (used only by the new selector) so its options stretch across the screen. Existing selectors (e.g. Region) are unaffected.

Targets `feature/geofence-on-device`.

## Verified
Built and run on an Android device — the selector renders full-width under Region, defaults to On App Start, and switching modes + Save persists and re-initializes the SDK.

## Ticket
[MBL-1785 — React Native: add geofencing support](https://linear.app/customerio/issue/MBL-1785/react-native-add-geofencing-support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-app UI and layout-only `SingleSelect` changes; no SDK or production auth/data paths touched.
> 
> **Overview**
> Adds a **Location Tracking Mode** control to the example app Settings screen so developers can choose Off, Manual, or On App Start and persist it on `config.location.trackingMode` (default **On App Start** when unset).
> 
> Introduces an optional **`fullWidth`** prop on `SingleSelect` that stacks the label above the option row and gives each option equal width; only the new location selector uses it, so existing controls like Region keep the prior layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7601beff25084989c91331b884a29d3fde10ef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->