### PR TITLE
chore: align sample location mode with SDK default and polish location screen

### DIFF
--- a/example/src/screens/location.tsx
+++ b/example/src/screens/location.tsx
@@ -42,8 +42,10 @@ type LocationStatus =
   | 'backgroundGranted'
   | 'denied';
 
-const isGrantedStatus = (status: LocationStatus | null) =>
-  status === 'foregroundOnly' || status === 'backgroundGranted';
+// Higher = more access. Used to fetch only when the permission level increases
+// (e.g. gaining "Always" in Settings), never on a downgrade between states.
+const grantRank = (status: LocationStatus | null) =>
+  status === 'backgroundGranted' ? 2 : status === 'foregroundOnly' ? 1 : 0;
 
 const PRESETS: { label: string; lat: number; lng: number }[] = [
   { label: 'New York', lat: 40.7128, lng: -74.006 },
@@ -136,11 +138,11 @@ export const LocationScreen = () => {
       if (state !== 'active') return;
       const previous = locationStatusRef.current;
       const status = await refreshLocationStatus();
-      // Fetch only when gaining access from a non-granted state — not on a downgrade
-      // between granted states (e.g. revoking "Always" back to "When in Use" in Settings).
-      // The SDK's auto-fetch hook runs once per process, so a grant made in Settings
-      // needs an explicit request to register geofences this session.
-      if (status && isGrantedStatus(status) && !isGrantedStatus(previous)) {
+      // Fetch whenever the permission level increased (a grant made in Settings),
+      // including foregroundOnly → backgroundGranted; skip downgrades between states
+      // (e.g. revoking "Always" back to "When in Use"). The SDK's auto-fetch hook runs
+      // once per process, so a grant made in Settings needs an explicit request.
+      if (status && grantRank(status) > grantRank(previous)) {
         CustomerIO.geofence.refreshFromCurrentLocation();
       }
     });
@@ -195,7 +197,9 @@ export const LocationScreen = () => {
           ? "Upgrade to 'Always'"
           : 'Allow all the time';
       case 'backgroundGranted':
-        return Platform.OS === 'ios' ? 'Always — granted' : 'Background — granted';
+        return Platform.OS === 'ios'
+          ? '✓ Always — granted'
+          : '✓ Background — granted';
       case 'denied':
         return 'Open Settings';
       default:
@@ -220,8 +224,15 @@ export const LocationScreen = () => {
   const requestBackgroundLocation = async () => {
     try {
       const result = await request(BACKGROUND_LOCATION_PERMISSION);
-      await refreshLocationStatus();
-      if (result === RESULTS.GRANTED) {
+      const next = await refreshLocationStatus();
+      // A concurrent refresh (e.g. AppState resume on return from Settings) superseded
+      // this read and owns the outcome — don't act on the stale request payload.
+      if (next === null) {
+        return;
+      }
+      // Trust the freshly-read status: the OS may already show background granted
+      // (e.g. enabled in Settings) even when the request result comes back denied.
+      if (next === 'backgroundGranted' || result === RESULTS.GRANTED) {
         // Refresh geofences from the current location now (silent — no analytics event).
         CustomerIO.geofence.refreshFromCurrentLocation();
         showMessage({
@@ -248,10 +259,10 @@ export const LocationScreen = () => {
     Alert.alert(
       'Allow background location?',
       'Geofence transitions only fire while the app is backgrounded if you grant ' +
-        '"Always" / "Allow all the time". If no prompt appears, use Open Settings.',
+        '"Always" / "Allow all the time". Continue and choose it when prompted — or ' +
+        'in Settings if no prompt appears.',
       [
         { text: 'Cancel', style: 'cancel' },
-        { text: 'Open Settings', onPress: () => Linking.openSettings() },
         { text: 'Continue', onPress: () => requestBackgroundLocation() },
       ]
     );
@@ -361,6 +372,7 @@ export const LocationScreen = () => {
             experience={ButtonExperience.callToAction}
             onPress={handleBackgroundLocationTap}
             disabled={!backgroundButtonEnabled}
+            style={backgroundButtonEnabled ? undefined : styles.buttonDone}
           />
           <BodyText style={styles.hint}>
             Geofence runs automatically once enabled, but needs background
@@ -377,6 +389,7 @@ export const LocationScreen = () => {
             title="Request location once (SDK)"
             experience={ButtonExperience.normal}
             onPress={handleRequestSdkLocationUpdate}
+            style={styles.secondaryButton}
           />
           <BodyText style={styles.hint}>
             Ask for permission if needed, then SDK fetches location once. The SDK
@@ -394,7 +407,7 @@ export const LocationScreen = () => {
                 title={label}
                 experience={ButtonExperience.normal}
                 onPress={() => handlePreset(lat, lng, label)}
-                style={styles.presetButton}
+                style={[styles.presetButton, styles.secondaryButton]}
               />
             ))}
           </View>
@@ -408,7 +421,7 @@ export const LocationScreen = () => {
             title={useCurrentLocationLoading ? '📍  Fetching...' : '📍  Use Current Location'}
             experience={ButtonExperience.normal}
             onPress={handleUseCurrentLocation}
-            style={styles.useCurrentButton}
+            style={[styles.useCurrentButton, styles.secondaryButton]}
             disabled={useCurrentLocationLoading}
           />
           <BodyText style={styles.hint}>
@@ -480,6 +493,15 @@ const styles = StyleSheet.create({
   sectionHeading: {
     fontWeight: '700',
     marginBottom: 4,
+  },
+  // Granted state: keep the CTA color but dim it so it reads as done, not actionable.
+  buttonDone: {
+    opacity: 0.55,
+  },
+  // Secondary buttons: darker fill so they stay visible against the card (which
+  // shares the default 'normal' button color).
+  secondaryButton: {
+    backgroundColor: Colors.bodyBg,
   },
   presetGrid: {
     flexDirection: 'row',

--- a/example/src/screens/location.tsx
+++ b/example/src/screens/location.tsx
@@ -230,9 +230,10 @@ export const LocationScreen = () => {
       if (next === null) {
         return;
       }
-      // Trust the freshly-read status: the OS may already show background granted
-      // (e.g. enabled in Settings) even when the request result comes back denied.
-      if (next === 'backgroundGranted' || result === RESULTS.GRANTED) {
+      // The freshly-read status is the single source of truth: request() can lag
+      // behind the OS (e.g. "Always" enabled in Settings), and it can also report
+      // GRANTED when the fresh check still reads foregroundOnly — so trust `next`.
+      if (next === 'backgroundGranted') {
         // Refresh geofences from the current location now (silent — no analytics event).
         CustomerIO.geofence.refreshFromCurrentLocation();
         showMessage({
@@ -282,8 +283,13 @@ export const LocationScreen = () => {
       default: {
         // notDetermined: request foreground first, then escalate to background.
         const result = await request(LOCATION_PERMISSION);
-        await refreshLocationStatus();
-        if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
+        const next = await refreshLocationStatus();
+        // A concurrent refresh superseded this read and owns the outcome.
+        if (next === null) {
+          return;
+        }
+        // Trust the freshly-read status (same as requestBackgroundLocation).
+        if (next === 'foregroundOnly' || next === 'backgroundGranted') {
           // Foreground granted — refresh geofences from current location, then offer background.
           CustomerIO.geofence.refreshFromCurrentLocation();
           showBackgroundRationale();

--- a/example/src/screens/location.tsx
+++ b/example/src/screens/location.tsx
@@ -282,14 +282,13 @@ export const LocationScreen = () => {
         return;
       default: {
         // notDetermined: request foreground first, then escalate to background.
+        // The in-app foreground prompt makes request()'s result authoritative here
+        // (unlike the background/Settings path); a concurrent AppState refresh can
+        // supersede a status read, so branch on the result to avoid skipping the
+        // background rationale.
         const result = await request(LOCATION_PERMISSION);
-        const next = await refreshLocationStatus();
-        // A concurrent refresh superseded this read and owns the outcome.
-        if (next === null) {
-          return;
-        }
-        // Trust the freshly-read status (same as requestBackgroundLocation).
-        if (next === 'foregroundOnly' || next === 'backgroundGranted') {
+        await refreshLocationStatus();
+        if (result === RESULTS.GRANTED || result === RESULTS.LIMITED) {
           // Foreground granted — refresh geofences from current location, then offer background.
           CustomerIO.geofence.refreshFromCurrentLocation();
           showBackgroundRationale();

--- a/example/src/screens/settings.tsx
+++ b/example/src/screens/settings.tsx
@@ -75,7 +75,7 @@ export const SettingsScreen = () => {
             });
           }}
           selectedValue={
-            config.location?.trackingMode ?? CioLocationTrackingMode.OnAppStart
+            config.location?.trackingMode ?? CioLocationTrackingMode.Manual
           }
           label="Location Tracking Mode"
           fullWidth

--- a/example/src/services/storage.ts
+++ b/example/src/services/storage.ts
@@ -18,7 +18,7 @@ const createDefaultConfig = (env: Env | null | undefined): Config => {
     logLevel: CioLogLevel.Debug,
     trackApplicationLifecycleEvents: true,
     location: {
-      trackingMode: CioLocationTrackingMode.OnAppStart,
+      trackingMode: CioLocationTrackingMode.Manual,
     },
     // Opt into geofence monitoring. Runs automatically once enabled and implies the
     // Location module above.


### PR DESCRIPTION
## Summary

Sample-app (`example/`) tweaks for the geofence Location screen. **No SDK changes** — `src/` and the public API are untouched.

> Targets `feature/geofence-on-device`, not `main`.

## Changes

- **Location tracking mode default → `Manual`.** The sample previously forced `On App Start`, which differs from the SDK's own default (`Manual`, applied when a location config is provided). Now the sample matches the SDK so it demonstrates default behavior. All three options stay selectable in Settings.
- **Background permission prompt.** Dropped the redundant "Open Settings" button — Continue already reaches the system prompt / Settings — while keeping the explanatory "what to do next" copy. Cancel + Continue remain.
- **Granted background button.** Keeps the call-to-action color but dims it and prefixes a check ("✓ … granted") so it reads as done rather than actionable, once background access is granted.
- **Secondary buttons.** The non-CTA buttons (SDK request, presets, use-current) shared the card's background color and blended in. Given them a darker fill so they render as distinct controls. (Pre-existing on `main` too; fixed here since it's a one-line style.)
- **Background-location fetch refinements.** Refresh geofences on any permission-*level increase* — including `foregroundOnly → backgroundGranted` (enabling "Always" in Settings), which the previous "granted vs not-granted" check missed. Also guard `requestBackgroundLocation` against a concurrent refresh (AppState resume on return from Settings) superseding its read, and trust the freshly-read OS status so a grant already applied in Settings is honored even when `request()` returns a stale non-granted result.

## Testing

Verified on an Android device: Settings shows `Manual` by default; the background prompt shows Cancel + Continue with Continue routing to the system permission flow; the granted button dims with the check; and the SDK / preset / use-current buttons are now visible against the cards.

## Ticket

[MBL-2148 — Align sample app location mode with SDK defaults](https://linear.app/customerio/issue/MBL-2148/mobile-align-sample-app-location-mode-with-sdk-defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the example app’s location screen, settings default, and storage defaults with no production SDK or security impact.
> 
> **Overview**
> **Sample app only** — no SDK or public API changes.
> 
> The example app’s default **location tracking mode** is now **`Manual`** (in `storage.ts` and Settings’ fallback), matching the native SDK default instead of **`On App Start`**.
> 
> On the **Location** screen, background permission handling is tightened: **`grantRank`** triggers `CustomerIO.geofence.refreshFromCurrentLocation()` on any permission *level increase* (including **foreground → Always** from Settings), not only the first transition into a “granted” state. **`requestBackgroundLocation`** bails out if a concurrent refresh superseded the read, and treats the freshly checked OS status as authoritative over `request()`’s result.
> 
> UX tweaks: granted background CTA shows **✓** and is dimmed via **`buttonDone`**; secondary actions use a darker **`secondaryButton`** fill; the background rationale drops redundant **Open Settings** in favor of **Continue** with clearer copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e095a58b6ed2357d866d625dbc2b685f01df6a8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

