### PR TITLE
feat(live-activities): expose Live Activities / Live Notifications

### DIFF
--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
+import io.customer.reactnative.sdk.liveactivities.NativeLiveActivitiesModule
 import io.customer.reactnative.sdk.location.NativeLocationModule
 import io.customer.reactnative.sdk.logging.NativeCustomerIOLoggingModule
 import io.customer.reactnative.sdk.messaginginapp.InlineInAppMessageViewManager
@@ -33,6 +34,7 @@ class CustomerIOReactNativePackage : BaseReactPackage() {
             InlineInAppMessageViewManager.NAME -> InlineInAppMessageViewManager()
             NativeCustomerIOLoggingModule.NAME -> NativeCustomerIOLoggingModule(reactContext)
             NativeCustomerIOModule.NAME -> NativeCustomerIOModule(reactContext = reactContext)
+            NativeLiveActivitiesModule.NAME -> NativeLiveActivitiesModule(reactContext)
             NativeLocationModule.NAME -> if (BuildConfig.CIO_LOCATION_ENABLED) {
                 NativeLocationModule(reactContext)
             } else null
@@ -71,6 +73,7 @@ class CustomerIOReactNativePackage : BaseReactPackage() {
             InlineInAppMessageViewManager.NAME,
             NativeCustomerIOLoggingModule.NAME,
             NativeCustomerIOModule.NAME,
+            NativeLiveActivitiesModule.NAME,
             NativeLocationModule.NAME,
             NativeMessagingInAppModule.NAME,
             NativeMessagingPushModule.NAME,

--- a/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
@@ -89,11 +89,14 @@ class NativeCustomerIOModule(
                 packageConfig.getTypedValue<String>(Keys.Config.CDN_HOST)
                     ?.let { cdnHost(it) }
 
-                // Configure push messaging module based on config provided by customer app
+                // Configure push messaging module based on config provided by customer app.
+                // Live Activities are hosted by the FCM push module, so the `liveActivities`
+                // config is applied to the same module.
                 packageConfig.getTypedValue<Map<String, Any>>(key = "push").let { pushConfig ->
                     NativeMessagingPushModule.addNativeModuleFromConfig(
                         builder = this,
-                        config = pushConfig ?: emptyMap()
+                        config = pushConfig ?: emptyMap(),
+                        liveActivitiesConfig = packageConfig.getTypedValue<Map<String, Any>>(key = "liveActivities")
                     )
                 }
                 // Configure in-app messaging module based on config provided by customer app

--- a/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
@@ -1,0 +1,200 @@
+package io.customer.reactnative.sdk.liveactivities
+
+import android.graphics.Color
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.module.annotations.ReactModule
+import io.customer.messagingpush.MessagingPushModuleConfig
+import io.customer.messagingpush.ModuleMessagingPushFCM
+import io.customer.messagingpush.livenotification.LiveNotificationAsset
+import io.customer.messagingpush.livenotification.LiveNotificationBranding
+import io.customer.messagingpush.livenotification.LiveNotificationData
+import io.customer.messagingpush.livenotification.LiveNotificationType
+import io.customer.reactnative.sdk.NativeCustomerIOLiveActivitiesSpec
+import io.customer.reactnative.sdk.extension.getTypedValue
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.Logger
+
+/**
+ * React Native module implementation for Customer.io Live Activities / Live Notifications
+ * using TurboModules with new architecture.
+ *
+ * Live Notifications live on the FCM push module ([ModuleMessagingPushFCM]); this bridge
+ * maps the wrapper's template payloads to [LiveNotificationData] and forwards them.
+ */
+@ReactModule(name = NativeLiveActivitiesModule.NAME)
+class NativeLiveActivitiesModule(
+    private val reactContext: ReactApplicationContext,
+) : NativeCustomerIOLiveActivitiesSpec(reactContext) {
+    private val logger: Logger
+        get() = SDKComponent.logger
+
+    // Live Notifications are hosted by the FCM push module. Reach it via the module registry
+    // (the wrapper can't reference the SDK-internal MODULE_NAME constant, so use the literal).
+    private fun getPushModule(): ModuleMessagingPushFCM? = runCatching {
+        SDKComponent.modules[PUSH_FCM_MODULE_NAME] as? ModuleMessagingPushFCM
+    }.onFailure {
+        logger.error("Live Notifications: push module is not initialized. Ensure the SDK is initialized with live activity templates enabled.")
+    }.getOrNull()
+
+    override fun start(payload: ReadableMap?, promise: Promise?) {
+        val module = getPushModule() ?: return promise.rejectNotAvailable()
+        try {
+            val data = parseData(requireNotNull(payload) { "payload is required" })
+            promise?.resolve(module.startLiveNotification(data))
+        } catch (ex: Throwable) {
+            promise?.reject("live_activity_start_failed", ex.message, ex)
+        }
+    }
+
+    override fun update(activityId: String?, payload: ReadableMap?, promise: Promise?) {
+        val module = getPushModule() ?: return promise.rejectNotAvailable()
+        try {
+            val id = requireNotNull(activityId) { "activityId is required" }
+            val data = parseData(requireNotNull(payload) { "payload is required" })
+            module.updateLiveNotification(id, data)
+            promise?.resolve(null)
+        } catch (ex: Throwable) {
+            promise?.reject("live_activity_update_failed", ex.message, ex)
+        }
+    }
+
+    override fun end(activityId: String?, promise: Promise?) {
+        val module = getPushModule() ?: return promise.rejectNotAvailable()
+        try {
+            module.endLiveNotification(requireNotNull(activityId) { "activityId is required" })
+            promise?.resolve(null)
+        } catch (ex: Throwable) {
+            promise?.reject("live_activity_end_failed", ex.message, ex)
+        }
+    }
+
+    override fun startCustom(
+        activityType: String?,
+        payload: ReadableMap?,
+        promise: Promise?,
+    ) {
+        val module = getPushModule() ?: return promise.rejectNotAvailable()
+        try {
+            val type = requireNotNull(activityType) { "activityType is required" }
+            val data = payload?.toHashMap() ?: emptyMap<String, Any?>()
+            promise?.resolve(module.startLiveNotification(type, data))
+        } catch (ex: Throwable) {
+            promise?.reject("live_activity_start_custom_failed", ex.message, ex)
+        }
+    }
+
+    override fun handleDeepLinkOpen(url: String?, promise: Promise?) {
+        // Deep-link/opened attribution for Live Activities is an iOS-only concept; no-op on Android.
+        promise?.resolve(false)
+    }
+
+    private fun parseData(payload: ReadableMap): LiveNotificationData {
+        return when (val type = payload.getString("type")) {
+            "segments" -> LiveNotificationData.Segments(
+                header = payload.requireString("header"),
+                status = payload.requireString("status"),
+                substatus = payload.optString("substatus"),
+                segmentsTotal = payload.requireDouble("segmentsTotal").toInt(),
+                segmentsComplete = payload.requireDouble("segmentsComplete").toInt(),
+                trailingText = payload.optString("trailingText"),
+            )
+
+            "countdownTimer" -> LiveNotificationData.CountdownTimer(
+                header = payload.requireString("header"),
+                title = payload.requireString("title"),
+                statusMessage = payload.optString("statusMessage"),
+                endTime = if (payload.hasKey("endTime") && !payload.isNull("endTime")) {
+                    payload.getDouble("endTime").toLong()
+                } else {
+                    null
+                },
+            )
+
+            else -> throw IllegalArgumentException("Unknown live activity template type: $type")
+        }
+    }
+
+    private fun ReadableMap.requireString(key: String): String =
+        requireNotNull(if (hasKey(key)) getString(key) else null) { "$key is required" }
+
+    private fun ReadableMap.optString(key: String): String? =
+        if (hasKey(key) && !isNull(key)) getString(key) else null
+
+    private fun ReadableMap.requireDouble(key: String): Double {
+        require(hasKey(key) && !isNull(key)) { "$key is required" }
+        return getDouble(key)
+    }
+
+    private fun Promise?.rejectNotAvailable() {
+        this?.reject(
+            "live_activity_module_unavailable",
+            "Live Notifications are unavailable. Enable live activity templates in the SDK config.",
+        )
+    }
+
+    companion object {
+        const val NAME = "NativeCustomerIOLiveActivities"
+
+        // The SDK's ModuleMessagingPushFCM.MODULE_NAME is `internal`, so we mirror its value here.
+        private const val PUSH_FCM_MODULE_NAME = "MessagingPushFCM"
+
+        /**
+         * Applies live activity configuration onto the FCM push module's config builder. Live
+         * Notifications are hosted by [ModuleMessagingPushFCM], so their config (enabled templates,
+         * custom types, branding) is set on the same [MessagingPushModuleConfig].
+         *
+         * @param builder the push module's config builder.
+         * @param config the `liveActivities` config map from the customer app.
+         */
+        internal fun applyLiveActivitiesConfig(
+            builder: MessagingPushModuleConfig.Builder,
+            config: Map<String, Any>,
+        ) {
+            val templateTypes = config.getTypedValue<List<*>>("templates")
+                ?.mapNotNull { it as? String }
+                ?.mapNotNull { name ->
+                    when (name) {
+                        "segments" -> LiveNotificationType.SEGMENTS
+                        "countdownTimer" -> LiveNotificationType.COUNTDOWN_TIMER
+                        else -> null
+                    }
+                }
+                .orEmpty()
+            if (templateTypes.isNotEmpty()) {
+                builder.enableLiveNotificationTypes(*templateTypes.toTypedArray())
+            }
+
+            val customTypes = config.getTypedValue<List<*>>("customTypes")
+                ?.mapNotNull { it as? String }
+                .orEmpty()
+            if (customTypes.isNotEmpty()) {
+                builder.enableCustomLiveNotificationTypes(*customTypes.toTypedArray())
+            }
+
+            val branding = config.getTypedValue<Map<String, Any>>("branding")
+            if (branding != null) {
+                val accentColor = branding.getTypedValue<String>("accentColorHex")
+                    ?.let { runCatching { Color.parseColor(it) }.getOrNull() }
+                    ?: Color.TRANSPARENT
+                val logoUrl = branding.getTypedValue<String>("logoUrl")
+                val smallIcon = branding.getTypedValue<String>("smallIconResource")
+                    ?.let { name ->
+                        val context = SDKComponent.android().applicationContext
+                        context.resources
+                            .getIdentifier(name, "drawable", context.packageName)
+                            .takeIf { it != 0 }
+                    }
+                builder.setLiveNotificationBranding(
+                    LiveNotificationBranding(
+                        companyName = branding.getTypedValue<String>("companyName").orEmpty(),
+                        accentColor = accentColor,
+                        smallIcon = smallIcon,
+                        logo = logoUrl?.let { LiveNotificationAsset.RemoteUrl(it) },
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/NativeMessagingPushModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/NativeMessagingPushModule.kt
@@ -21,6 +21,7 @@ import io.customer.messagingpush.di.pushModuleConfig
 import io.customer.messagingpush.di.pushTrackingUtil
 import io.customer.reactnative.sdk.NativeCustomerIOMessagingPushSpec
 import io.customer.reactnative.sdk.constant.Keys
+import io.customer.reactnative.sdk.liveactivities.NativeLiveActivitiesModule
 import io.customer.reactnative.sdk.extension.getTypedValue
 import io.customer.reactnative.sdk.extension.takeIfNotBlank
 import io.customer.reactnative.sdk.util.unsupportedOnAndroid
@@ -257,7 +258,8 @@ class NativeMessagingPushModule(
          */
         internal fun addNativeModuleFromConfig(
             builder: CustomerIOBuilder,
-            config: Map<String, Any>
+            config: Map<String, Any>,
+            liveActivitiesConfig: Map<String, Any>? = null,
         ) {
             val androidConfig =
                 config.getTypedValue<Map<String, Any>>(key = "android") ?: emptyMap()
@@ -275,6 +277,14 @@ class NativeMessagingPushModule(
             val module = ModuleMessagingPushFCM(
                 moduleConfig = MessagingPushModuleConfig.Builder().apply {
                     setPushClickBehavior(pushClickBehavior = pushClickBehavior)
+                    // Live Notifications are hosted by the FCM push module, so their config is
+                    // applied to the same MessagingPushModuleConfig.
+                    liveActivitiesConfig?.let { liveConfig ->
+                        NativeLiveActivitiesModule.applyLiveActivitiesConfig(
+                            builder = this,
+                            config = liveConfig,
+                        )
+                    }
                 }.build(),
             )
             builder.addCustomerIOModule(module)

--- a/customerio-reactnative.podspec
+++ b/customerio-reactnative.podspec
@@ -57,4 +57,14 @@ Pod::Spec.new do |s|
       'OTHER_SWIFT_FLAGS' => '$(inherited) -DCIO_LOCATION_ENABLED'
     }
   end
+
+  # Live Activities module is optional - customers must opt in by adding this subspec, and must
+  # also add a Widget Extension target that renders the built-in templates. See the docs.
+  s.subspec "liveactivities" do |ss|
+    ss.dependency "CustomerIO/LiveActivities", package["cioNativeiOSSdkVersion"]
+    ss.dependency "CustomerIO/LiveActivitiesTemplates", package["cioNativeiOSSdkVersion"]
+    ss.pod_target_xcconfig = {
+      'OTHER_SWIFT_FLAGS' => '$(inherited) -DCIO_LIVEACTIVITIES_ENABLED'
+    }
+  end
 end

--- a/docs/live-activities.md
+++ b/docs/live-activities.md
@@ -1,0 +1,106 @@
+# Live Activities (iOS) / Live Notifications (Android)
+
+The `CustomerIO.liveActivities` module shows a live, updating notification driven by a
+built-in template. Two templates ship today: **Segments** and **Countdown Timer**.
+
+- **Android** renders built-in templates entirely inside the SDK — **no native code required**.
+- **iOS** requires a **Widget Extension** in your app to render (ActivityKit has no data-only
+  entry point). The SwiftUI for the built-in templates ships in the SDK, so your widget file is
+  ~10 lines (below). Live Activities need **iOS 16.2+** (push-to-start needs 17.2+).
+
+## Enable templates at init
+
+```ts
+import { CustomerIO } from 'customerio-reactnative';
+
+CustomerIO.initialize({
+  cdpApiKey: '…',
+  liveActivities: {
+    templates: ['segments', 'countdownTimer'],
+    // Android-only branding (iOS branding is compiled into the widget):
+    branding: { companyName: 'Acme', accentColorHex: '#FF6D00', logoUrl: 'https://…/logo.png' },
+  },
+});
+```
+
+## Start / update / end
+
+```ts
+// Segments
+const id = await CustomerIO.liveActivities.start({
+  type: 'segments',
+  header: 'Order #4021',
+  status: 'Preparing your order',
+  segmentsTotal: 4,
+  segmentsComplete: 1,
+});
+
+// update() replaces the whole content-state — pass the FULL desired state each time.
+await CustomerIO.liveActivities.update(id, {
+  type: 'segments',
+  header: 'Order #4021',
+  status: 'Out for delivery',
+  segmentsTotal: 4,
+  segmentsComplete: 3,
+});
+
+await CustomerIO.liveActivities.end(id);
+
+// Countdown Timer — endTime is epoch SECONDS
+const c = await CustomerIO.liveActivities.start({
+  type: 'countdownTimer',
+  header: 'Flash Sale',
+  title: '50% off ends in',
+  endTime: Math.floor(Date.now() / 1000) + 3600,
+});
+```
+
+`start` resolves with an `activityId` — the only handle you need for `update`/`end`. There is
+no lifecycle event callback; delivery/lifecycle metrics are reported to Customer.io automatically.
+
+### Custom types
+
+`startCustom(activityType, data)` starts an app-defined type. **Android** renders it via your
+`CustomerIOPushNotificationCallback.createLiveNotification` callback. **On iOS this rejects** —
+custom types require a native Widget Extension + `ActivityAttributes` and an `adopt()` call.
+
+### Deep-link / opened metric (iOS)
+
+Call `CustomerIO.liveActivities.handleDeepLinkOpen(url)` from your URL-handling entry point to
+report an `opened` metric when the app is opened from a tapped Live Activity. No-op on Android.
+
+## iOS setup (one time)
+
+1. Add the Live Activities pods to your app target's Podfile:
+   ```ruby
+   pod 'customerio-reactnative/liveactivities'
+   ```
+2. Add `NSSupportsLiveActivities = YES` to your app's `Info.plist`.
+3. Add a **Widget Extension** target (File ▸ New ▸ Target ▸ Widget Extension). In its Podfile
+   target, add:
+   ```ruby
+   pod 'CustomerIO/LiveActivitiesTemplates'
+   pod 'CustomerIO/LiveActivitiesAttributes'
+   ```
+4. Replace the generated widget bundle with the built-in templates:
+   ```swift
+   import WidgetKit
+   import CioLiveActivities_Templates   // ships CIOSegmentsLiveActivity, CIOCountdownTimerLiveActivity
+   import CioLiveActivities_Attributes
+
+   @main
+   struct CIOLiveActivitiesWidgets: WidgetBundle {
+       var body: some Widget {
+           CIOSegmentsLiveActivity()
+           CIOCountdownTimerLiveActivity()
+       }
+   }
+   ```
+
+> Expo apps can generate the widget extension automatically via the config plugin (planned).
+
+## Android setup
+
+Nothing beyond the standard `messaging-push-fcm` setup — built-in templates render in-SDK. For
+API 36+ the SDK uses `Notification.ProgressStyle`; older versions fall back to a native progress
+notification.

--- a/example/src/navigation/props.ts
+++ b/example/src/navigation/props.ts
@@ -12,6 +12,7 @@ export const CustomDeviceAttrScreenName = 'Device Attributes' as const;
 export const InternalSettingsScreenName = 'Internal Settings' as const;
 export const InlineExamplesScreenName = 'Inline Examples' as const;
 export const InboxMessagesScreenName = 'Inbox Messages' as const;
+export const LiveActivitiesScreenName = 'Live Activities' as const;
 export const LocationScreenName = 'Location' as const;
 
 export type NavigationStackParamList = {
@@ -25,6 +26,7 @@ export type NavigationStackParamList = {
   [InternalSettingsScreenName]: undefined;
   [InlineExamplesScreenName]: undefined;
   [InboxMessagesScreenName]: undefined;
+  [LiveActivitiesScreenName]: undefined;
   [LocationScreenName]: undefined;
 };
 

--- a/example/src/screens/content-navigator.tsx
+++ b/example/src/screens/content-navigator.tsx
@@ -5,6 +5,7 @@ import {
   InboxMessagesScreenName,
   InlineExamplesScreenName,
   InternalSettingsScreenName,
+  LiveActivitiesScreenName,
   LocationScreenName,
   LoginScreenName,
   NavigationCallbackContext,
@@ -23,6 +24,7 @@ import {
   InboxMessagesScreen,
   InlineExamplesScreen,
   InternalSettingsScreen,
+  LiveActivitiesScreen,
   LocationScreen,
   LogingScreen,
   SettingsScreen,
@@ -126,6 +128,15 @@ export const ContentNavigator = ({ appName }: { appName: string }) => {
           name={InboxMessagesScreenName}
           component={InboxMessagesScreen}
           options={{
+            headerBackButtonDisplayMode: 'minimal',
+            headerBackVisible: true,
+          }}
+        />
+        <Stack.Screen
+          name={LiveActivitiesScreenName}
+          component={LiveActivitiesScreen}
+          options={{
+            title: 'Live Activities',
             headerBackButtonDisplayMode: 'minimal',
             headerBackVisible: true,
           }}

--- a/example/src/screens/home.tsx
+++ b/example/src/screens/home.tsx
@@ -4,6 +4,7 @@ import {
   CustomProfileAttrScreenName,
   InboxMessagesScreenName,
   InlineExamplesScreenName,
+  LiveActivitiesScreenName,
   LocationScreenName,
   NavigationCallbackContext,
   NavigationScreenProps,
@@ -80,6 +81,10 @@ export const HomeScreen = ({
           <Button
             title="Location (test)"
             onPress={() => navigation.navigate(LocationScreenName)}
+          />
+          <Button
+            title="Live Activities"
+            onPress={() => navigation.navigate(LiveActivitiesScreenName)}
           />
         </View>
       </ScrollView>

--- a/example/src/screens/index.ts
+++ b/example/src/screens/index.ts
@@ -4,6 +4,7 @@ export * from './home';
 export * from './inbox-messages';
 export * from './inline-examples';
 export * from './internal-settings';
+export * from './liveactivities';
 export * from './location';
 export * from './login';
 export * from './settings';

--- a/example/src/screens/liveactivities.tsx
+++ b/example/src/screens/liveactivities.tsx
@@ -1,0 +1,161 @@
+import { BodyText, Button, ButtonExperience } from '@components';
+import { Colors } from '@colors';
+import { CustomerIO } from 'customerio-reactnative';
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { showMessage } from 'react-native-flash-message';
+
+const SectionCard = ({ children }: { children: React.ReactNode }) => (
+  <View style={styles.sectionCard}>{children}</View>
+);
+
+export const LiveActivitiesScreen = () => {
+  const [segmentsId, setSegmentsId] = useState<string | null>(null);
+  const [segmentsComplete, setSegmentsComplete] = useState(0);
+  const [countdownId, setCountdownId] = useState<string | null>(null);
+
+  const segmentsTotal = 4;
+
+  const startSegments = async () => {
+    try {
+      const id = await CustomerIO.liveActivities.start({
+        type: 'segments',
+        header: 'Order #4021',
+        status: 'Preparing your order',
+        segmentsTotal,
+        segmentsComplete: 1,
+      });
+      setSegmentsId(id);
+      setSegmentsComplete(1);
+      showMessage({ message: `Segments started (${id})`, type: 'success' });
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const advanceSegments = async () => {
+    if (!segmentsId) return;
+    const next = Math.min(segmentsComplete + 1, segmentsTotal);
+    try {
+      await CustomerIO.liveActivities.update(segmentsId, {
+        type: 'segments',
+        header: 'Order #4021',
+        status: next >= segmentsTotal ? 'Delivered' : 'Out for delivery',
+        segmentsTotal,
+        segmentsComplete: next,
+      });
+      setSegmentsComplete(next);
+      showMessage({ message: `Segments → ${next}/${segmentsTotal}`, type: 'success' });
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const endSegments = async () => {
+    if (!segmentsId) return;
+    try {
+      await CustomerIO.liveActivities.end(segmentsId);
+      showMessage({ message: 'Segments ended', type: 'info' });
+      setSegmentsId(null);
+      setSegmentsComplete(0);
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const startCountdown = async () => {
+    try {
+      const id = await CustomerIO.liveActivities.start({
+        type: 'countdownTimer',
+        header: 'Flash Sale',
+        title: '50% off ends in',
+        statusMessage: 'Hurry!',
+        endTime: Math.floor(Date.now() / 1000) + 3600, // epoch seconds, +1h
+      });
+      setCountdownId(id);
+      showMessage({ message: `Countdown started (${id})`, type: 'success' });
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const endCountdown = async () => {
+    if (!countdownId) return;
+    try {
+      await CustomerIO.liveActivities.end(countdownId);
+      showMessage({ message: 'Countdown ended', type: 'info' });
+      setCountdownId(null);
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.scrollContent}>
+      <View style={styles.container}>
+        <SectionCard>
+          <BodyText style={styles.sectionHeading}>SEGMENTS</BodyText>
+          <Button
+            title="Start Segments"
+            experience={ButtonExperience.callToAction}
+            onPress={startSegments}
+          />
+          <Button
+            title="Advance Segment (update)"
+            experience={ButtonExperience.normal}
+            onPress={advanceSegments}
+            disabled={!segmentsId}
+          />
+          <Button
+            title="End Segments"
+            experience={ButtonExperience.normal}
+            onPress={endSegments}
+            disabled={!segmentsId}
+          />
+          <BodyText style={styles.hint}>
+            {segmentsId
+              ? `Running: ${segmentsComplete}/${segmentsTotal}`
+              : 'Not started'}
+          </BodyText>
+        </SectionCard>
+
+        <SectionCard>
+          <BodyText style={styles.sectionHeading}>COUNTDOWN TIMER</BodyText>
+          <Button
+            title="Start Countdown (+1h)"
+            experience={ButtonExperience.callToAction}
+            onPress={startCountdown}
+          />
+          <Button
+            title="End Countdown"
+            experience={ButtonExperience.normal}
+            onPress={endCountdown}
+            disabled={!countdownId}
+          />
+          <BodyText style={styles.hint}>
+            {countdownId ? 'Running' : 'Not started'}
+          </BodyText>
+        </SectionCard>
+
+        <BodyText style={styles.note}>
+          Android renders live notifications in-SDK. iOS additionally requires a
+          Widget Extension in the app to render the built-in templates.
+        </BodyText>
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  scrollContent: { paddingBottom: 24 },
+  container: { padding: 16, gap: 16 },
+  sectionCard: {
+    padding: 16,
+    borderRadius: 8,
+    backgroundColor: Colors.bodySecondaryBg,
+    gap: 12,
+  },
+  sectionHeading: { fontWeight: '700', marginBottom: 4 },
+  hint: { opacity: 0.9, marginTop: 4 },
+  note: { opacity: 0.8, marginTop: 8, textAlign: 'center' },
+});

--- a/ios/wrappers/NativeCustomerIO.swift
+++ b/ios/wrappers/NativeCustomerIO.swift
@@ -64,6 +64,11 @@ public class NativeCustomerIO: NSObject {
                 }
                 CustomerIO.initialize(withConfig: builtConfig)
 
+                #if CIO_LIVEACTIVITIES_ENABLED
+                // Initialize Live Activities after CustomerIO.initialize (it reads the shared SDK).
+                NativeLiveActivities.initializeModule(from: config)
+                #endif
+
                 do {
                     // Initialize in-app messaging if config provided
                     if let inAppConfig = try MessagingInAppConfigBuilder.build(from: config) {

--- a/ios/wrappers/liveactivities/NativeLiveActivities.mm
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.mm
@@ -1,0 +1,93 @@
+#import <React/RCTBridgeModule.h>
+#import <RNCustomerIOSpec/RNCustomerIOSpec.h>
+
+// Objective-C wrapper for new architecture TurboModule implementation
+@interface RCTNativeLiveActivities : NSObject <NativeCustomerIOLiveActivitiesSpec>
+// Bridge to Swift implementation for cross-language compatibility
+@property(nonatomic, strong) id<NativeCustomerIOLiveActivitiesSpec> swiftBridge;
+@end
+
+@implementation RCTNativeLiveActivities
+
+RCT_EXPORT_MODULE()
+
+// Create TurboModule instance for new architecture JSI integration
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params {
+  return std::make_shared<facebook::react::NativeCustomerIOLiveActivitiesSpecJSI>(params);
+}
+
+- (instancetype)init {
+  if (self = [super init]) {
+    // Runtime class lookup - the Swift class only exists when the liveactivities subspec is installed.
+    Class swiftClass = NSClassFromString(@"NativeCustomerIOLiveActivities");
+    if (swiftClass) {
+      _swiftBridge = [[swiftClass alloc] init];
+    }
+  }
+  return self;
+}
+
+// Module initialization can happen on background thread
++ (BOOL)requiresMainQueueSetup {
+  return NO;
+}
+
+- (void)start:(NSDictionary *)payload
+      resolve:(RCTPromiseResolveBlock)resolve
+       reject:(RCTPromiseRejectBlock)reject {
+  if (!_swiftBridge) {
+    reject(@"live_activity_module_unavailable", @"Live Activities are unavailable.", nil);
+    return;
+  }
+  [_swiftBridge start:payload resolve:resolve reject:reject];
+}
+
+- (void)update:(NSString *)activityId
+       payload:(NSDictionary *)payload
+       resolve:(RCTPromiseResolveBlock)resolve
+        reject:(RCTPromiseRejectBlock)reject {
+  if (!_swiftBridge) {
+    reject(@"live_activity_module_unavailable", @"Live Activities are unavailable.", nil);
+    return;
+  }
+  [_swiftBridge update:activityId payload:payload resolve:resolve reject:reject];
+}
+
+- (void)end:(NSString *)activityId
+    resolve:(RCTPromiseResolveBlock)resolve
+     reject:(RCTPromiseRejectBlock)reject {
+  if (!_swiftBridge) {
+    reject(@"live_activity_module_unavailable", @"Live Activities are unavailable.", nil);
+    return;
+  }
+  [_swiftBridge end:activityId resolve:resolve reject:reject];
+}
+
+- (void)startCustom:(NSString *)activityType
+            payload:(NSDictionary *)payload
+            resolve:(RCTPromiseResolveBlock)resolve
+             reject:(RCTPromiseRejectBlock)reject {
+  if (!_swiftBridge) {
+    reject(@"live_activity_module_unavailable", @"Live Activities are unavailable.", nil);
+    return;
+  }
+  [_swiftBridge startCustom:activityType payload:payload resolve:resolve reject:reject];
+}
+
+- (void)handleDeepLinkOpen:(NSString *)url
+                   resolve:(RCTPromiseResolveBlock)resolve
+                    reject:(RCTPromiseRejectBlock)reject {
+  if (!_swiftBridge) {
+    resolve(@(NO));
+    return;
+  }
+  [_swiftBridge handleDeepLinkOpen:url resolve:resolve reject:reject];
+}
+
+// Export class factory function for React Native component registration
+Class<RCTBridgeModule> NativeCustomerIOLiveActivitiesCls(void) {
+  return RCTNativeLiveActivities.class;
+}
+
+@end

--- a/ios/wrappers/liveactivities/NativeLiveActivities.swift
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.swift
@@ -1,0 +1,202 @@
+#if CIO_LIVEACTIVITIES_ENABLED
+import ActivityKit
+import CioDataPipelines
+import CioLiveActivities
+import CioLiveActivities_Attributes
+import CioLiveActivities_Templates
+import Foundation
+
+@objc(NativeCustomerIOLiveActivities)
+public class NativeLiveActivities: NSObject {
+    /// The held Live Activities module (not a singleton in the native SDK), created during SDK init.
+    private static var module: LiveActivitiesModule?
+
+    /// Type-erased handles keyed by activity id. The native `start` returns a generic
+    /// `CIOLiveActivity<Attributes>` that can't cross the bridge, so we keep closures that capture
+    /// the concrete handle and rebuild its content-state from a JS map on update.
+    private struct ActivityBox {
+        let update: ([String: Any]) async throws -> Void
+        let end: () async -> Void
+    }
+
+    private static var activities: [String: ActivityBox] = [:]
+    private static let lock = NSLock()
+
+    // MARK: - Init from SDK config
+
+    /// Initialize the Live Activities module from the SDK config's `liveActivities` key. Registers
+    /// the enabled built-in template attribute types so `start` can request them.
+    static func initializeModule(from config: [String: Any]) {
+        guard let laConfig = config["liveActivities"] as? [String: Any] else { return }
+        guard #available(iOS 16.2, *) else { return }
+        let templates = (laConfig["templates"] as? [String]) ?? []
+        var builder = LiveActivityConfigBuilder()
+        if templates.contains("segments") {
+            builder = builder.register(CIOSegmentsAttributes.self)
+        }
+        if templates.contains("countdownTimer") {
+            builder = builder.register(CIOCountdownTimerAttributes.self)
+        }
+        module = LiveActivitiesModule.initialize(builder.build())
+    }
+
+    // MARK: - Bridge methods
+
+    @objc(start:resolve:reject:)
+    public func start(
+        _ payload: NSDictionary,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        guard #available(iOS 16.2, *), let module = Self.module else {
+            return reject(Self.unavailableCode, Self.unavailableMessage, nil)
+        }
+        guard let map = payload as? [String: Any], let type = map["type"] as? String else {
+            return reject("live_activity_start_failed", "payload.type is required", nil)
+        }
+        do {
+            let id: String
+            switch type {
+            case "segments":
+                let handle = try module.start(
+                    CIOSegmentsAttributes(header: map["header"] as? String ?? ""),
+                    contentState: Self.segmentsState(from: map)
+                )
+                Self.store(handle: handle, contentBuilder: Self.segmentsState)
+                id = handle.id
+            case "countdownTimer":
+                let handle = try module.start(
+                    CIOCountdownTimerAttributes(header: map["header"] as? String ?? ""),
+                    contentState: Self.countdownState(from: map)
+                )
+                Self.store(handle: handle, contentBuilder: Self.countdownState)
+                id = handle.id
+            default:
+                return reject("live_activity_start_failed", "Unknown live activity template type: \(type)", nil)
+            }
+            resolve(id)
+        } catch {
+            reject("live_activity_start_failed", error.localizedDescription, error)
+        }
+    }
+
+    @objc(update:payload:resolve:reject:)
+    public func update(
+        _ activityId: String,
+        payload: NSDictionary,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        Self.lock.lock()
+        let box = Self.activities[activityId]
+        Self.lock.unlock()
+        guard let box else {
+            return reject("live_activity_update_failed", "No live activity found for id \(activityId)", nil)
+        }
+        guard let map = payload as? [String: Any] else {
+            return reject("live_activity_update_failed", "payload is required", nil)
+        }
+        Task {
+            do {
+                try await box.update(map)
+                resolve(nil)
+            } catch {
+                reject("live_activity_update_failed", error.localizedDescription, error)
+            }
+        }
+    }
+
+    @objc(end:resolve:reject:)
+    public func end(
+        _ activityId: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject _: @escaping RCTPromiseRejectBlock
+    ) {
+        Self.lock.lock()
+        let box = Self.activities.removeValue(forKey: activityId)
+        Self.lock.unlock()
+        // Unknown/already-ended id is treated as success (idempotent end).
+        guard let box else { return resolve(nil) }
+        Task {
+            await box.end()
+            resolve(nil)
+        }
+    }
+
+    @objc(startCustom:payload:resolve:reject:)
+    public func startCustom(
+        _: String,
+        payload _: NSDictionary,
+        resolve _: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        // Custom activity types on iOS require a native Widget Extension + ActivityAttributes and an
+        // `adopt(_:)` call; they cannot be data-driven across the bridge.
+        reject(
+            "live_activity_custom_unsupported_ios",
+            "Custom live activity types are not supported from JavaScript on iOS. Use a native Widget Extension and adopt().",
+            nil
+        )
+    }
+
+    @objc(handleDeepLinkOpen:resolve:reject:)
+    public func handleDeepLinkOpen(
+        _ url: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject _: @escaping RCTPromiseRejectBlock
+    ) {
+        guard let module = Self.module, let parsed = URL(string: url) else {
+            return resolve(false)
+        }
+        resolve(module.handleDeepLinkOpen(parsed))
+    }
+
+    // MARK: - Helpers
+
+    @available(iOS 16.2, *)
+    private static func store<A: ActivityAttributes>(
+        handle: CIOLiveActivity<A>,
+        contentBuilder: @escaping ([String: Any]) throws -> A.ContentState
+    ) {
+        let box = ActivityBox(
+            update: { map in await handle.update(try contentBuilder(map)) },
+            end: { await handle.end() }
+        )
+        lock.lock()
+        activities[handle.id] = box
+        lock.unlock()
+    }
+
+    @available(iOS 16.2, *)
+    private static func segmentsState(from map: [String: Any]) throws -> CIOSegmentsAttributes.ContentState {
+        CIOSegmentsAttributes.ContentState(
+            status: map["status"] as? String ?? "",
+            substatus: map["substatus"] as? String,
+            segmentsTotal: intValue(map["segmentsTotal"]),
+            segmentsComplete: intValue(map["segmentsComplete"]),
+            trailingText: map["trailingText"] as? String
+        )
+    }
+
+    @available(iOS 16.2, *)
+    private static func countdownState(from map: [String: Any]) throws -> CIOCountdownTimerAttributes.ContentState {
+        var endTime: EpochSecondsDate?
+        if let seconds = map["endTime"] as? NSNumber {
+            endTime = EpochSecondsDate(Date(timeIntervalSince1970: seconds.doubleValue))
+        }
+        return CIOCountdownTimerAttributes.ContentState(
+            title: map["title"] as? String ?? "",
+            statusMessage: map["statusMessage"] as? String,
+            endTime: endTime
+        )
+    }
+
+    private static func intValue(_ any: Any?) -> Int {
+        (any as? NSNumber)?.intValue ?? 0
+    }
+
+    private static let unavailableCode = "live_activity_module_unavailable"
+    private static let unavailableMessage =
+        "Live Activities are unavailable. Enable live activity templates in the SDK config and add the widget extension."
+}
+#endif

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
       "modulesProvider": {
         "NativeCustomerIOLogging": "RCTNativeCustomerIOLogging",
         "NativeCustomerIO": "RCTNativeCustomerIO",
+        "NativeCustomerIOLiveActivities": "RCTNativeLiveActivities",
         "NativeCustomerIOLocation": "RCTNativeCustomerIOLocation",
         "NativeCustomerIOMessagingInApp": "RCTNativeMessagingInApp",
         "NativeCustomerIOMessagingPush": "RCTNativeMessagingPush"

--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -1,4 +1,5 @@
 import { CustomerIOInAppMessaging } from './customerio-inapp';
+import { CustomerIOLiveActivities } from './customerio-liveactivities';
 import { CustomerIOLocation } from './customerio-location';
 import { CustomerIOPushMessaging } from './customerio-push';
 import { NativeLoggerListener } from './native-logger-listener';
@@ -179,6 +180,7 @@ export class CustomerIO {
   static readonly isInitialized = () => _initialized;
 
   static readonly inAppMessaging = new CustomerIOInAppMessaging();
+  static readonly liveActivities = new CustomerIOLiveActivities();
   static readonly location = new CustomerIOLocation();
   static readonly pushMessaging = new CustomerIOPushMessaging();
 }

--- a/src/customerio-liveactivities.ts
+++ b/src/customerio-liveactivities.ts
@@ -1,0 +1,113 @@
+import { type TurboModule } from 'react-native';
+import {
+  default as NativeModule,
+  type Spec as CodegenSpec,
+} from './specs/modules/NativeCustomerIOLiveActivities';
+import type { LiveActivityPayload } from './types/live-activities';
+
+/**
+ * Ensures all methods defined in codegen spec are implemented by the public module
+ *
+ * @internal
+ */
+interface NativeLiveActivitiesSpec extends Omit<
+  CodegenSpec,
+  keyof TurboModule
+> {}
+
+// Live Activities is an optional module — NativeModule may be null when it is not
+// compiled in. Promise-returning methods reject with a clear error in that case.
+let hasWarnedNotEnabled = false;
+const withNativeModule = <T>(
+  fn: (native: CodegenSpec) => Promise<T>
+): Promise<T> => {
+  if (NativeModule) {
+    return fn(NativeModule);
+  }
+  if (__DEV__ && !hasWarnedNotEnabled) {
+    hasWarnedNotEnabled = true;
+    console.warn(
+      'Customer.io: Live Activities module is not available. ' +
+        'On iOS, add the CustomerIO Live Activities pods and a Widget Extension; ' +
+        'on Android it ships with messaging-push-fcm.'
+    );
+  }
+  return Promise.reject(
+    new Error('Customer.io: Live Activities module is not available.')
+  );
+};
+
+/**
+ * Live Activities (iOS) / Live Notifications (Android).
+ *
+ * Start, update, and end live, updating notifications from built-in templates
+ * (Segments, Countdown Timer). Enable templates via the `liveActivities` key of the
+ * SDK config passed to {@link CustomerIO.initialize}.
+ *
+ * @public
+ */
+export class CustomerIOLiveActivities implements NativeLiveActivitiesSpec {
+  /**
+   * Start a built-in-template activity.
+   *
+   * @param payload - Template payload; `payload.type` selects the template.
+   * @returns The SDK-minted activity id, used for later `update`/`end`.
+   */
+  start(payload: LiveActivityPayload): Promise<string> {
+    return withNativeModule((native) => native.start(payload));
+  }
+
+  /**
+   * Replace the whole content-state of a running activity.
+   *
+   * ActivityKit (iOS) replaces content-state wholesale, so pass the **full** desired
+   * state — not just the changed fields. Static attributes (e.g. `header`) cannot
+   * change after start and are ignored on iOS.
+   *
+   * @param activityId - Id returned by {@link start}.
+   * @param payload - The complete desired state.
+   */
+  update(activityId: string, payload: LiveActivityPayload): Promise<void> {
+    return withNativeModule((native) => native.update(activityId, payload));
+  }
+
+  /**
+   * End a running activity.
+   *
+   * @param activityId - Id returned by {@link start}.
+   */
+  end(activityId: string): Promise<void> {
+    return withNativeModule((native) => native.end(activityId));
+  }
+
+  /**
+   * Start a custom (app-defined) activity type.
+   *
+   * On **Android**, the host app renders it via its `createLiveNotification` callback.
+   * On **iOS**, custom types require a native `adopt` call, so this rejects — use a
+   * native Widget Extension + `ActivityAttributes` for custom iOS activities.
+   *
+   * @param activityType - Reverse-DNS identifier registered via config `customTypes`.
+   * @param payload - Flat key/value data passed to the native template/callback.
+   * @returns The SDK-minted activity id.
+   */
+  startCustom(
+    activityType: string,
+    payload: Record<string, unknown>
+  ): Promise<string> {
+    return withNativeModule((native) =>
+      native.startCustom(activityType, payload)
+    );
+  }
+
+  /**
+   * Report an `opened` metric when the app is opened from a tapped Live Activity.
+   * Call from your deep-link/URL handling entry point (iOS). No-op on Android.
+   *
+   * @param url - The opened URL.
+   * @returns `true` if the URL matched a Customer.io-tracked activity (iOS).
+   */
+  handleDeepLinkOpen(url: string): Promise<boolean> {
+    return withNativeModule((native) => native.handleDeepLinkOpen(url));
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
  */
 export * from './customerio-cdp';
 export * from './customerio-inapp';
+export * from './customerio-liveactivities';
 export * from './customerio-location';
 export * from './customerio-push';
 export * from './types';

--- a/src/specs/modules/NativeCustomerIOLiveActivities.ts
+++ b/src/specs/modules/NativeCustomerIOLiveActivities.ts
@@ -1,0 +1,40 @@
+import { TurboModuleRegistry, type TurboModule } from 'react-native';
+import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
+
+/**
+ * Native module specification for CustomerIO Live Activities React Native SDK
+ *
+ * Live Activities (iOS) / Live Notifications (Android) let you show a live,
+ * updating notification driven by a built-in template (Segments, Countdown Timer).
+ *
+ * @see NativeCustomerIO.ts for detailed documentation on TurboModule patterns,
+ * Codegen compatibility, and type safety approach.
+ */
+
+type NativeBridgeObject = UnsafeObject;
+
+export interface Spec extends TurboModule {
+  /** Start a built-in-template activity. Resolves with the SDK-minted activity id. */
+  start(payload: NativeBridgeObject): Promise<string>;
+  /** Replace the whole content-state of a running activity. Pass the full desired state. */
+  update(activityId: string, payload: NativeBridgeObject): Promise<void>;
+  /** End a running activity. */
+  end(activityId: string): Promise<void>;
+  /**
+   * Start a custom (app-defined) activity type. Android renders it via the host app's
+   * `createLiveNotification` callback; on iOS custom types require a native `adopt` call,
+   * so this rejects on iOS.
+   */
+  startCustom(
+    activityType: string,
+    payload: NativeBridgeObject
+  ): Promise<string>;
+  /**
+   * Report an `opened` metric when the app is opened from a tapped Live Activity (iOS).
+   * Resolves `true` if the URL matched a tracked activity. No-op resolving `false` on Android.
+   */
+  handleDeepLinkOpen(url: string): Promise<boolean>;
+}
+
+// Optional module — NativeModule may be null when Live Activities is not compiled in.
+export default TurboModuleRegistry.get<Spec>('NativeCustomerIOLiveActivities');

--- a/src/types/data-pipelines.ts
+++ b/src/types/data-pipelines.ts
@@ -1,3 +1,4 @@
+import type { LiveActivitiesConfig } from './live-activities';
 import type { PushClickBehaviorAndroid } from './push';
 
 /**
@@ -76,6 +77,8 @@ export type CioConfig = {
     /** Location tracking mode. Defaults to 'manual' if location config is provided. */
     trackingMode?: CioLocationTrackingMode;
   };
+  /** Live Activities (iOS) / Live Notifications (Android) configuration. */
+  liveActivities?: LiveActivitiesConfig;
 };
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './data-pipelines';
 export * from './in-app';
+export * from './live-activities';
 export * from './push';

--- a/src/types/live-activities.ts
+++ b/src/types/live-activities.ts
@@ -1,0 +1,92 @@
+/**
+ * Public types for the Live Activities module.
+ *
+ * Live Activities (iOS) / Live Notifications (Android) render live, updating
+ * notifications from built-in templates. Two templates ship today: Segments and
+ * Countdown Timer. Field names and identifiers are identical across platforms.
+ *
+ * @public
+ */
+
+/** Built-in template identifiers usable from the wrapper. */
+export type LiveActivityTemplate = 'segments' | 'countdownTimer';
+
+/**
+ * Segments template — a progress activity split into N segments.
+ * `header` is a static attribute (fixed at start); the rest are content-state.
+ */
+export interface LiveActivitySegmentsPayload {
+  type: 'segments';
+  /** Static header line (set at start, never changes). */
+  header: string;
+  /** Primary status line. */
+  status: string;
+  /** Optional secondary status line. */
+  substatus?: string;
+  /** Total number of segments. */
+  segmentsTotal: number;
+  /** Number of completed segments (clamped to 0..segmentsTotal). */
+  segmentsComplete: number;
+  /** Optional trailing text (e.g. an ETA). */
+  trailingText?: string;
+}
+
+/**
+ * Countdown Timer template — a live countdown to a target time.
+ * `header` is a static attribute (fixed at start); the rest are content-state.
+ */
+export interface LiveActivityCountdownTimerPayload {
+  type: 'countdownTimer';
+  /** Static header line (set at start, never changes). */
+  header: string;
+  /** Primary title line. */
+  title: string;
+  /** Optional status message. */
+  statusMessage?: string;
+  /** Target time as epoch **seconds**. Omit to render the finished state. */
+  endTime?: number;
+}
+
+/**
+ * Payload for {@link CustomerIOLiveActivities.start} and
+ * {@link CustomerIOLiveActivities.update}.
+ *
+ * Because ActivityKit replaces content-state wholesale on update, `update` takes the
+ * same full payload as `start` — pass the complete desired state each time.
+ *
+ * @public
+ */
+export type LiveActivityPayload =
+  | LiveActivitySegmentsPayload
+  | LiveActivityCountdownTimerPayload;
+
+/**
+ * Live Activities branding (Android only). On iOS, branding is compiled into the
+ * widget extension's SwiftUI, so these values are ignored there.
+ *
+ * @public
+ */
+export interface LiveActivitiesBranding {
+  /** Reserved for future use. */
+  companyName?: string;
+  /** Accent color as "#RRGGBB". */
+  accentColorHex?: string;
+  /** Remote logo URL (downloaded and cached natively). */
+  logoUrl?: string;
+  /** Android drawable resource name, resolved natively. */
+  smallIconResource?: string;
+}
+
+/**
+ * Live Activities configuration, passed under the `liveActivities` key of the SDK config.
+ *
+ * @public
+ */
+export interface LiveActivitiesConfig {
+  /** Built-in templates to enable. Enables the matching native type on each platform. */
+  templates?: LiveActivityTemplate[];
+  /** Reverse-DNS identifiers for custom (app-defined) activity types. */
+  customTypes?: string[];
+  /** Android Live Notification branding (ignored on iOS). */
+  branding?: LiveActivitiesBranding;
+}


### PR DESCRIPTION
Adds `CustomerIO.liveActivities` (start/update/end/startCustom/handleDeepLinkOpen) bridging the native Live Activities (iOS) / Live Notifications (Android) feature: built-in Segments + Countdown Timer templates, init config (templates, custom types, Android branding), a sample-app demo screen, and docs.

- **Android**: renders in-SDK, zero native code. Verified — example app assembles against the native LN build.
- **iOS**: requires a Widget Extension (documented); ships an optional `liveactivities` podspec subspec.

Depends on unreleased native: Android Live Notifications and the iOS Live Activities CocoaPods podspecs. Draft until those release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)