### PR TITLE
chore: expose geofence locationMode config and refreshFromCurrentLocation

### DIFF
--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
+import io.customer.reactnative.sdk.geofence.NativeGeofenceModule
 import io.customer.reactnative.sdk.location.NativeLocationModule
 import io.customer.reactnative.sdk.logging.NativeCustomerIOLoggingModule
 import io.customer.reactnative.sdk.messaginginapp.InlineInAppMessageViewManager
@@ -35,6 +36,9 @@ class CustomerIOReactNativePackage : BaseReactPackage() {
             NativeCustomerIOModule.NAME -> NativeCustomerIOModule(reactContext = reactContext)
             NativeLocationModule.NAME -> if (BuildConfig.CIO_LOCATION_ENABLED) {
                 NativeLocationModule(reactContext)
+            } else null
+            NativeGeofenceModule.NAME -> if (BuildConfig.CIO_GEOFENCE_ENABLED) {
+                NativeGeofenceModule(reactContext)
             } else null
             NativeMessagingInAppModule.NAME -> NativeMessagingInAppModule(reactContext)
             NativeMessagingPushModule.NAME -> NativeMessagingPushModule(reactContext)
@@ -72,6 +76,7 @@ class CustomerIOReactNativePackage : BaseReactPackage() {
             NativeCustomerIOLoggingModule.NAME,
             NativeCustomerIOModule.NAME,
             NativeLocationModule.NAME,
+            NativeGeofenceModule.NAME,
             NativeMessagingInAppModule.NAME,
             NativeMessagingPushModule.NAME,
         )

--- a/android/src/main/java/io/customer/reactnative/sdk/geofence/NativeGeofenceModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/geofence/NativeGeofenceModule.kt
@@ -1,30 +1,65 @@
 package io.customer.reactnative.sdk.geofence
 
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.annotations.ReactModule
+import io.customer.geofence.GeofenceLocationMode
 import io.customer.geofence.GeofenceModuleConfig
 import io.customer.geofence.ModuleGeofence
+import io.customer.reactnative.sdk.NativeCustomerIOGeofenceSpec
+import io.customer.reactnative.sdk.extension.getTypedValue
 import io.customer.sdk.CustomerIOBuilder
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.Logger
 
 /**
- * Registers the optional geofence module with the native Android SDK.
+ * React Native module implementation for Customer.io Geofence Native SDK
+ * using TurboModules with new architecture.
  *
- * Geofence has no app-facing methods — it runs automatically once registered — so this is
- * not a TurboModule. The reference to [ModuleGeofence] is isolated here so the geofence
- * dependency is only loaded when the module is enabled and bundled. Geofence depends on the
- * location module, which the caller registers alongside it.
+ * The reference to [ModuleGeofence] is isolated in this file so the geofence dependency is
+ * only loaded when the module is enabled and bundled. Geofence depends on the location
+ * module, which the caller registers alongside it.
  */
-internal object NativeGeofenceModule {
-    /**
-     * Adds the geofence module to the native Android SDK.
-     *
-     * @param builder instance of CustomerIOBuilder to add the geofence module.
-     * @param config configuration provided by the customer app for the geofence module.
-     */
-    fun addNativeModuleFromConfig(
-        builder: CustomerIOBuilder,
-        @Suppress("UNUSED_PARAMETER") config: Map<String, Any>
-    ) {
-        builder.addCustomerIOModule(
-            ModuleGeofence(GeofenceModuleConfig.Builder().build())
-        )
+@ReactModule(name = NativeGeofenceModule.NAME)
+class NativeGeofenceModule(
+    private val reactContext: ReactApplicationContext,
+) : NativeCustomerIOGeofenceSpec(reactContext) {
+    private val logger: Logger
+        get() = SDKComponent.logger
+
+    private fun getModuleGeofence() = runCatching {
+        ModuleGeofence.instance()
+    }.onFailure {
+        logger.error("Geofence module is not initialized. Ensure geofence config is provided during SDK initialization.")
+    }.getOrNull()
+
+    override fun refreshFromCurrentLocation() {
+        getModuleGeofence()?.refreshFromCurrentLocation()
+    }
+
+    companion object {
+        const val NAME = "NativeCustomerIOGeofence"
+
+        /**
+         * Adds the geofence module to the native Android SDK based on the configuration
+         * provided by the customer app.
+         *
+         * @param builder instance of CustomerIOBuilder to add the geofence module.
+         * @param config configuration provided by the customer app for the geofence module.
+         */
+        internal fun addNativeModuleFromConfig(
+            builder: CustomerIOBuilder,
+            config: Map<String, Any>
+        ) {
+            val locationModeValue = config.getTypedValue<String>("locationMode")
+            // Uppercase before matching so casing can't diverge from iOS (which uppercases too);
+            // enumValueOf is case-sensitive. Unknown values fall back to the SDK default.
+            val locationMode = locationModeValue?.let { value ->
+                runCatching { enumValueOf<GeofenceLocationMode>(value.uppercase()) }.getOrNull()
+            }
+
+            val configBuilder = GeofenceModuleConfig.Builder()
+            locationMode?.let { configBuilder.setLocationMode(it) }
+            builder.addCustomerIOModule(ModuleGeofence(configBuilder.build()))
+        }
     }
 }

--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -39,11 +39,19 @@ export type CioConfig = {
     location?: {
         trackingMode?: CioLocationTrackingMode;
     };
-    geofence?: {};
+    geofence?: {
+        locationMode?: CioGeofenceLocationMode;
+    };
     ios?: {
         allowBackgroundDelivery?: boolean;
     };
 };
+
+// @public
+export enum CioGeofenceLocationMode {
+    Automatic = "AUTOMATIC",
+    Manual = "MANUAL"
+}
 
 // @public
 export enum CioLocationTrackingMode {
@@ -114,8 +122,11 @@ export class CustomerIO {
     }) => Promise<void>;
 }
 
+// Warning: (ae-forgotten-export) The symbol "NativeGeofenceSpec" needs to be exported by the entry point index.d.ts
+//
 // @public
-export class CustomerIOGeofence {
+export class CustomerIOGeofence implements NativeGeofenceSpec {
+    refreshFromCurrentLocation(): void;
 }
 
 // Warning: (ae-forgotten-export) The symbol "NativeInAppSpec" needs to be exported by the entry point index.d.ts

--- a/example/src/screens/location.tsx
+++ b/example/src/screens/location.tsx
@@ -141,7 +141,7 @@ export const LocationScreen = () => {
       // The SDK's auto-fetch hook runs once per process, so a grant made in Settings
       // needs an explicit request to register geofences this session.
       if (status && isGrantedStatus(status) && !isGrantedStatus(previous)) {
-        CustomerIO.location.requestLocationUpdate();
+        CustomerIO.geofence.refreshFromCurrentLocation();
       }
     });
     return () => subscription.remove();
@@ -222,8 +222,8 @@ export const LocationScreen = () => {
       const result = await request(BACKGROUND_LOCATION_PERMISSION);
       await refreshLocationStatus();
       if (result === RESULTS.GRANTED) {
-        // Fetch so geofences register now (auto-fetch already ran this process).
-        CustomerIO.location.requestLocationUpdate();
+        // Refresh geofences from the current location now (silent — no analytics event).
+        CustomerIO.geofence.refreshFromCurrentLocation();
         showMessage({
           message: 'Background location granted — fetching location to start geofence',
           type: 'success',
@@ -273,8 +273,8 @@ export const LocationScreen = () => {
         const result = await request(LOCATION_PERMISSION);
         await refreshLocationStatus();
         if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
-          // Foreground granted — fetch so geofences register, then offer background.
-          CustomerIO.location.requestLocationUpdate();
+          // Foreground granted — refresh geofences from current location, then offer background.
+          CustomerIO.geofence.refreshFromCurrentLocation();
           showBackgroundRationale();
         } else if (result === RESULTS.BLOCKED) {
           showOpenSettingsDialog();

--- a/ios/wrappers/geofence/NativeGeofence.mm
+++ b/ios/wrappers/geofence/NativeGeofence.mm
@@ -1,0 +1,46 @@
+#import <React/RCTBridgeModule.h>
+#import <RNCustomerIOSpec/RNCustomerIOSpec.h>
+
+// Objective-C wrapper for new architecture TurboModule implementation
+@interface RCTNativeCustomerIOGeofence : NSObject <NativeCustomerIOGeofenceSpec>
+// Bridge to Swift implementation for cross-language compatibility
+@property(nonatomic, strong) id<NativeCustomerIOGeofenceSpec> swiftBridge;
+@end
+
+@implementation RCTNativeCustomerIOGeofence
+
+RCT_EXPORT_MODULE()
+
+// Create TurboModule instance for new architecture JSI integration
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params {
+  return std::make_shared<facebook::react::NativeCustomerIOGeofenceSpecJSI>(params);
+}
+
+- (instancetype)init {
+  if (self = [super init]) {
+    // Use runtime class lookup - NativeGeofence class only exists when the CioLocationGeofence subspec is installed
+    Class swiftClass = NSClassFromString(@"NativeCustomerIOGeofence");
+    if (swiftClass) {
+      _swiftBridge = [[swiftClass alloc] init];
+    }
+  }
+  return self;
+}
+
+// Module initialization can happen on background thread
++ (BOOL)requiresMainQueueSetup {
+  return NO;
+}
+
+- (void)refreshFromCurrentLocation {
+  if (!_swiftBridge) return;
+  [_swiftBridge refreshFromCurrentLocation];
+}
+
+// Export class factory function for React Native component registration
+Class<RCTBridgeModule> NativeCustomerIOGeofenceCls(void) {
+  return RCTNativeCustomerIOGeofence.class;
+}
+
+@end

--- a/ios/wrappers/geofence/NativeGeofence.swift
+++ b/ios/wrappers/geofence/NativeGeofence.swift
@@ -1,20 +1,27 @@
 #if CIO_GEOFENCE_ENABLED
+import CioDataPipelines
 import CioLocationGeofence
 
-/// Registers the optional geofence module with the native iOS SDK.
-///
-/// Geofence has no app-facing methods — it runs automatically once registered — so this
-/// only parses the opt-in config and builds the module. The reference to `GeofenceModule`
-/// is isolated here so it is only compiled when the geofence subspec is installed. Geofence
-/// depends on the location module, which the caller registers alongside it.
+/// Registers the optional geofence module with the native iOS SDK and exposes its app-facing
+/// methods. The reference to `GeofenceModule` is isolated here so it is only compiled when the
+/// geofence subspec is installed. Geofence depends on the location module, which the caller
+/// registers alongside it.
 @objc(NativeCustomerIOGeofence)
 public class NativeGeofence: NSObject {
 
-    /// Returns a `GeofenceModule` when the app opts into geofence via the `geofence` config.
-    /// Geofence runs automatically once registered and has no options yet.
+    /// Returns a `GeofenceModule` when the app opts into geofence via the `geofence` config,
+    /// applying the optional `locationMode` (defaults to `.automatic`).
     static func module(from config: [String: Any]) -> GeofenceModule? {
-        guard config["geofence"] != nil else { return nil }
-        return GeofenceModule()
+        guard let geofenceConfig = config["geofence"] as? [String: Any] else { return nil }
+        let locationModeValue = geofenceConfig["locationMode"] as? String
+        let locationMode: GeofenceLocationMode =
+            locationModeValue?.uppercased() == "MANUAL" ? .manual : .automatic
+        return GeofenceModule(config: GeofenceModuleConfig(locationMode: locationMode))
+    }
+
+    @objc
+    func refreshFromCurrentLocation() {
+        CustomerIO.geofence.refreshFromCurrentLocation()
     }
 }
 #endif

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
         "NativeCustomerIOLogging": "RCTNativeCustomerIOLogging",
         "NativeCustomerIO": "RCTNativeCustomerIO",
         "NativeCustomerIOLocation": "RCTNativeCustomerIOLocation",
+        "NativeCustomerIOGeofence": "RCTNativeCustomerIOGeofence",
         "NativeCustomerIOMessagingInApp": "RCTNativeMessagingInApp",
         "NativeCustomerIOMessagingPush": "RCTNativeMessagingPush"
       }

--- a/src/customerio-geofence.ts
+++ b/src/customerio-geofence.ts
@@ -1,12 +1,56 @@
+import { type TurboModule } from 'react-native';
+import {
+  default as NativeModule,
+  type Spec as CodegenSpec,
+} from './specs/modules/NativeCustomerIOGeofence';
+
+/**
+ * Ensures all methods defined in codegen spec are implemented by the public module
+ *
+ * @internal
+ */
+interface NativeGeofenceSpec extends Omit<CodegenSpec, keyof TurboModule> {}
+
+// Geofence is an optional module — NativeModule may be null when geofence is not enabled.
+// Methods silently no-op when the native module is unavailable, with a one-time dev warning.
+let hasWarnedNotEnabled = false;
+const withNativeModule = (fn: (native: CodegenSpec) => void): void => {
+  if (NativeModule) {
+    fn(NativeModule);
+  } else if (__DEV__ && !hasWarnedNotEnabled) {
+    hasWarnedNotEnabled = true;
+    console.warn(
+      'Customer.io: Geofence module is not enabled. ' +
+        'To use geofence features, set customerio_geofence_enabled=true in ' +
+        'gradle.properties (Android) or add the geofence subspec to your Podfile (iOS).'
+    );
+  }
+};
+
 /**
  * Public entry point for the optional Geofence module.
  *
- * Geofence runs automatically once enabled — there are no app-facing methods yet.
- * Apps opt in by passing a `geofence` config to `initialize` and enabling the module
- * at build time: set `customerio_geofence_enabled=true` in `gradle.properties` (Android)
- * or add the `geofence` subspec to your Podfile (iOS). Enabling geofence also enables
- * the Location module, which geofence depends on.
+ * Geofence runs automatically once enabled. Apps opt in by passing a `geofence` config to
+ * `initialize` and enabling the module at build time: set `customerio_geofence_enabled=true`
+ * in `gradle.properties` (Android) or add the `geofence` subspec to your Podfile (iOS).
+ * Enabling geofence also enables the Location module, which geofence depends on.
  *
  * @public
  */
-export class CustomerIOGeofence {}
+export class CustomerIOGeofence implements NativeGeofenceSpec {
+  /**
+   * Requests a one-shot location fix and refreshes the nearby geofence set from it,
+   * without sending a location analytics event (unlike
+   * `CustomerIO.location.requestLocationUpdate()`) and without caching the fix.
+   *
+   * Call this after the host app has been granted location permission — the SDK never
+   * requests permission itself. It is the primary way to drive geofencing when the module
+   * is configured with `MANUAL` location mode; with the default `AUTOMATIC` the SDK acquires
+   * location on its own and this only forces an immediate refresh.
+   *
+   * No-ops if the geofence module is not enabled or a user has not been identified.
+   */
+  refreshFromCurrentLocation(): void {
+    return withNativeModule((native) => native.refreshFromCurrentLocation());
+  }
+}

--- a/src/specs/modules/NativeCustomerIOGeofence.ts
+++ b/src/specs/modules/NativeCustomerIOGeofence.ts
@@ -1,0 +1,14 @@
+import { TurboModuleRegistry, type TurboModule } from 'react-native';
+
+/**
+ * Native module specification for CustomerIO Geofence React Native SDK
+ *
+ * @see NativeCustomerIO.ts for detailed documentation on TurboModule patterns,
+ * Codegen compatibility, and type safety approach.
+ */
+
+export interface Spec extends TurboModule {
+  refreshFromCurrentLocation(): void;
+}
+
+export default TurboModuleRegistry.get<Spec>('NativeCustomerIOGeofence');

--- a/src/types/data-pipelines.ts
+++ b/src/types/data-pipelines.ts
@@ -78,10 +78,18 @@ export type CioConfig = {
   };
   /**
    * Geofence configuration. Providing this opts the app into geofence monitoring,
-   * which runs automatically once enabled and has no options yet. Enabling geofence
-   * also enables the Location module, which geofence depends on.
+   * which runs automatically once enabled. Enabling geofence also enables the
+   * Location module, which geofence depends on.
    */
-  geofence?: {};
+  geofence?: {
+    /**
+     * How the SDK acquires location fixes for geofence monitoring. Defaults to
+     * `AUTOMATIC` (the SDK acquires location itself on identify and app launch). Use
+     * `MANUAL` to drive refreshes yourself via
+     * `CustomerIO.geofence.refreshFromCurrentLocation()`.
+     */
+    locationMode?: CioGeofenceLocationMode;
+  };
   /** iOS-only SDK configuration. Has no effect on Android. */
   ios?: {
     /**
@@ -147,6 +155,18 @@ export enum CioLocationTrackingMode {
   Manual = 'MANUAL',
   /** SDK auto-captures location once per app launch when the app becomes active. */
   OnAppStart = 'ON_APP_START',
+}
+
+/**
+ * How the Geofence module acquires location fixes.
+ *
+ * @public
+ */
+export enum CioGeofenceLocationMode {
+  /** SDK acquires location itself (on identify and app launch). Default. */
+  Automatic = 'AUTOMATIC',
+  /** Host drives refreshes via `CustomerIO.geofence.refreshFromCurrentLocation()`. */
+  Manual = 'MANUAL',
 }
 
 /**


### PR DESCRIPTION
## Summary

Exposes the geofence module's new native config and method in the React Native wrapper.

- **Config** — `CioGeofenceLocationMode` (`Automatic` default / `Manual`) via `geofence.locationMode`, wired to `GeofenceModuleConfig` on both platforms.
- **Method** — `CustomerIO.geofence.refreshFromCurrentLocation()`: a new geofence TurboModule that acquires a one-shot location fix **silently** — no `CIO Location Update` analytics event and no caching — unlike `CustomerIO.location.requestLocationUpdate()`. In `Manual` mode it's how the host drives geofencing; in `Automatic` (default) the SDK self-acquires and this only forces an immediate refresh.

Adds the geofence TurboModule mirroring the location module (spec + JS + Android/iOS native + codegen registration), gated on `CIO_GEOFENCE_ENABLED`. String→enum parsing is uppercased on both platforms so casing can't diverge.

## Sample app
The geofence permission-flow now drives geofencing via `geofence.refreshFromCurrentLocation()` (silent, no analytics event); the location-module `requestLocationUpdate()` demo is left unchanged.

## Requires (native)
Depends on the native changes below. Until they're released, builds resolve the new API from the feature-branch snapshot / branch, so CI on `feature/geofence-on-device` stays red until then — consistent with the rest of the feature branch.
- customerio-android#768
- customerio-ios#1140

## Ticket
[MBL-1978 — Route geofence location updates through an internal API](https://linear.app/customerio/issue/MBL-1978/route-geofence-location-updates-through-an-internal-api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches background location and geofence registration behavior via a new public API and init wiring; risk is moderated by optional build-time gating and no-op when the module is disabled, but incorrect use after permission changes could affect geofence delivery.
> 
> **Overview**
> Adds a **geofence TurboModule** and public JS API so apps can configure how geofences get location and trigger a **silent** refresh (no location analytics event, unlike `CustomerIO.location.requestLocationUpdate()`).
> 
> **`initialize` config** — `geofence.locationMode` accepts `CioGeofenceLocationMode` (`AUTOMATIC` default / `MANUAL`), wired on Android to `GeofenceModuleConfig` and on iOS to `GeofenceModuleConfig` with uppercased string parsing on both platforms.
> 
> **`CustomerIO.geofence.refreshFromCurrentLocation()`** — codegen spec, optional-module wrapper (no-op + one-time dev warning when disabled), and native implementations on Android (`NativeGeofenceModule` behind `CIO_GEOFENCE_ENABLED`) and iOS (new `NativeGeofence.mm` TurboModule bridge + Swift method). Package registration and `codegenConfig` include `NativeCustomerIOGeofence`.
> 
> The **example** geofence/permission flows call `refreshFromCurrentLocation()` after grants instead of `location.requestLocationUpdate()`; the SDK location demo path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15d9c9b0ef92d0fdf72e3cc5c42644132ecb7c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->