### PR TITLE
feat(live-activities): expose Live Activities through CustomerIO.liveActivities

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ This SDK supports [rich push notifications](https://customer.io/docs/sdk/react-n
 
 Enable the activity types you use under the `liveNotifications` key of your SDK config. On iOS, also add the `liveactivities` pod subspec and a Widget Extension that renders the SDK's built-in templates.
 
-**One manual step is required on iOS.** Forward every opened URL to the SDK from your `AppDelegate`, or taps on a Live Activity are not attributed:
+**One manual step is required on iOS.** Forward every opened URL to the SDK from your `AppDelegate`, or taps on a Live Activity are not attributed. `NativeLiveActivities` comes from the wrapper pod, so import it — and note this only compiles once the `liveactivities` subspec is installed:
 
 ```swift
+import customerio_reactnative
+
 override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
   // Reports an `opened` metric and returns the deep link to route to. A non-Customer.io URL comes
   // back unchanged; `nil` means the activity carried no deep link, so there is nothing to open.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ This SDK supports [rich push notifications](https://customer.io/docs/sdk/react-n
 
 ---
 
+## 🔴 Live Activities
+
+Enable the activity types you use under the `liveNotifications` key of your SDK config. On iOS, also add the `liveactivities` pod subspec and a Widget Extension that renders the SDK's built-in templates.
+
+**One manual step is required on iOS.** Forward every opened URL to the SDK from your `AppDelegate`, or taps on a Live Activity are not attributed:
+
+```swift
+override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+  // Reports an `opened` metric and returns the deep link to route to. A non-Customer.io URL comes
+  // back unchanged; `nil` means the activity carried no deep link, so there is nothing to open.
+  guard let routableUrl = NativeLiveActivities.handleWidgetUrl(url) else { return true }
+  return super.application(app, open: routableUrl, options: options)
+}
+```
+
+Android needs no equivalent step. Expo apps need none either — the [config plugin](https://github.com/customerio/customerio-expo-plugin) injects this for you.
+
+---
+
 ## Identify Users, Track Events, and More
 
 Customer.io helps you personalize your mobile experience:

--- a/README.md
+++ b/README.md
@@ -73,20 +73,30 @@ This SDK supports [rich push notifications](https://customer.io/docs/sdk/react-n
 
 ## 🔴 Live Activities
 
-Enable the activity types you use under the `liveNotifications` key of your SDK config. On iOS, also add the `liveactivities` pod subspec and a Widget Extension that renders the SDK's built-in templates.
+Enable the activity types you use under the `liveNotifications` key of your SDK config. On iOS, also add `NSSupportsLiveActivities` to your app's `Info.plist`, the `liveactivities` pod subspec, and a Widget Extension that renders the SDK's built-in templates. Without the `Info.plist` key, iOS refuses to start any activity:
+
+```xml
+<key>NSSupportsLiveActivities</key>
+<true/>
+```
 
 **One manual step is required on iOS.** Forward every opened URL to the SDK from your `AppDelegate`, or taps on a Live Activity are not attributed. `NativeLiveActivities` comes from the wrapper pod, so import it — and note this only compiles once the `liveactivities` subspec is installed:
 
 ```swift
 import customerio_reactnative
+import React
 
-override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-  // Reports an `opened` metric and returns the deep link to route to. A non-Customer.io URL comes
-  // back unchanged; `nil` means the activity carried no deep link, so there is nothing to open.
-  guard let routableUrl = NativeLiveActivities.handleWidgetUrl(url) else { return true }
-  return super.application(app, open: routableUrl, options: options)
+extension AppDelegate {
+  func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    // Reports an `opened` metric and returns the deep link to route to. A non-Customer.io URL comes
+    // back unchanged; `nil` means the activity carried no deep link, so there is nothing to open.
+    guard let routableUrl = NativeLiveActivities.handleWidgetUrl(url) else { return true }
+    return RCTLinkingManager.application(app, open: routableUrl, options: options)
+  }
 }
 ```
+
+A React Native `AppDelegate` conforms to `UIApplicationDelegate` directly rather than subclassing, so this method is not an `override`, and the URL is passed on to `RCTLinkingManager` instead of `super`. See [the sample app's `AppDelegate.swift`](/example/ios/SampleApp/AppDelegate.swift) for this in context.
 
 Android needs no equivalent step. Expo apps need none either — the [config plugin](https://github.com/customerio/customerio-expo-plugin) injects this for you.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,6 +59,10 @@ repositories {
   mavenCentral()
   google()
 
+  // TEMPORARY (REL-1): remove once Live Notifications ships in a released Android SDK.
+  // Live Notifications are only available from the unreleased branch snapshot.
+  maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
+
   def found = false
   def defaultDir = null
   def androidSourcesName = 'React Native sources'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,6 @@ customerio.reactnative.kotlinVersion=2.1.20
 customerio.reactnative.compileSdkVersion=36
 customerio.reactnative.targetSdkVersion=36
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=4.18.2
+# TEMPORARY (REL-1): pinned to the unreleased Live Notifications branch snapshot.
+# Restore a released version once Live Notifications ships.
+customerio.reactnative.cioSDKVersionAndroid=live-notifications-review-fixes-SNAPSHOT

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,4 +4,4 @@ customerio.reactnative.targetSdkVersion=36
 customerio.reactnative.minSdkVersion=21
 # TEMPORARY (REL-1): pinned to the unreleased Live Notifications branch snapshot.
 # Restore a released version once Live Notifications ships.
-customerio.reactnative.cioSDKVersionAndroid=live-notifications-review-fixes-SNAPSHOT
+customerio.reactnative.cioSDKVersionAndroid=feature-live-notifications-SNAPSHOT

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
+import io.customer.reactnative.sdk.liveactivities.NativeLiveActivitiesModule
 import io.customer.reactnative.sdk.location.NativeLocationModule
 import io.customer.reactnative.sdk.logging.NativeCustomerIOLoggingModule
 import io.customer.reactnative.sdk.messaginginapp.InlineInAppMessageViewManager
@@ -33,6 +34,7 @@ class CustomerIOReactNativePackage : BaseReactPackage() {
             InlineInAppMessageViewManager.NAME -> InlineInAppMessageViewManager()
             NativeCustomerIOLoggingModule.NAME -> NativeCustomerIOLoggingModule(reactContext)
             NativeCustomerIOModule.NAME -> NativeCustomerIOModule(reactContext = reactContext)
+            NativeLiveActivitiesModule.NAME -> NativeLiveActivitiesModule(reactContext)
             NativeLocationModule.NAME -> if (BuildConfig.CIO_LOCATION_ENABLED) {
                 NativeLocationModule(reactContext)
             } else null
@@ -71,6 +73,7 @@ class CustomerIOReactNativePackage : BaseReactPackage() {
             InlineInAppMessageViewManager.NAME,
             NativeCustomerIOLoggingModule.NAME,
             NativeCustomerIOModule.NAME,
+            NativeLiveActivitiesModule.NAME,
             NativeLocationModule.NAME,
             NativeMessagingInAppModule.NAME,
             NativeMessagingPushModule.NAME,

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
@@ -34,6 +34,12 @@ class CustomerIOReactNativePackage : BaseReactPackage() {
             InlineInAppMessageViewManager.NAME -> InlineInAppMessageViewManager()
             NativeCustomerIOLoggingModule.NAME -> NativeCustomerIOLoggingModule(reactContext)
             NativeCustomerIOModule.NAME -> NativeCustomerIOModule(reactContext = reactContext)
+            // Unconditional on purpose, unlike Location below. Location has its own artifact
+            // (io.customer.android:location) that the flag switches between `api` and `compileOnly`,
+            // so gating it genuinely keeps a dependency off the consumer's classpath. Live
+            // Notifications ship inside messaging-push-fcm, already a hard dependency here, so a flag
+            // would remove nothing — and the module is inert until `liveNotifications` config enables
+            // a type. iOS gates its equivalent only because the subspec pulls in extra pods.
             NativeLiveActivitiesModule.NAME -> NativeLiveActivitiesModule(reactContext)
             NativeLocationModule.NAME -> if (BuildConfig.CIO_LOCATION_ENABLED) {
                 NativeLocationModule(reactContext)

--- a/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
@@ -89,11 +89,14 @@ class NativeCustomerIOModule(
                 packageConfig.getTypedValue<String>(Keys.Config.CDN_HOST)
                     ?.let { cdnHost(it) }
 
-                // Configure push messaging module based on config provided by customer app
+                // Configure push messaging module based on config provided by customer app.
+                // Live Activities are hosted by the FCM push module, so the `liveActivities`
+                // config is applied to the same module.
                 packageConfig.getTypedValue<Map<String, Any>>(key = "push").let { pushConfig ->
                     NativeMessagingPushModule.addNativeModuleFromConfig(
                         builder = this,
-                        config = pushConfig ?: emptyMap()
+                        config = pushConfig ?: emptyMap(),
+                        liveActivitiesConfig = packageConfig.getTypedValue<Map<String, Any>>(key = "liveActivities")
                     )
                 }
                 // Configure in-app messaging module based on config provided by customer app

--- a/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
@@ -90,13 +90,13 @@ class NativeCustomerIOModule(
                     ?.let { cdnHost(it) }
 
                 // Configure push messaging module based on config provided by customer app.
-                // Live Activities are hosted by the FCM push module, so the `liveActivities`
+                // Live Activities are hosted by the FCM push module, so the `liveNotifications`
                 // config is applied to the same module.
                 packageConfig.getTypedValue<Map<String, Any>>(key = "push").let { pushConfig ->
                     NativeMessagingPushModule.addNativeModuleFromConfig(
                         builder = this,
                         config = pushConfig ?: emptyMap(),
-                        liveActivitiesConfig = packageConfig.getTypedValue<Map<String, Any>>(key = "liveNotifications")
+                        liveNotificationsConfig = packageConfig.getTypedValue<Map<String, Any>>(key = "liveNotifications")
                     )
                 }
                 // Configure in-app messaging module based on config provided by customer app

--- a/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/NativeCustomerIOModule.kt
@@ -96,7 +96,7 @@ class NativeCustomerIOModule(
                     NativeMessagingPushModule.addNativeModuleFromConfig(
                         builder = this,
                         config = pushConfig ?: emptyMap(),
-                        liveActivitiesConfig = packageConfig.getTypedValue<Map<String, Any>>(key = "liveActivities")
+                        liveActivitiesConfig = packageConfig.getTypedValue<Map<String, Any>>(key = "liveNotifications")
                     )
                 }
                 // Configure in-app messaging module based on config provided by customer app

--- a/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
@@ -7,6 +7,7 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
 import io.customer.messagingpush.MessagingPushModuleConfig
 import io.customer.messagingpush.ModuleMessagingPushFCM
+import io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback
 import io.customer.messagingpush.livenotification.LiveNotificationAsset
 import io.customer.messagingpush.livenotification.LiveNotificationBranding
 import io.customer.messagingpush.livenotification.LiveNotificationData
@@ -87,7 +88,7 @@ class NativeLiveActivitiesModule(
 
     private fun parseData(payload: ReadableMap): LiveNotificationData {
         return when (val type = payload.getString("type")) {
-            "segments" -> LiveNotificationData.Segments(
+            LiveNotificationType.SEGMENTS.identifier -> LiveNotificationData.Segments(
                 header = payload.requireString("header"),
                 status = payload.requireString("status"),
                 substatus = payload.optString("substatus"),
@@ -96,7 +97,7 @@ class NativeLiveActivitiesModule(
                 trailingText = payload.optString("trailingText"),
             )
 
-            "countdownTimer" -> LiveNotificationData.CountdownTimer(
+            LiveNotificationType.COUNTDOWN_TIMER.identifier -> LiveNotificationData.CountdownTimer(
                 header = payload.requireString("header"),
                 title = payload.requireString("title"),
                 statusMessage = payload.optString("statusMessage"),
@@ -107,7 +108,9 @@ class NativeLiveActivitiesModule(
                 },
             )
 
-            else -> throw IllegalArgumentException("Unknown live activity template type: $type")
+            // A newer native SDK may know this type even though this wrapper build doesn't.
+            // Reject softly (the caller turns this into a rejected promise) rather than crash.
+            else -> throw IllegalArgumentException("Unsupported Live Activity template: $type")
         }
     }
 
@@ -140,19 +143,18 @@ class NativeLiveActivitiesModule(
         // (e.g. in Application.onCreate before React Native starts). Stored statically because the
         // SDK config is applied in applyLiveActivitiesConfig, not on this module instance.
         @Volatile
-        private var liveNotificationCallback:
-            io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback? = null
+        private var liveNotificationCallback: CustomerIOLiveNotificationsCallback? = null
 
         /**
-         * Register the host app's callback for rendering custom live notifications. Custom
+         * Register the host app's callback for rendering live notifications itself. Custom
          * (app-defined) activity types have no built-in template, so the app must build the
-         * [android.app.Notification] in [io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback.createLiveNotification].
+         * [android.app.Notification] in
+         * [CustomerIOLiveNotificationsCallback.createLiveNotification]; returning `null` there
+         * falls back to the SDK's built-in template.
          * Call this before the Customer.io SDK is initialized.
          */
         @JvmStatic
-        fun setLiveNotificationCallback(
-            callback: io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback,
-        ) {
+        fun setLiveNotificationCallback(callback: CustomerIOLiveNotificationsCallback) {
             liveNotificationCallback = callback
         }
 
@@ -168,17 +170,15 @@ class NativeLiveActivitiesModule(
             builder: MessagingPushModuleConfig.Builder,
             config: Map<String, Any>,
         ) {
-            // Wire the host app's custom-live-notification renderer, if one was registered.
-            liveNotificationCallback?.let { builder.setNotificationCallback(it) }
+            // Wire the host app's live-notification renderer, if one was registered.
+            liveNotificationCallback?.let { builder.setLiveNotificationCallback(it) }
 
-            val templateTypes = config.getTypedValue<List<*>>("templates")
+            // Unrecognized identifiers are ignored: a newer native SDK may ship types this
+            // wrapper build doesn't know, and that must never break the ones it does know.
+            val templateTypes = config.getTypedValue<List<*>>("types")
                 ?.mapNotNull { it as? String }
-                ?.mapNotNull { name ->
-                    when (name) {
-                        "segments" -> LiveNotificationType.SEGMENTS
-                        "countdownTimer" -> LiveNotificationType.COUNTDOWN_TIMER
-                        else -> null
-                    }
+                ?.mapNotNull { identifier ->
+                    LiveNotificationType.entries.firstOrNull { it.identifier == identifier }
                 }
                 .orEmpty()
             if (templateTypes.isNotEmpty()) {
@@ -197,23 +197,34 @@ class NativeLiveActivitiesModule(
                 val accentColor = branding.getTypedValue<String>("accentColorHex")
                     ?.let { runCatching { Color.parseColor(it) }.getOrNull() }
                     ?: Color.TRANSPARENT
-                val logoUrl = branding.getTypedValue<String>("logoUrl")
+                // A bundled drawable is preferred over a remote URL: it renders without a network
+                // round-trip, so the logo is present on the very first frame.
+                val logo = branding.getTypedValue<String>("logoResource")
+                    ?.let { name -> drawableResId(name)?.let(LiveNotificationAsset::Drawable) }
+                    ?: branding.getTypedValue<String>("logoUrl")
+                        ?.let(LiveNotificationAsset::RemoteUrl)
                 val smallIcon = branding.getTypedValue<String>("smallIconResource")
-                    ?.let { name ->
-                        val context = SDKComponent.android().applicationContext
-                        context.resources
-                            .getIdentifier(name, "drawable", context.packageName)
-                            .takeIf { it != 0 }
-                    }
+                    ?.let { name -> drawableResId(name) }
                 builder.setLiveNotificationBranding(
                     LiveNotificationBranding(
                         companyName = branding.getTypedValue<String>("companyName").orEmpty(),
                         accentColor = accentColor,
                         smallIcon = smallIcon,
-                        logo = logoUrl?.let { LiveNotificationAsset.RemoteUrl(it) },
+                        logo = logo,
                     ),
                 )
             }
+        }
+
+        /**
+         * Resolve a bundled drawable by name, or `null` when the host app doesn't ship one under
+         * that name — a missing asset must degrade to "no image", never crash rendering.
+         */
+        private fun drawableResId(name: String): Int? {
+            val context = SDKComponent.android().applicationContext
+            return context.resources
+                .getIdentifier(name, "drawable", context.packageName)
+                .takeIf { it != 0 }
         }
     }
 }

--- a/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
@@ -33,11 +33,16 @@ class NativeLiveActivitiesModule(
 
     // Live Notifications are hosted by the FCM push module. Reach it via the module registry
     // (the wrapper can't reference the SDK-internal MODULE_NAME constant, so use the literal).
-    private fun getPushModule(): ModuleMessagingPushFCM? = runCatching {
-        SDKComponent.modules[PUSH_FCM_MODULE_NAME] as? ModuleMessagingPushFCM
-    }.onFailure {
-        logger.error("Live Notifications: push module is not initialized. Ensure the SDK is initialized with live activity templates enabled.")
-    }.getOrNull()
+    //
+    // Deliberately not runCatching: `as?` yields null instead of throwing, so a failure branch keyed
+    // on a thrown error would never run and the message below would never be logged.
+    private fun getPushModule(): ModuleMessagingPushFCM? {
+        val module = SDKComponent.modules[PUSH_FCM_MODULE_NAME] as? ModuleMessagingPushFCM
+        if (module == null) {
+            logger.error("Live Notifications: push module is not initialized. Ensure the SDK is initialized with live activity templates enabled.")
+        }
+        return module
+    }
 
     override fun start(payload: ReadableMap?, promise: Promise?) {
         val module = getPushModule() ?: return promise.rejectNotAvailable()
@@ -169,7 +174,7 @@ class NativeLiveActivitiesModule(
          * custom types, branding) is set on the same [MessagingPushModuleConfig].
          *
          * @param builder the push module's config builder.
-         * @param config the `liveActivities` config map from the customer app.
+         * @param config the `liveNotifications` config map from the customer app.
          */
         internal fun applyLiveActivitiesConfig(
             builder: MessagingPushModuleConfig.Builder,

--- a/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
@@ -8,6 +8,7 @@ import com.facebook.react.module.annotations.ReactModule
 import io.customer.messagingpush.MessagingPushModuleConfig
 import io.customer.messagingpush.ModuleMessagingPushFCM
 import io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback
+import io.customer.messagingpush.di.pushModuleConfig
 import io.customer.messagingpush.livenotification.LiveNotificationAsset
 import io.customer.messagingpush.livenotification.LiveNotificationBranding
 import io.customer.messagingpush.livenotification.LiveNotificationData
@@ -56,7 +57,7 @@ class NativeLiveActivitiesModule(
             } else {
                 requireNotNull(map.getString("type")) { "payload.type is required" }
             }
-            if (activityType !in enabledActivityTypes) {
+            if (activityType !in enabledActivityTypes()) {
                 return promise.rejectNotRegistered(activityType)
             }
             val id = if (isCustom) {
@@ -106,7 +107,26 @@ class NativeLiveActivitiesModule(
      * without configuring `liveNotifications.customType` — say so, rather than starting a
      * notification the allowlist would silently drop.
      */
-    private fun requireCustomActivityType(): String = requireNotNull(customActivityType) {
+    /**
+     * Identifiers the SDK currently has enabled. Read from the live module config rather than cached
+     * at wrapper init: the config can also be built by generated native code that never calls
+     * [applyLiveActivitiesConfig] — the Expo config plugin does exactly that — and a cached set would
+     * be empty there, rejecting every start.
+     */
+    private fun enabledActivityTypes(): Set<String> =
+        SDKComponent.pushModuleConfig.liveNotificationTypes
+
+    /**
+     * The custom identifier, preferring what the wrapper saw and otherwise deriving it from the live
+     * config: exactly one custom type is supported, so it is the single enabled identifier that no
+     * built-in [LiveNotificationType] claims.
+     */
+    private fun customActivityTypeOrNull(): String? = customActivityType
+        ?: enabledActivityTypes().firstOrNull { identifier ->
+            LiveNotificationType.entries.none { it.identifier == identifier }
+        }
+
+    private fun requireCustomActivityType(): String = requireNotNull(customActivityTypeOrNull()) {
         "No custom Live Activity type is configured. Set `liveNotifications.customType` in your " +
             "Customer.io SDK config to your own reverse-DNS identifier, and render it from your " +
             "CustomerIOLiveNotificationsCallback."
@@ -186,12 +206,6 @@ class NativeLiveActivitiesModule(
         @Volatile
         private var customActivityType: String? = null
 
-        // Identifiers actually enabled at SDK init, built-in and custom. The native start call mints
-        // an id regardless of enablement and the handler then drops unenabled types at debug level,
-        // so this is what lets `start` fail loudly instead.
-        @Volatile
-        private var enabledActivityTypes: Set<String> = emptySet()
-
         // Host-app callback used to render custom (app-defined) live notifications. The native SDK
         // only accepts it at build time, so the app must register it before the SDK initializes
         // (e.g. in Application.onCreate before React Native starts). Stored statically because the
@@ -251,11 +265,6 @@ class NativeLiveActivitiesModule(
             if (customType != null) {
                 builder.enableCustomLiveNotificationTypes(customType)
             }
-
-            // Remember what ended up enabled so `start` can refuse a type that isn't, instead of
-            // returning an id for a notification the handler will silently drop. iOS already rejects
-            // in this case; Android had no equivalent because the native call always mints an id.
-            enabledActivityTypes = templateTypes.map { it.identifier }.toSet() + setOfNotNull(customType)
 
             val branding = config.getTypedValue<Map<String, Any>>("branding")
             if (branding != null) {

--- a/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
@@ -61,7 +61,12 @@ class NativeLiveActivitiesModule(
         }
     }
 
-    override fun end(activityId: String?, promise: Promise?) {
+    /**
+     * Ends a live notification. [payload] is accepted for signature parity with iOS, where a final
+     * content-state is what makes ActivityKit render a terminal state; Android renders its own
+     * terminal state (the notification simply stops being ongoing), so it is ignored here.
+     */
+    override fun end(activityId: String?, payload: ReadableMap?, promise: Promise?) {
         val module = getPushModule() ?: return promise.rejectNotAvailable()
         try {
             module.endLiveNotification(requireNotNull(activityId) { "activityId is required" })

--- a/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
@@ -47,8 +47,15 @@ class NativeLiveActivitiesModule(
     override fun start(payload: ReadableMap?, promise: Promise?) {
         val module = getPushModule() ?: return promise.rejectNotAvailable()
         try {
-            val data = parseData(requireNotNull(payload) { "payload is required" })
-            promise?.resolve(module.startLiveNotification(data))
+            val map = requireNotNull(payload) { "payload is required" }
+            // Custom types have no built-in template, so they take the SDK's untyped map path and are
+            // rendered by the app's own callback. Built-ins keep the typed path.
+            val id = if (map.getString("type") == CUSTOM_TYPE_DISCRIMINATOR) {
+                module.startLiveNotification(requireCustomActivityType(), customData(map))
+            } else {
+                module.startLiveNotification(parseData(map))
+            }
+            promise?.resolve(id)
         } catch (ex: Throwable) {
             promise?.reject("live_activity_start_failed", ex.message, ex)
         }
@@ -58,8 +65,12 @@ class NativeLiveActivitiesModule(
         val module = getPushModule() ?: return promise.rejectNotAvailable()
         try {
             val id = requireNotNull(activityId) { "activityId is required" }
-            val data = parseData(requireNotNull(payload) { "payload is required" })
-            module.updateLiveNotification(id, data)
+            val map = requireNotNull(payload) { "payload is required" }
+            if (map.getString("type") == CUSTOM_TYPE_DISCRIMINATOR) {
+                module.updateLiveNotification(id, requireCustomActivityType(), customData(map))
+            } else {
+                module.updateLiveNotification(id, parseData(map))
+            }
             promise?.resolve(null)
         } catch (ex: Throwable) {
             promise?.reject("live_activity_update_failed", ex.message, ex)
@@ -81,20 +92,20 @@ class NativeLiveActivitiesModule(
         }
     }
 
-    override fun startCustom(
-        activityType: String?,
-        payload: ReadableMap?,
-        promise: Promise?,
-    ) {
-        val module = getPushModule() ?: return promise.rejectNotAvailable()
-        try {
-            val type = requireNotNull(activityType) { "activityType is required" }
-            val data = payload?.toHashMap() ?: emptyMap<String, Any?>()
-            promise?.resolve(module.startLiveNotification(type, data))
-        } catch (ex: Throwable) {
-            promise?.reject("live_activity_start_custom_failed", ex.message, ex)
-        }
+    /**
+     * The app's own identifier for the custom template. Absent means the app sent a custom payload
+     * without configuring `liveNotifications.customType` — say so, rather than starting a
+     * notification the allowlist would silently drop.
+     */
+    private fun requireCustomActivityType(): String = requireNotNull(customActivityType) {
+        "No custom Live Activity type is configured. Set `liveNotifications.customType` in your " +
+            "Customer.io SDK config to your own reverse-DNS identifier, and render it from your " +
+            "CustomerIOLiveNotificationsCallback."
     }
+
+    /** Flattens the payload's `data` map. Android stringifies every value downstream anyway. */
+    private fun customData(payload: ReadableMap): Map<String, Any?> =
+        payload.getMap("data")?.toHashMap() ?: emptyMap()
 
     private fun parseData(payload: ReadableMap): LiveNotificationData {
         return when (val type = payload.getString("type")) {
@@ -148,6 +159,14 @@ class NativeLiveActivitiesModule(
         // The SDK's ModuleMessagingPushFCM.MODULE_NAME is `internal`, so we mirror its value here.
         private const val PUSH_FCM_MODULE_NAME = "MessagingPushFCM"
 
+        // Discriminator JavaScript sends for the custom template. Not a wire identifier — the
+        // notification is started under the app's own `liveNotifications.customType`.
+        private const val CUSTOM_TYPE_DISCRIMINATOR = "custom"
+
+        // The app's own identifier for the custom template, captured from config at SDK init.
+        @Volatile
+        private var customActivityType: String? = null
+
         // Host-app callback used to render custom (app-defined) live notifications. The native SDK
         // only accepts it at build time, so the app must register it before the SDK initializes
         // (e.g. in Application.onCreate before React Native starts). Stored statically because the
@@ -195,11 +214,13 @@ class NativeLiveActivitiesModule(
                 builder.enableLiveNotificationTypes(*templateTypes.toTypedArray())
             }
 
-            val customTypes = config.getTypedValue<List<*>>("customTypes")
-                ?.mapNotNull { it as? String }
-                .orEmpty()
-            if (customTypes.isNotEmpty()) {
-                builder.enableCustomLiveNotificationTypes(*customTypes.toTypedArray())
+            // The custom template. Allowlisting the identifier is both necessary and sufficient:
+            // LiveNotificationHandler drops any push whose activityType isn't in this set, and a type
+            // with no built-in template falls through to the host app's render callback.
+            val customType = config.getTypedValue<String>("customType")?.trim()
+            if (!customType.isNullOrEmpty()) {
+                customActivityType = customType
+                builder.enableCustomLiveNotificationTypes(customType)
             }
 
             val branding = config.getTypedValue<Map<String, Any>>("branding")

--- a/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
@@ -1,0 +1,219 @@
+package io.customer.reactnative.sdk.liveactivities
+
+import android.graphics.Color
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.module.annotations.ReactModule
+import io.customer.messagingpush.MessagingPushModuleConfig
+import io.customer.messagingpush.ModuleMessagingPushFCM
+import io.customer.messagingpush.livenotification.LiveNotificationAsset
+import io.customer.messagingpush.livenotification.LiveNotificationBranding
+import io.customer.messagingpush.livenotification.LiveNotificationData
+import io.customer.messagingpush.livenotification.LiveNotificationType
+import io.customer.reactnative.sdk.NativeCustomerIOLiveActivitiesSpec
+import io.customer.reactnative.sdk.extension.getTypedValue
+import io.customer.sdk.core.di.SDKComponent
+import io.customer.sdk.core.util.Logger
+
+/**
+ * React Native module implementation for Customer.io Live Activities / Live Notifications
+ * using TurboModules with new architecture.
+ *
+ * Live Notifications live on the FCM push module ([ModuleMessagingPushFCM]); this bridge
+ * maps the wrapper's template payloads to [LiveNotificationData] and forwards them.
+ */
+@ReactModule(name = NativeLiveActivitiesModule.NAME)
+class NativeLiveActivitiesModule(
+    private val reactContext: ReactApplicationContext,
+) : NativeCustomerIOLiveActivitiesSpec(reactContext) {
+    private val logger: Logger
+        get() = SDKComponent.logger
+
+    // Live Notifications are hosted by the FCM push module. Reach it via the module registry
+    // (the wrapper can't reference the SDK-internal MODULE_NAME constant, so use the literal).
+    private fun getPushModule(): ModuleMessagingPushFCM? = runCatching {
+        SDKComponent.modules[PUSH_FCM_MODULE_NAME] as? ModuleMessagingPushFCM
+    }.onFailure {
+        logger.error("Live Notifications: push module is not initialized. Ensure the SDK is initialized with live activity templates enabled.")
+    }.getOrNull()
+
+    override fun start(payload: ReadableMap?, promise: Promise?) {
+        val module = getPushModule() ?: return promise.rejectNotAvailable()
+        try {
+            val data = parseData(requireNotNull(payload) { "payload is required" })
+            promise?.resolve(module.startLiveNotification(data))
+        } catch (ex: Throwable) {
+            promise?.reject("live_activity_start_failed", ex.message, ex)
+        }
+    }
+
+    override fun update(activityId: String?, payload: ReadableMap?, promise: Promise?) {
+        val module = getPushModule() ?: return promise.rejectNotAvailable()
+        try {
+            val id = requireNotNull(activityId) { "activityId is required" }
+            val data = parseData(requireNotNull(payload) { "payload is required" })
+            module.updateLiveNotification(id, data)
+            promise?.resolve(null)
+        } catch (ex: Throwable) {
+            promise?.reject("live_activity_update_failed", ex.message, ex)
+        }
+    }
+
+    override fun end(activityId: String?, promise: Promise?) {
+        val module = getPushModule() ?: return promise.rejectNotAvailable()
+        try {
+            module.endLiveNotification(requireNotNull(activityId) { "activityId is required" })
+            promise?.resolve(null)
+        } catch (ex: Throwable) {
+            promise?.reject("live_activity_end_failed", ex.message, ex)
+        }
+    }
+
+    override fun startCustom(
+        activityType: String?,
+        payload: ReadableMap?,
+        promise: Promise?,
+    ) {
+        val module = getPushModule() ?: return promise.rejectNotAvailable()
+        try {
+            val type = requireNotNull(activityType) { "activityType is required" }
+            val data = payload?.toHashMap() ?: emptyMap<String, Any?>()
+            promise?.resolve(module.startLiveNotification(type, data))
+        } catch (ex: Throwable) {
+            promise?.reject("live_activity_start_custom_failed", ex.message, ex)
+        }
+    }
+
+    private fun parseData(payload: ReadableMap): LiveNotificationData {
+        return when (val type = payload.getString("type")) {
+            "segments" -> LiveNotificationData.Segments(
+                header = payload.requireString("header"),
+                status = payload.requireString("status"),
+                substatus = payload.optString("substatus"),
+                segmentsTotal = payload.requireDouble("segmentsTotal").toInt(),
+                segmentsComplete = payload.requireDouble("segmentsComplete").toInt(),
+                trailingText = payload.optString("trailingText"),
+            )
+
+            "countdownTimer" -> LiveNotificationData.CountdownTimer(
+                header = payload.requireString("header"),
+                title = payload.requireString("title"),
+                statusMessage = payload.optString("statusMessage"),
+                endTime = if (payload.hasKey("endTime") && !payload.isNull("endTime")) {
+                    payload.getDouble("endTime").toLong()
+                } else {
+                    null
+                },
+            )
+
+            else -> throw IllegalArgumentException("Unknown live activity template type: $type")
+        }
+    }
+
+    private fun ReadableMap.requireString(key: String): String =
+        requireNotNull(if (hasKey(key)) getString(key) else null) { "$key is required" }
+
+    private fun ReadableMap.optString(key: String): String? =
+        if (hasKey(key) && !isNull(key)) getString(key) else null
+
+    private fun ReadableMap.requireDouble(key: String): Double {
+        require(hasKey(key) && !isNull(key)) { "$key is required" }
+        return getDouble(key)
+    }
+
+    private fun Promise?.rejectNotAvailable() {
+        this?.reject(
+            "live_activity_module_unavailable",
+            "Live Notifications are unavailable. Enable live activity templates in the SDK config.",
+        )
+    }
+
+    companion object {
+        const val NAME = "NativeCustomerIOLiveActivities"
+
+        // The SDK's ModuleMessagingPushFCM.MODULE_NAME is `internal`, so we mirror its value here.
+        private const val PUSH_FCM_MODULE_NAME = "MessagingPushFCM"
+
+        // Host-app callback used to render custom (app-defined) live notifications. The native SDK
+        // only accepts it at build time, so the app must register it before the SDK initializes
+        // (e.g. in Application.onCreate before React Native starts). Stored statically because the
+        // SDK config is applied in applyLiveActivitiesConfig, not on this module instance.
+        @Volatile
+        private var liveNotificationCallback:
+            io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback? = null
+
+        /**
+         * Register the host app's callback for rendering custom live notifications. Custom
+         * (app-defined) activity types have no built-in template, so the app must build the
+         * [android.app.Notification] in [io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback.createLiveNotification].
+         * Call this before the Customer.io SDK is initialized.
+         */
+        @JvmStatic
+        fun setLiveNotificationCallback(
+            callback: io.customer.messagingpush.data.communication.CustomerIOPushNotificationCallback,
+        ) {
+            liveNotificationCallback = callback
+        }
+
+        /**
+         * Applies live activity configuration onto the FCM push module's config builder. Live
+         * Notifications are hosted by [ModuleMessagingPushFCM], so their config (enabled templates,
+         * custom types, branding) is set on the same [MessagingPushModuleConfig].
+         *
+         * @param builder the push module's config builder.
+         * @param config the `liveActivities` config map from the customer app.
+         */
+        internal fun applyLiveActivitiesConfig(
+            builder: MessagingPushModuleConfig.Builder,
+            config: Map<String, Any>,
+        ) {
+            // Wire the host app's custom-live-notification renderer, if one was registered.
+            liveNotificationCallback?.let { builder.setNotificationCallback(it) }
+
+            val templateTypes = config.getTypedValue<List<*>>("templates")
+                ?.mapNotNull { it as? String }
+                ?.mapNotNull { name ->
+                    when (name) {
+                        "segments" -> LiveNotificationType.SEGMENTS
+                        "countdownTimer" -> LiveNotificationType.COUNTDOWN_TIMER
+                        else -> null
+                    }
+                }
+                .orEmpty()
+            if (templateTypes.isNotEmpty()) {
+                builder.enableLiveNotificationTypes(*templateTypes.toTypedArray())
+            }
+
+            val customTypes = config.getTypedValue<List<*>>("customTypes")
+                ?.mapNotNull { it as? String }
+                .orEmpty()
+            if (customTypes.isNotEmpty()) {
+                builder.enableCustomLiveNotificationTypes(*customTypes.toTypedArray())
+            }
+
+            val branding = config.getTypedValue<Map<String, Any>>("branding")
+            if (branding != null) {
+                val accentColor = branding.getTypedValue<String>("accentColorHex")
+                    ?.let { runCatching { Color.parseColor(it) }.getOrNull() }
+                    ?: Color.TRANSPARENT
+                val logoUrl = branding.getTypedValue<String>("logoUrl")
+                val smallIcon = branding.getTypedValue<String>("smallIconResource")
+                    ?.let { name ->
+                        val context = SDKComponent.android().applicationContext
+                        context.resources
+                            .getIdentifier(name, "drawable", context.packageName)
+                            .takeIf { it != 0 }
+                    }
+                builder.setLiveNotificationBranding(
+                    LiveNotificationBranding(
+                        companyName = branding.getTypedValue<String>("companyName").orEmpty(),
+                        accentColor = accentColor,
+                        smallIcon = smallIcon,
+                        logo = logoUrl?.let { LiveNotificationAsset.RemoteUrl(it) },
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
@@ -50,8 +50,17 @@ class NativeLiveActivitiesModule(
             val map = requireNotNull(payload) { "payload is required" }
             // Custom types have no built-in template, so they take the SDK's untyped map path and are
             // rendered by the app's own callback. Built-ins keep the typed path.
-            val id = if (map.getString("type") == CUSTOM_TYPE_DISCRIMINATOR) {
-                module.startLiveNotification(requireCustomActivityType(), customData(map))
+            val isCustom = map.getString("type") == CUSTOM_TYPE_DISCRIMINATOR
+            val activityType = if (isCustom) {
+                requireCustomActivityType()
+            } else {
+                requireNotNull(map.getString("type")) { "payload.type is required" }
+            }
+            if (activityType !in enabledActivityTypes) {
+                return promise.rejectNotRegistered(activityType)
+            }
+            val id = if (isCustom) {
+                module.startLiveNotification(activityType, customData(map))
             } else {
                 module.startLiveNotification(parseData(map))
             }
@@ -153,6 +162,16 @@ class NativeLiveActivitiesModule(
         )
     }
 
+    /** Mirrors iOS's `live_activity_type_not_registered` so the same mistake reads the same way. */
+    private fun Promise?.rejectNotRegistered(activityType: String?) {
+        this?.reject(
+            "live_activity_type_not_registered",
+            "Live Activity type '$activityType' is not registered. Add it to " +
+                "`liveNotifications.types` in your Customer.io SDK config (or set " +
+                "`liveNotifications.customType` for a custom type).",
+        )
+    }
+
     companion object {
         const val NAME = "NativeCustomerIOLiveActivities"
 
@@ -166,6 +185,12 @@ class NativeLiveActivitiesModule(
         // The app's own identifier for the custom template, captured from config at SDK init.
         @Volatile
         private var customActivityType: String? = null
+
+        // Identifiers actually enabled at SDK init, built-in and custom. The native start call mints
+        // an id regardless of enablement and the handler then drops unenabled types at debug level,
+        // so this is what lets `start` fail loudly instead.
+        @Volatile
+        private var enabledActivityTypes: Set<String> = emptySet()
 
         // Host-app callback used to render custom (app-defined) live notifications. The native SDK
         // only accepts it at build time, so the app must register it before the SDK initializes
@@ -217,11 +242,20 @@ class NativeLiveActivitiesModule(
             // The custom template. Allowlisting the identifier is both necessary and sufficient:
             // LiveNotificationHandler drops any push whose activityType isn't in this set, and a type
             // with no built-in template falls through to the host app's render callback.
-            val customType = config.getTypedValue<String>("customType")?.trim()
-            if (!customType.isNullOrEmpty()) {
-                customActivityType = customType
+            //
+            // Assigned unconditionally: a re-initialize that drops `customType` must clear it, or
+            // `start` would keep minting notifications under an identifier no longer allowlisted —
+            // which the handler then discards, leaving the caller with an id and nothing on screen.
+            val customType = config.getTypedValue<String>("customType")?.trim()?.takeIf { it.isNotEmpty() }
+            customActivityType = customType
+            if (customType != null) {
                 builder.enableCustomLiveNotificationTypes(customType)
             }
+
+            // Remember what ended up enabled so `start` can refuse a type that isn't, instead of
+            // returning an id for a notification the handler will silently drop. iOS already rejects
+            // in this case; Android had no equivalent because the native call always mints an id.
+            enabledActivityTypes = templateTypes.map { it.identifier }.toSet() + setOfNotNull(customType)
 
             val branding = config.getTypedValue<Map<String, Any>>("branding")
             if (branding != null) {

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/NativeMessagingPushModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/NativeMessagingPushModule.kt
@@ -21,9 +21,9 @@ import io.customer.messagingpush.di.pushModuleConfig
 import io.customer.messagingpush.di.pushTrackingUtil
 import io.customer.reactnative.sdk.NativeCustomerIOMessagingPushSpec
 import io.customer.reactnative.sdk.constant.Keys
-import io.customer.reactnative.sdk.liveactivities.NativeLiveActivitiesModule
 import io.customer.reactnative.sdk.extension.getTypedValue
 import io.customer.reactnative.sdk.extension.takeIfNotBlank
+import io.customer.reactnative.sdk.liveactivities.NativeLiveActivitiesModule
 import io.customer.reactnative.sdk.util.unsupportedOnAndroid
 import io.customer.sdk.CustomerIO
 import io.customer.sdk.CustomerIOBuilder

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/NativeMessagingPushModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/NativeMessagingPushModule.kt
@@ -259,7 +259,7 @@ class NativeMessagingPushModule(
         internal fun addNativeModuleFromConfig(
             builder: CustomerIOBuilder,
             config: Map<String, Any>,
-            liveActivitiesConfig: Map<String, Any>? = null,
+            liveNotificationsConfig: Map<String, Any>? = null,
         ) {
             val androidConfig =
                 config.getTypedValue<Map<String, Any>>(key = "android") ?: emptyMap()
@@ -279,7 +279,7 @@ class NativeMessagingPushModule(
                     setPushClickBehavior(pushClickBehavior = pushClickBehavior)
                     // Live Notifications are hosted by the FCM push module, so their config is
                     // applied to the same MessagingPushModuleConfig.
-                    liveActivitiesConfig?.let { liveConfig ->
+                    liveNotificationsConfig?.let { liveConfig ->
                         NativeLiveActivitiesModule.applyLiveActivitiesConfig(
                             builder = this,
                             config = liveConfig,

--- a/android/src/main/java/io/customer/reactnative/sdk/messagingpush/NativeMessagingPushModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messagingpush/NativeMessagingPushModule.kt
@@ -21,6 +21,7 @@ import io.customer.messagingpush.di.pushModuleConfig
 import io.customer.messagingpush.di.pushTrackingUtil
 import io.customer.reactnative.sdk.NativeCustomerIOMessagingPushSpec
 import io.customer.reactnative.sdk.constant.Keys
+import io.customer.reactnative.sdk.liveactivities.NativeLiveActivitiesModule
 import io.customer.reactnative.sdk.extension.getTypedValue
 import io.customer.reactnative.sdk.extension.takeIfNotBlank
 import io.customer.reactnative.sdk.util.unsupportedOnAndroid
@@ -257,7 +258,8 @@ class NativeMessagingPushModule(
          */
         internal fun addNativeModuleFromConfig(
             builder: CustomerIOBuilder,
-            config: Map<String, Any>
+            config: Map<String, Any>,
+            liveActivitiesConfig: Map<String, Any>? = null,
         ) {
             val androidConfig =
                 config.getTypedValue<Map<String, Any>>(key = "android") ?: emptyMap()
@@ -275,6 +277,14 @@ class NativeMessagingPushModule(
             val module = ModuleMessagingPushFCM(
                 moduleConfig = MessagingPushModuleConfig.Builder().apply {
                     setPushClickBehavior(pushClickBehavior = pushClickBehavior)
+                    // Live Notifications are hosted by the FCM push module, so their config is
+                    // applied to the same MessagingPushModuleConfig.
+                    liveActivitiesConfig?.let { liveConfig ->
+                        NativeLiveActivitiesModule.applyLiveActivitiesConfig(
+                            builder = this,
+                            config = liveConfig,
+                        )
+                    }
                 }.build(),
             )
             builder.addCustomerIOModule(module)

--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -238,7 +238,7 @@ export interface LiveActivitiesBranding {
 export interface LiveActivitiesConfig {
     branding?: LiveActivitiesBranding;
     customType?: string;
-    types?: LiveActivityTemplate[];
+    types?: Exclude<LiveActivityTemplate, LiveActivityTemplate.Custom>[];
 }
 
 // @public

--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -39,6 +39,7 @@ export type CioConfig = {
     location?: {
         trackingMode?: CioLocationTrackingMode;
     };
+    liveNotifications?: LiveActivitiesConfig;
 };
 
 // @public
@@ -93,6 +94,8 @@ export class CustomerIO {
     // @deprecated
     static readonly isInitialized: () => boolean;
     // (undocumented)
+    static readonly liveActivities: CustomerIOLiveActivities;
+    // (undocumented)
     static readonly location: CustomerIOLocation;
     // (undocumented)
     static readonly pushMessaging: CustomerIOPushMessaging;
@@ -116,6 +119,16 @@ export class CustomerIOInAppMessaging implements NativeInAppSpec {
     inbox(): NotificationInbox;
     // (undocumented)
     registerEventsListener(listener: (event: InAppMessageEvent) => void): EventSubscription;
+}
+
+// Warning: (ae-forgotten-export) The symbol "NativeLiveActivitiesSpec" needs to be exported by the entry point index.d.ts
+//
+// @public
+export class CustomerIOLiveActivities implements NativeLiveActivitiesSpec {
+    end(activityId: string, payload?: LiveActivityPayload): Promise<void>;
+    start(payload: LiveActivityPayload): Promise<string>;
+    startCustom(activityType: string, payload: Record<string, unknown>): Promise<string>;
+    update(activityId: string, payload: LiveActivityPayload): Promise<void>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "NativeLocationSpec" needs to be exported by the entry point index.d.ts
@@ -211,6 +224,55 @@ export interface InlineInAppMessageViewProps extends Omit<NativeProps, 'onSizeCh
         minimumHeight?: number;
     };
     onActionClick?: (message: InAppMessage, actionValue: string, actionName: string) => void;
+}
+
+// @public
+export interface LiveActivitiesBranding {
+    accentColorHex?: string;
+    companyName?: string;
+    logoResource?: string;
+    logoUrl?: string;
+    smallIconResource?: string;
+}
+
+// @public
+export interface LiveActivitiesConfig {
+    branding?: LiveActivitiesBranding;
+    customTypes?: string[];
+    types?: LiveActivityTemplate[];
+}
+
+// @public
+export interface LiveActivityCountdownTimerPayload {
+    endTime?: number;
+    header: string;
+    statusMessage?: string;
+    title: string;
+    // (undocumented)
+    type: LiveActivityTemplate.CountdownTimer;
+}
+
+// @public
+export type LiveActivityPayload = LiveActivitySegmentsPayload | LiveActivityCountdownTimerPayload;
+
+// @public
+export interface LiveActivitySegmentsPayload {
+    header: string;
+    segmentsComplete: number;
+    segmentsTotal: number;
+    status: string;
+    substatus?: string;
+    trailingText?: string;
+    // (undocumented)
+    type: LiveActivityTemplate.Segments;
+}
+
+// @public
+export enum LiveActivityTemplate {
+    // (undocumented)
+    CountdownTimer = "io.customer.livenotifications.countdowntimer",
+    // (undocumented)
+    Segments = "io.customer.livenotifications.segments"
 }
 
 // @public

--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -127,7 +127,6 @@ export class CustomerIOInAppMessaging implements NativeInAppSpec {
 export class CustomerIOLiveActivities implements NativeLiveActivitiesSpec {
     end(activityId: string, payload?: LiveActivityPayload): Promise<void>;
     start(payload: LiveActivityPayload): Promise<string>;
-    startCustom(activityType: string, payload: Record<string, unknown>): Promise<string>;
     update(activityId: string, payload: LiveActivityPayload): Promise<void>;
 }
 
@@ -238,7 +237,7 @@ export interface LiveActivitiesBranding {
 // @public
 export interface LiveActivitiesConfig {
     branding?: LiveActivitiesBranding;
-    customTypes?: string[];
+    customType?: string;
     types?: LiveActivityTemplate[];
 }
 
@@ -253,7 +252,14 @@ export interface LiveActivityCountdownTimerPayload {
 }
 
 // @public
-export type LiveActivityPayload = LiveActivitySegmentsPayload | LiveActivityCountdownTimerPayload;
+export interface LiveActivityCustomPayload {
+    data: Record<string, string>;
+    // (undocumented)
+    type: LiveActivityTemplate.Custom;
+}
+
+// @public
+export type LiveActivityPayload = LiveActivitySegmentsPayload | LiveActivityCountdownTimerPayload | LiveActivityCustomPayload;
 
 // @public
 export interface LiveActivitySegmentsPayload {
@@ -271,6 +277,7 @@ export interface LiveActivitySegmentsPayload {
 export enum LiveActivityTemplate {
     // (undocumented)
     CountdownTimer = "io.customer.livenotifications.countdowntimer",
+    Custom = "custom",
     // (undocumented)
     Segments = "io.customer.livenotifications.segments"
 }

--- a/customerio-reactnative.podspec
+++ b/customerio-reactnative.podspec
@@ -57,4 +57,14 @@ Pod::Spec.new do |s|
       'OTHER_SWIFT_FLAGS' => '$(inherited) -DCIO_LOCATION_ENABLED'
     }
   end
+
+  # Live Activities module is optional - customers must opt in by adding this subspec, and must
+  # also add a Widget Extension target that renders the built-in templates. See the docs.
+  s.subspec "liveactivities" do |ss|
+    ss.dependency "CustomerIO/LiveActivities", package["cioNativeiOSSdkVersion"]
+    ss.dependency "CustomerIO/LiveActivitiesTemplates", package["cioNativeiOSSdkVersion"]
+    ss.pod_target_xcconfig = {
+      'OTHER_SWIFT_FLAGS' => '$(inherited) -DCIO_LIVEACTIVITIES_ENABLED'
+    }
+  end
 end

--- a/example/android/app/src/main/java/io/customer/rn_sample/fcm/MainApplication.kt
+++ b/example/android/app/src/main/java/io/customer/rn_sample/fcm/MainApplication.kt
@@ -1,11 +1,19 @@
 package io.customer.rn_sample.fcm
 
 import android.app.Application
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import androidx.core.app.NotificationCompat
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
+import io.customer.messagingpush.data.communication.CustomerIOLiveNotificationsCallback
+import io.customer.messagingpush.data.model.CustomerIOParsedPushPayload
+import io.customer.reactnative.sdk.liveactivities.NativeLiveActivitiesModule
 
 class MainApplication : Application(), ReactApplication {
 
@@ -22,6 +30,66 @@ class MainApplication : Application(), ReactApplication {
 
   override fun onCreate() {
     super.onCreate()
+
+    // Register the host-app renderer for custom (app-defined) live notifications BEFORE React
+    // Native (and the Customer.io SDK) initialize. Custom activity types have no built-in
+    // template, so the SDK asks this callback to build the Notification for them.
+    NativeLiveActivitiesModule.setLiveNotificationCallback(RideshareLiveNotificationCallback())
+
     loadReactNative(this)
+  }
+}
+
+/**
+ * Renders the custom "rideshare" live notification. The SDK calls
+ * [createLiveNotification] for every live notification; return a built [Notification] to take
+ * over rendering for our custom type, or null to let the SDK use its built-in templates.
+ */
+private class RideshareLiveNotificationCallback : CustomerIOLiveNotificationsCallback {
+  override fun createLiveNotification(
+    payload: CustomerIOParsedPushPayload,
+    context: Context,
+  ): Notification? {
+    // Live-notification template fields are flattened into `extras`; the activity type is under
+    // the reserved "notification_type" key.
+    val extras = payload.extras
+    if (extras.getString("notification_type") != RIDESHARE_TYPE) return null
+
+    // The SDK re-invokes this callback on the "end" event. Return a terminal, non-ongoing
+    // notification then so it can be dismissed instead of sticking around forever.
+    val ended = extras.getString("event") == "end"
+
+    val driverName = extras.getString("driverName") ?: "Your driver"
+    val status = extras.getString("status") ?: ""
+    // Numeric fields cross the bridge as doubles and are stored as strings ("5.0"); render as int.
+    val etaMinutes = extras.getString("etaMinutes")?.toDoubleOrNull()?.toInt()
+    val text = buildString {
+      append(driverName)
+      if (status.isNotEmpty()) append(" • ").append(status)
+      if (etaMinutes != null) append(" • ETA ").append(etaMinutes).append(" min")
+    }
+
+    ensureChannel(context)
+    return NotificationCompat.Builder(context, CHANNEL_ID)
+      .setContentTitle(if (ended) "Rideshare complete" else "Rideshare")
+      .setContentText(text)
+      .setSmallIcon(context.applicationInfo.icon)
+      .setOngoing(!ended)
+      .setOnlyAlertOnce(true)
+      .build()
+  }
+
+  private fun ensureChannel(context: Context) {
+    val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    if (manager.getNotificationChannel(CHANNEL_ID) == null) {
+      manager.createNotificationChannel(
+        NotificationChannel(CHANNEL_ID, "Rideshare", NotificationManager.IMPORTANCE_DEFAULT),
+      )
+    }
+  }
+
+  companion object {
+    private const val RIDESHARE_TYPE = "io.customer.livenotifications.custom.rideshare"
+    private const val CHANNEL_ID = "rideshare_live"
   }
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -24,6 +24,8 @@ allprojects {
       google()  // Google's Maven repository
       mavenLocal() // Only required for using locally deployed versions of the SDK
       maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' } // Only required for using SNAPSHOT versions of the SDK
+      // TEMPORARY (REL-1): Live Notifications branch snapshots live on the new Central host.
+      maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
    }
 }
 

--- a/example/fastlane/Appfile
+++ b/example/fastlane/Appfile
@@ -1,10 +1,13 @@
-# Include all of the bundle identifiers for your iOS app and for your rich push target. 
+# Include all of the bundle identifiers for your iOS app and for its app extensions (rich push
+# and the Live Activity widget), for each push provider.
 
 app_identifier([
   "io.customer.ami",
   "io.customer.ami.richpush",
+  "io.customer.ami.LiveActivityWidget",
   "io.customer.rn-sample.fcm",
-  "io.customer.rn-sample.fcm.richpush"
+  "io.customer.rn-sample.fcm.richpush",
+  "io.customer.rn-sample.fcm.LiveActivityWidget"
 ])
 
 package_name("io.customer.rn_sample.fcm")

--- a/example/ios/LiveActivityWidget/BuildSettings/apn/Common.xcconfig
+++ b/example/ios/LiveActivityWidget/BuildSettings/apn/Common.xcconfig
@@ -1,0 +1,1 @@
+PRODUCT_BUNDLE_IDENTIFIER=io.customer.ami.LiveActivityWidget

--- a/example/ios/LiveActivityWidget/BuildSettings/apn/Debug.xcconfig
+++ b/example/ios/LiveActivityWidget/BuildSettings/apn/Debug.xcconfig
@@ -1,0 +1,4 @@
+#include "Pods/Target Support Files/Pods-LiveActivityWidget/Pods-LiveActivityWidget.debug.xcconfig"
+
+#include "apn/Common.xcconfig"
+PROVISIONING_PROFILE_SPECIFIER=match Development io.customer.ami.LiveActivityWidget

--- a/example/ios/LiveActivityWidget/BuildSettings/apn/Release.xcconfig
+++ b/example/ios/LiveActivityWidget/BuildSettings/apn/Release.xcconfig
@@ -1,0 +1,5 @@
+#include "Pods/Target Support Files/Pods-LiveActivityWidget/Pods-LiveActivityWidget.release.xcconfig"
+
+#include "apn/Common.xcconfig"
+
+PROVISIONING_PROFILE_SPECIFIER=match AdHoc io.customer.ami.LiveActivityWidget

--- a/example/ios/LiveActivityWidget/BuildSettings/fcm/Common.xcconfig
+++ b/example/ios/LiveActivityWidget/BuildSettings/fcm/Common.xcconfig
@@ -1,0 +1,1 @@
+PRODUCT_BUNDLE_IDENTIFIER=io.customer.rn-sample.fcm.LiveActivityWidget

--- a/example/ios/LiveActivityWidget/BuildSettings/fcm/Debug.xcconfig
+++ b/example/ios/LiveActivityWidget/BuildSettings/fcm/Debug.xcconfig
@@ -1,0 +1,4 @@
+#include "Pods/Target Support Files/Pods-LiveActivityWidget/Pods-LiveActivityWidget.debug.xcconfig"
+
+#include "fcm/Common.xcconfig"
+PROVISIONING_PROFILE_SPECIFIER=match Development io.customer.rn-sample.fcm.LiveActivityWidget

--- a/example/ios/LiveActivityWidget/BuildSettings/fcm/Release.xcconfig
+++ b/example/ios/LiveActivityWidget/BuildSettings/fcm/Release.xcconfig
@@ -1,0 +1,5 @@
+#include "Pods/Target Support Files/Pods-LiveActivityWidget/Pods-LiveActivityWidget.release.xcconfig"
+
+#include "fcm/Common.xcconfig"
+
+PROVISIONING_PROFILE_SPECIFIER=match AdHoc io.customer.rn-sample.fcm.LiveActivityWidget

--- a/example/ios/LiveActivityWidget/Info.plist
+++ b/example/ios/LiveActivityWidget/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>LiveActivityWidget</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+	<key>RCTNewArchEnabled</key>
+	<true/>
+</dict>
+</plist>

--- a/example/ios/LiveActivityWidget/LiveActivityWidgetBundle.swift
+++ b/example/ios/LiveActivityWidget/LiveActivityWidgetBundle.swift
@@ -1,0 +1,16 @@
+import CioLiveActivities_Attributes
+import CioLiveActivities_Templates
+import SwiftUI
+import WidgetKit
+
+// Renders the Customer.io built-in Live Activity templates. The SwiftUI lives in the SDK, so this
+// widget bundle is all the app needs. Add more `CIO…LiveActivity()` entries as templates ship.
+@main
+struct LiveActivityWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        CIOSegmentsLiveActivity()
+        CIOCountdownTimerLiveActivity()
+        // Custom template: the SDK owns the attributes type, the app owns the view.
+        RideshareLiveActivity()
+    }
+}

--- a/example/ios/LiveActivityWidget/RideshareLiveActivity.swift
+++ b/example/ios/LiveActivityWidget/RideshareLiveActivity.swift
@@ -1,0 +1,56 @@
+#if os(iOS)
+import ActivityKit
+import CioLiveActivities_Attributes
+import SwiftUI
+import WidgetKit
+
+/// SwiftUI rendering for the app's custom "rideshare" Live Activity.
+///
+/// The built-in templates ship their SwiftUI in the SDK; a custom activity is rendered entirely by
+/// the app. What the SDK does provide is the attributes *type*: ``CIOCustomAttributes`` carries an
+/// untyped `data` map, which is what lets JavaScript start and update this activity without the app
+/// defining a Swift type the bridge could never reach.
+///
+/// The keys read below are the ones the JS screen sends. Every value is a string, so parse whatever
+/// you need at render time.
+@available(iOS 16.2, *)
+struct RideshareLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: CIOCustomAttributes.self) { context in
+            // Lock screen / banner presentation.
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Rideshare").font(.headline)
+                Text(context.state.data["driverName"] ?? "").font(.subheadline)
+                Text(context.state.data["status"] ?? "").font(.body)
+                Text("ETA \(context.state.data["etaMinutes"] ?? "—") min")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+            // Required on any custom template: this is what carries the tap URL the SDK
+            // reports `opened` from and routes the deep link with. The bundled templates do
+            // the same on both their lock screen and Dynamic Island.
+            .cioWidgetUrl(context.state.cioMetadata)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Text(context.state.data["driverName"] ?? "")
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("\(context.state.data["etaMinutes"] ?? "—") min")
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text(context.state.data["status"] ?? "")
+                }
+            } compactLeading: {
+                Image(systemName: "car.fill")
+            } compactTrailing: {
+                Text("\(context.state.data["etaMinutes"] ?? "")m")
+            } minimal: {
+                Image(systemName: "car.fill")
+            }
+            .cioWidgetUrl(context.state.cioMetadata)
+        }
+    }
+}
+#endif

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -31,21 +31,23 @@ push_provider = (ENV["PUSH_PROVIDER"] || "apn").downcase
 
 app_target_name = "SampleApp"
 nse_target_name = "NotificationServiceExtension"
+widget_target_name = "LiveActivityWidget"
 installation_root = Pod::Config.instance.installation_root
 
 # This function is very specific to the sample app setup
 # and is not part of the SDK or its usage.
 create_project_file_if_not_exists(installation_root, app_target_name)
-update_project_build_settings(installation_root, app_target_name, nse_target_name, push_provider)
+update_project_build_settings(installation_root, app_target_name, nse_target_name, widget_target_name, push_provider)
 
-# React Native 0.82 (New Architecture only) does not support dynamic frameworks yet
-# Use static frameworks instead when using FCM
+# React Native 0.82 (New Architecture only) does not support dynamic frameworks yet, so where a
+# framework build type is needed it has to be the static one.
 # See: https://github.com/reactwg/react-native-new-architecture/discussions/115
-if push_provider == "fcm"
-  linkage = "static"
-else
-  linkage = ENV["USE_FRAMEWORKS"]
-end
+#
+# Both providers use it, not just FCM: the Live Activity widget links Swift pods, and CocoaPods
+# requires a host target and the target it embeds to agree on use_frameworks!. Leaving APN on plain
+# static libraries builds the shared pods without a framework module layout, and the app then fails
+# with "could not build module 'customerio_reactnative'".
+linkage = ENV["USE_FRAMEWORKS"] || "static"
 
 if linkage != nil
   Pod::UI.puts "Configuring the app for #{push_provider.upcase} setup with #{linkage}ally linked Frameworks".green
@@ -60,7 +62,16 @@ target app_target_name do
     :path => config[:reactNativePath],
     :app_path => "#{installation_root}/..",
   )
-  pod "customerio-reactnative", :path => cio_package_path, :subspecs => [push_provider, "location"]
+  pod "customerio-reactnative", :path => cio_package_path, :subspecs => [push_provider, "location", "liveactivities"]
+  # TEMPORARY (REL-1): the Live Activities pods are not on CocoaPods trunk yet, so pull the whole
+  # Customer.io iOS SDK from the branch that carries their podspecs. Remove once they ship.
+  %w[
+    CustomerIO CustomerIOCommon CustomerIODataPipelines CustomerIOTrackingMigration
+    CustomerIOMessagingPush CustomerIOMessagingPushAPN CustomerIOMessagingInApp CustomerIOLocation
+    CustomerIOLiveActivities CustomerIOLiveActivitiesAttributes CustomerIOLiveActivitiesTemplates
+  ].each do |cio_pod|
+    pod cio_pod, :git => "https://github.com/customerio/customerio-ios.git", :branch => "feat/live-activities"
+  end
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: push_provider)
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: push_provider)
 
@@ -82,4 +93,15 @@ target nse_target_name do
   pod "customerio-reactnative-richpush/#{push_provider}", :path => cio_package_path
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: true, push_service: push_provider)
   # install_non_production_ios_sdk_git_branch(branch_name: 'BRANCH-NAME-HERE', is_app_extension: true, push_service: push_provider)
+end
+
+# Live Activities Widget Extension: renders the built-in SDK templates plus the app-owned custom
+# one. The widget links the attributes + templates pods directly; it does not inherit the app
+# target's pods.
+target "LiveActivityWidget" do
+  # TEMPORARY (REL-1): these pods are not on CocoaPods trunk yet, so pull them from the branch that
+  # carries their podspecs. Remove the :git/:branch overrides once Live Activities ships.
+  %w[CustomerIOLiveActivitiesTemplates CustomerIOLiveActivitiesAttributes].each do |cio_pod|
+    pod cio_pod, :git => "https://github.com/customerio/customerio-ios.git", :branch => "feat/live-activities"
+  end
 end

--- a/example/ios/SampleApp.xcodeproj.tracked/project.pbxproj
+++ b/example/ios/SampleApp.xcodeproj.tracked/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3F21DFC9CDA733A3E4C4576D /* LiveActivityWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 2FA91E07A031C20270FC9492 /* LiveActivityWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		6027E65D2DB84F1A002F3F8A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6027E6572DB84F1A002F3F8A /* Assets.xcassets */; };
 		6027E65F2DB84F1A002F3F8A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6027E65A2DB84F1A002F3F8A /* LaunchScreen.storyboard */; };
 		6027E6602DB84F1A002F3F8A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6027E6562DB84F1A002F3F8A /* AppDelegate.swift */; };
@@ -15,9 +16,19 @@
 		6027E67E2DB8507B002F3F8A /* Env.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6027E6782DB8507B002F3F8A /* Env.swift */; };
 		6027E6802DB8507B002F3F8A /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6027E67B2DB8507B002F3F8A /* NotificationService.swift */; };
 		6027E6822DB85145002F3F8A /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6027E6812DB85145002F3F8A /* GoogleService-Info.plist */; };
+		A52CBC81C45FFD335A77686E /* RideshareLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D51740CB2F3D1F7968BFDC /* RideshareLiveActivity.swift */; };
+		B3308ADC4285759BC2F56637 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46FB8D344F4C2D92F366D48B /* Foundation.framework */; };
+		D24313EAB27CE236230665DD /* LiveActivityWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67464F634D3D1DD1B66802C5 /* LiveActivityWidgetBundle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		3970D3BF398DC5FDA02BD8E5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6027E6222DB8477F002F3F8A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 639DAFF193923EF6076C8D2E;
+			remoteInfo = LiveActivityWidget;
+		};
 		6027E66C2DB84F97002F3F8A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6027E6222DB8477F002F3F8A /* Project object */;
@@ -35,6 +46,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				6027E66E2DB84F97002F3F8A /* NotificationServiceExtension.appex in Embed Foundation Extensions */,
+				3F21DFC9CDA733A3E4C4576D /* LiveActivityWidget.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -42,6 +54,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2FA91E07A031C20270FC9492 /* LiveActivityWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; name = LiveActivityWidget.appex; path = LiveActivityWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		46FB8D344F4C2D92F366D48B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		6027E62A2DB8477F002F3F8A /* SampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6027E6562DB84F1A002F3F8A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6027E6572DB84F1A002F3F8A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -58,9 +72,22 @@
 		609C0BDC2DBE127100061E29 /* .Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = .Release.xcconfig; sourceTree = "<group>"; };
 		609C0BDD2DBE12A300061E29 /* .Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = .Debug.xcconfig; sourceTree = "<group>"; };
 		609C0BDE2DBE12A300061E29 /* .Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = .Release.xcconfig; sourceTree = "<group>"; };
+		67464F634D3D1DD1B66802C5 /* LiveActivityWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LiveActivityWidgetBundle.swift; path = LiveActivityWidget/LiveActivityWidgetBundle.swift; sourceTree = "<group>"; };
+		9E54E1130F8A696F39C18A68 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = LiveActivityWidget/Info.plist; sourceTree = "<group>"; };
+		CI0LAW1DEBUG0000000000AA /* .Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = .Debug.xcconfig; path = LiveActivityWidget/BuildSettings/.Debug.xcconfig; sourceTree = "<group>"; };
+		CI0LAW1RELEASE00000000AA /* .Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = .Release.xcconfig; path = LiveActivityWidget/BuildSettings/.Release.xcconfig; sourceTree = "<group>"; };
+		F5D51740CB2F3D1F7968BFDC /* RideshareLiveActivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RideshareLiveActivity.swift; path = LiveActivityWidget/RideshareLiveActivity.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		17BE8E1B6435D664A2B281DE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B3308ADC4285759BC2F56637 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6027E6272DB8477F002F3F8A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -85,6 +112,34 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		1C9CC8CC3496E6376044E945 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2374E649184F62C01522BD53 /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		2374E649184F62C01522BD53 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				46FB8D344F4C2D92F366D48B /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		38296FF0AB3FEE5CDEA5E4B4 /* LiveActivityWidget */ = {
+			isa = PBXGroup;
+			children = (
+				67464F634D3D1DD1B66802C5 /* LiveActivityWidgetBundle.swift */,
+				9E54E1130F8A696F39C18A68 /* Info.plist */,
+				F5D51740CB2F3D1F7968BFDC /* RideshareLiveActivity.swift */,
+				CI0LAW1DEBUG0000000000AA /* .Debug.xcconfig */,
+				CI0LAW1RELEASE00000000AA /* .Release.xcconfig */,
+			);
+			name = LiveActivityWidget;
+			sourceTree = SOURCE_ROOT;
+		};
 		6027E6212DB8477F002F3F8A = {
 			isa = PBXGroup;
 			children = (
@@ -92,6 +147,8 @@
 				6027E67C2DB8507B002F3F8A /* NotificationServiceExtension */,
 				6027E62B2DB8477F002F3F8A /* Products */,
 				051D7405610CA163A106992D /* Pods */,
+				1C9CC8CC3496E6376044E945 /* Frameworks */,
+				38296FF0AB3FEE5CDEA5E4B4 /* LiveActivityWidget */,
 			);
 			sourceTree = "<group>";
 		};
@@ -100,6 +157,7 @@
 			children = (
 				6027E62A2DB8477F002F3F8A /* SampleApp.app */,
 				6027E6672DB84F97002F3F8A /* NotificationServiceExtension.appex */,
+				2FA91E07A031C20270FC9492 /* LiveActivityWidget.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -165,6 +223,7 @@
 			);
 			dependencies = (
 				6027E66D2DB84F97002F3F8A /* PBXTargetDependency */,
+				9B9D3D7484CF1C38EC435FF3 /* PBXTargetDependency */,
 			);
 			name = SampleApp;
 			productName = SampleApp;
@@ -186,6 +245,23 @@
 			name = NotificationServiceExtension;
 			productName = NotificationServiceExtension;
 			productReference = 6027E6672DB84F97002F3F8A /* NotificationServiceExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		639DAFF193923EF6076C8D2E /* LiveActivityWidget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 780D80B378E95F0D60DF6BB8 /* Build configuration list for PBXNativeTarget "LiveActivityWidget" */;
+			buildPhases = (
+				34D44E8C89C0DD93D09651F9 /* Sources */,
+				17BE8E1B6435D664A2B281DE /* Frameworks */,
+				34953B5F12CEE3CBD17B0EF8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LiveActivityWidget;
+			productName = LiveActivityWidget;
+			productReference = 2FA91E07A031C20270FC9492 /* LiveActivityWidget.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
@@ -222,11 +298,19 @@
 			targets = (
 				6027E6292DB8477F002F3F8A /* SampleApp */,
 				6027E6662DB84F97002F3F8A /* NotificationServiceExtension */,
+				639DAFF193923EF6076C8D2E /* LiveActivityWidget */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		34953B5F12CEE3CBD17B0EF8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6027E6282DB8477F002F3F8A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -265,6 +349,15 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		34D44E8C89C0DD93D09651F9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D24313EAB27CE236230665DD /* LiveActivityWidgetBundle.swift in Sources */,
+				A52CBC81C45FFD335A77686E /* RideshareLiveActivity.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6027E6262DB8477F002F3F8A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -290,6 +383,12 @@
 			target = 6027E6662DB84F97002F3F8A /* NotificationServiceExtension */;
 			targetProxy = 6027E66C2DB84F97002F3F8A /* PBXContainerItemProxy */;
 		};
+		9B9D3D7484CF1C38EC435FF3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = LiveActivityWidget;
+			target = 639DAFF193923EF6076C8D2E /* LiveActivityWidget */;
+			targetProxy = 3970D3BF398DC5FDA02BD8E5 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -304,6 +403,31 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		53F519B219C11356495E50A4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CI0LAW1DEBUG0000000000AA /* .Debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = LiveActivityWidget/Info.plist;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = 2YC97BQN3N;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_NAME = LiveActivityWidget;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 		6027E63E2DB84781002F3F8A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 609C0BDB2DBE127100061E29 /* .Debug.xcconfig */;
@@ -575,6 +699,33 @@
 			};
 			name = Release;
 		};
+		E46988A20C9404BDC3521A5E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CI0LAW1RELEASE00000000AA /* .Release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = LiveActivityWidget/Info.plist;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = 2YC97BQN3N;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_NAME = LiveActivityWidget;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -601,6 +752,15 @@
 			buildConfigurations = (
 				6027E6712DB84F97002F3F8A /* Debug */,
 				6027E6722DB84F97002F3F8A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		780D80B378E95F0D60DF6BB8 /* Build configuration list for PBXNativeTarget "LiveActivityWidget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E46988A20C9404BDC3521A5E /* Release */,
+				53F519B219C11356495E50A4 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/example/ios/SampleApp/AppDelegate.swift
+++ b/example/ios/SampleApp/AppDelegate.swift
@@ -4,6 +4,8 @@ import React_RCTAppDelegate
 import ReactAppDependencyProvider
 
 import UserNotifications
+// Wrapper pod module — exposes NativeLiveActivities for reporting a Live Activity deep-link open.
+import customerio_reactnative
 
 #if USE_FCM
 import FirebaseMessaging
@@ -83,7 +85,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 // MARK: Deep linking
 extension AppDelegate {
   func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-    return RCTLinkingManager.application(app, open: url, options: options)
+    // Reference pattern: report the "opened" metric when the app is launched from a tapped Live
+    // Activity. A Live Activity tap arrives here (the app's URL entry point), not through JS, so the
+    // host app forwards the URL to the wrapper. For a Customer.io widget URL this returns the
+    // customer's redirect target to route to (nil when it carries none); any other URL comes back
+    // unchanged, so existing deep links keep working.
+    guard let routableUrl = NativeLiveActivities.handleWidgetUrl(url) else { return true }
+
+    return RCTLinkingManager.application(app, open: routableUrl, options: options)
   }
   
   func application(

--- a/example/ios/SampleApp/Info.plist
+++ b/example/ios/SampleApp/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/example/scripts/ios_project_setup_utils.rb
+++ b/example/scripts/ios_project_setup_utils.rb
@@ -1,9 +1,9 @@
 
-# Updates the symlinks in the BuildSettings folder for the app and NSE targets
-# based on the push provider.
+# Updates the symlinks in the BuildSettings folder for the app, NSE and Live Activity widget
+# targets based on the push provider.
 # The symlinks point to the xcconfig files that contain the app name, app id, provisioning profile, etc.
 
-def update_project_build_settings(installation_root, app_target_name, nse_target_name, push_provider)
+def update_project_build_settings(installation_root, app_target_name, nse_target_name, widget_target_name, push_provider)
 
   # Create a symlink to the GoogleService-Info.plist file in the root of the project
   # This file contains the configs for Firebase app distribution
@@ -11,7 +11,10 @@ def update_project_build_settings(installation_root, app_target_name, nse_target
   dest_google_service_info = "#{installation_root}/#{app_target_name}/GoogleService-Info.plist"
   system("ln -f #{src_google_service_info} #{dest_google_service_info}")
 
-  [app_target_name, nse_target_name].each do |target|
+  # The Live Activity widget is included: like the NSE it is an app extension, so its bundle id has
+  # to track the host app's per push provider — an extension id that isn't prefixed by its host's is
+  # rejected at signing.
+  [app_target_name, nse_target_name, widget_target_name].each do |target|
     ["Debug", "Release"].each do |config|
       # This will create a symlink to the xcconfig file in the build settings folder
       # The xcconfig file contains the app id, provisioning profile, and other settings

--- a/example/src/navigation/props.ts
+++ b/example/src/navigation/props.ts
@@ -12,6 +12,7 @@ export const CustomDeviceAttrScreenName = 'Device Attributes' as const;
 export const InternalSettingsScreenName = 'Internal Settings' as const;
 export const InlineExamplesScreenName = 'Inline Examples' as const;
 export const InboxMessagesScreenName = 'Inbox Messages' as const;
+export const LiveActivitiesScreenName = 'Live Activities' as const;
 export const LocationScreenName = 'Location' as const;
 
 export type NavigationStackParamList = {
@@ -25,6 +26,7 @@ export type NavigationStackParamList = {
   [InternalSettingsScreenName]: undefined;
   [InlineExamplesScreenName]: undefined;
   [InboxMessagesScreenName]: undefined;
+  [LiveActivitiesScreenName]: undefined;
   [LocationScreenName]: undefined;
 };
 

--- a/example/src/screens/content-navigator.tsx
+++ b/example/src/screens/content-navigator.tsx
@@ -5,6 +5,7 @@ import {
   InboxMessagesScreenName,
   InlineExamplesScreenName,
   InternalSettingsScreenName,
+  LiveActivitiesScreenName,
   LocationScreenName,
   LoginScreenName,
   NavigationCallbackContext,
@@ -23,6 +24,7 @@ import {
   InboxMessagesScreen,
   InlineExamplesScreen,
   InternalSettingsScreen,
+  LiveActivitiesScreen,
   LocationScreen,
   LogingScreen,
   SettingsScreen,
@@ -126,6 +128,15 @@ export const ContentNavigator = ({ appName }: { appName: string }) => {
           name={InboxMessagesScreenName}
           component={InboxMessagesScreen}
           options={{
+            headerBackButtonDisplayMode: 'minimal',
+            headerBackVisible: true,
+          }}
+        />
+        <Stack.Screen
+          name={LiveActivitiesScreenName}
+          component={LiveActivitiesScreen}
+          options={{
+            title: 'Live Activities',
             headerBackButtonDisplayMode: 'minimal',
             headerBackVisible: true,
           }}

--- a/example/src/screens/home.tsx
+++ b/example/src/screens/home.tsx
@@ -4,6 +4,7 @@ import {
   CustomProfileAttrScreenName,
   InboxMessagesScreenName,
   InlineExamplesScreenName,
+  LiveActivitiesScreenName,
   LocationScreenName,
   NavigationCallbackContext,
   NavigationScreenProps,
@@ -80,6 +81,10 @@ export const HomeScreen = ({
           <Button
             title="Location (test)"
             onPress={() => navigation.navigate(LocationScreenName)}
+          />
+          <Button
+            title="Live Activities"
+            onPress={() => navigation.navigate(LiveActivitiesScreenName)}
           />
         </View>
       </ScrollView>

--- a/example/src/screens/index.ts
+++ b/example/src/screens/index.ts
@@ -4,6 +4,7 @@ export * from './home';
 export * from './inbox-messages';
 export * from './inline-examples';
 export * from './internal-settings';
+export * from './liveactivities';
 export * from './location';
 export * from './login';
 export * from './settings';

--- a/example/src/screens/liveactivities.tsx
+++ b/example/src/screens/liveactivities.tsx
@@ -1,0 +1,254 @@
+import { BodyText, Button, ButtonExperience } from '@components';
+import { Colors } from '@colors';
+import { CustomerIO, LiveActivityTemplate } from 'customerio-reactnative';
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { showMessage } from 'react-native-flash-message';
+
+const SectionCard = ({ children }: { children: React.ReactNode }) => (
+  <View style={styles.sectionCard}>{children}</View>
+);
+
+export const LiveActivitiesScreen = () => {
+  const [segmentsId, setSegmentsId] = useState<string | null>(null);
+  const [segmentsComplete, setSegmentsComplete] = useState(0);
+  const [countdownId, setCountdownId] = useState<string | null>(null);
+  const [customId, setCustomId] = useState<string | null>(null);
+
+  const segmentsTotal = 4;
+
+  const startSegments = async () => {
+    try {
+      const id = await CustomerIO.liveActivities.start({
+        type: LiveActivityTemplate.Segments,
+        header: 'Order #4021',
+        status: 'Preparing your order',
+        segmentsTotal,
+        segmentsComplete: 1,
+      });
+      setSegmentsId(id);
+      setSegmentsComplete(1);
+      showMessage({ message: `Segments started (${id})`, type: 'success' });
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const advanceSegments = async () => {
+    if (!segmentsId) return;
+    const next = Math.min(segmentsComplete + 1, segmentsTotal);
+    try {
+      await CustomerIO.liveActivities.update(segmentsId, {
+        type: LiveActivityTemplate.Segments,
+        header: 'Order #4021',
+        status: next >= segmentsTotal ? 'Delivered' : 'Out for delivery',
+        segmentsTotal,
+        segmentsComplete: next,
+      });
+      setSegmentsComplete(next);
+      showMessage({
+        message: `Segments → ${next}/${segmentsTotal}`,
+        type: 'success',
+      });
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const endSegments = async () => {
+    if (!segmentsId) return;
+    try {
+      // Pass a final content-state so iOS renders a terminal card instead of freezing on the
+      // last progress value. Android ignores it and renders its own terminal state.
+      await CustomerIO.liveActivities.end(segmentsId, {
+        type: LiveActivityTemplate.Segments,
+        header: 'Order #4021',
+        status: 'Delivered',
+        segmentsTotal,
+        segmentsComplete: segmentsTotal,
+      });
+      showMessage({ message: 'Segments ended', type: 'info' });
+      setSegmentsId(null);
+      setSegmentsComplete(0);
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const startCountdown = async () => {
+    try {
+      const id = await CustomerIO.liveActivities.start({
+        type: LiveActivityTemplate.CountdownTimer,
+        header: 'Flash Sale',
+        title: '50% off ends in',
+        statusMessage: 'Hurry!',
+        endTime: Math.floor(Date.now() / 1000) + 3600, // epoch seconds, +1h
+      });
+      setCountdownId(id);
+      showMessage({ message: `Countdown started (${id})`, type: 'success' });
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const endCountdown = async () => {
+    if (!countdownId) return;
+    try {
+      // Terminal state: drop the endTime so the card reads as finished rather than counting down.
+      await CustomerIO.liveActivities.end(countdownId, {
+        type: LiveActivityTemplate.CountdownTimer,
+        header: 'Flash sale',
+        title: 'Sale ended',
+        statusMessage: 'Thanks for shopping',
+      });
+      showMessage({ message: 'Countdown ended', type: 'info' });
+      setCountdownId(null);
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  // Custom template — "Rideshare".
+  //
+  // One code path on both platforms. The SDK owns the attributes type, so the payload is just a
+  // map of strings: iOS renders it from `CIOCustomAttributes` in the Widget Extension, Android
+  // from the app's `createLiveNotification` callback (wired in MainApplication). The activity is
+  // named by `liveNotifications.customType` in the SDK config, not here.
+  const rideshare = (status: string, etaMinutes: number) => ({
+    type: LiveActivityTemplate.Custom as const,
+    // Values are strings — a bridge payload carries no schema, so the widget parses what it needs.
+    data: { driverName: 'Alex', status, etaMinutes: String(etaMinutes) },
+  });
+
+  const startCustom = async () => {
+    try {
+      const id = await CustomerIO.liveActivities.start(
+        rideshare('On the way', 5)
+      );
+      setCustomId(id);
+      showMessage({ message: `Rideshare started (${id})`, type: 'success' });
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const updateCustom = async () => {
+    if (!customId) return;
+    try {
+      await CustomerIO.liveActivities.update(
+        customId,
+        rideshare('Almost there', 2)
+      );
+      showMessage({ message: 'Rideshare updated', type: 'success' });
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  const endCustom = async () => {
+    if (!customId) return;
+    try {
+      // A final content-state so the card reads as finished rather than freezing mid-trip.
+      await CustomerIO.liveActivities.end(customId, rideshare('Arrived', 0));
+      showMessage({ message: 'Rideshare ended', type: 'info' });
+      setCustomId(null);
+    } catch (e) {
+      showMessage({ message: (e as Error).message, type: 'danger' });
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.scrollContent}>
+      <View style={styles.container}>
+        <SectionCard>
+          <BodyText style={styles.sectionHeading}>SEGMENTS</BodyText>
+          <Button
+            title="Start Segments"
+            experience={ButtonExperience.callToAction}
+            onPress={startSegments}
+          />
+          <Button
+            title="Advance Segment (update)"
+            experience={ButtonExperience.normal}
+            onPress={advanceSegments}
+            disabled={!segmentsId}
+          />
+          <Button
+            title="End Segments"
+            experience={ButtonExperience.normal}
+            onPress={endSegments}
+            disabled={!segmentsId}
+          />
+          <BodyText style={styles.hint}>
+            {segmentsId
+              ? `Running: ${segmentsComplete}/${segmentsTotal}`
+              : 'Not started'}
+          </BodyText>
+        </SectionCard>
+
+        <SectionCard>
+          <BodyText style={styles.sectionHeading}>COUNTDOWN TIMER</BodyText>
+          <Button
+            title="Start Countdown (+1h)"
+            experience={ButtonExperience.callToAction}
+            onPress={startCountdown}
+          />
+          <Button
+            title="End Countdown"
+            experience={ButtonExperience.normal}
+            onPress={endCountdown}
+            disabled={!countdownId}
+          />
+          <BodyText style={styles.hint}>
+            {countdownId ? 'Running' : 'Not started'}
+          </BodyText>
+        </SectionCard>
+
+        <SectionCard>
+          <BodyText style={styles.sectionHeading}>CUSTOM (RIDESHARE)</BodyText>
+          <Button
+            title="Start Custom"
+            experience={ButtonExperience.callToAction}
+            onPress={startCustom}
+          />
+          <Button
+            title="Update Custom"
+            experience={ButtonExperience.normal}
+            onPress={updateCustom}
+            disabled={!customId}
+          />
+          <Button
+            title="End Custom"
+            experience={ButtonExperience.normal}
+            onPress={endCustom}
+            disabled={!customId}
+          />
+          <BodyText style={styles.hint}>
+            {customId ? 'Running' : 'Not started'}
+          </BodyText>
+        </SectionCard>
+
+        <BodyText style={styles.note}>
+          Android renders live notifications in-SDK; custom types go to the app's
+          createLiveNotification callback. iOS additionally requires a Widget
+          Extension — the SDK ships the SwiftUI for the built-in templates, and
+          the app supplies a view for the custom one.
+        </BodyText>
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  scrollContent: { paddingBottom: 24 },
+  container: { padding: 16, gap: 16 },
+  sectionCard: {
+    padding: 16,
+    borderRadius: 8,
+    backgroundColor: Colors.bodySecondaryBg,
+    gap: 12,
+  },
+  sectionHeading: { fontWeight: '700', marginBottom: 4 },
+  hint: { opacity: 0.9, marginTop: 4 },
+  note: { opacity: 0.8, marginTop: 8, textAlign: 'center' },
+});

--- a/example/src/services/storage.ts
+++ b/example/src/services/storage.ts
@@ -1,6 +1,11 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { User } from '@utils';
-import { CioConfig, CioLocationTrackingMode, CioLogLevel, CioRegion } from 'customerio-reactnative';
+import {
+  CioConfig,
+  CioLocationTrackingMode,
+  CioLogLevel,
+  CioRegion,
+} from 'customerio-reactnative';
 import { Env } from '../env';
 
 const USER_STORAGE_KEY = 'user';

--- a/example/src/services/storage.ts
+++ b/example/src/services/storage.ts
@@ -5,6 +5,7 @@ import {
   CioLocationTrackingMode,
   CioLogLevel,
   CioRegion,
+  LiveActivityTemplate,
 } from 'customerio-reactnative';
 import { Env } from '../env';
 
@@ -24,6 +25,13 @@ const createDefaultConfig = (env: Env | null | undefined): Config => {
     trackApplicationLifecycleEvents: true,
     location: {
       trackingMode: CioLocationTrackingMode.OnAppStart,
+    },
+    liveNotifications: {
+      types: [
+        LiveActivityTemplate.Segments,
+        LiveActivityTemplate.CountdownTimer,
+      ],
+      customType: 'io.customer.livenotifications.custom.rideshare',
     },
   };
 };

--- a/ios/wrappers/NativeCustomerIO.swift
+++ b/ios/wrappers/NativeCustomerIO.swift
@@ -54,6 +54,12 @@ public class NativeCustomerIO: NSObject {
             }
             #endif
 
+            #if CIO_LIVEACTIVITIES_ENABLED
+            if let liveActivitiesModule = NativeLiveActivities.module(from: config) {
+                _ = sdkConfigBuilder.addModule(liveActivitiesModule)
+            }
+            #endif
+
             let builtConfig = sdkConfigBuilder.build()
 
             // Only CustomerIO.initialize must run on the main thread (e.g. for Location module).
@@ -63,11 +69,6 @@ public class NativeCustomerIO: NSObject {
                     return
                 }
                 CustomerIO.initialize(withConfig: builtConfig)
-
-                #if CIO_LIVEACTIVITIES_ENABLED
-                // Initialize Live Activities after CustomerIO.initialize (it reads the shared SDK).
-                NativeLiveActivities.initializeModule(from: config)
-                #endif
 
                 do {
                     // Initialize in-app messaging if config provided

--- a/ios/wrappers/NativeCustomerIO.swift
+++ b/ios/wrappers/NativeCustomerIO.swift
@@ -64,6 +64,11 @@ public class NativeCustomerIO: NSObject {
                 }
                 CustomerIO.initialize(withConfig: builtConfig)
 
+                #if CIO_LIVEACTIVITIES_ENABLED
+                // Initialize Live Activities after CustomerIO.initialize (it reads the shared SDK).
+                NativeLiveActivities.initializeModule(from: config)
+                #endif
+
                 do {
                     // Initialize in-app messaging if config provided
                     if let inAppConfig = try MessagingInAppConfigBuilder.build(from: config) {

--- a/ios/wrappers/liveactivities/NativeLiveActivities.mm
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.mm
@@ -65,17 +65,6 @@ RCT_EXPORT_MODULE()
   [_swiftBridge end:activityId payload:payload resolve:resolve reject:reject];
 }
 
-- (void)startCustom:(NSString *)activityType
-            payload:(NSDictionary *)payload
-            resolve:(RCTPromiseResolveBlock)resolve
-             reject:(RCTPromiseRejectBlock)reject {
-  if (!_swiftBridge) {
-    reject(@"live_activity_module_unavailable", @"Live Activities are unavailable.", nil);
-    return;
-  }
-  [_swiftBridge startCustom:activityType payload:payload resolve:resolve reject:reject];
-}
-
 // Export class factory function for React Native component registration
 Class<RCTBridgeModule> NativeCustomerIOLiveActivitiesCls(void) {
   return RCTNativeLiveActivities.class;

--- a/ios/wrappers/liveactivities/NativeLiveActivities.mm
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.mm
@@ -1,0 +1,83 @@
+#import <React/RCTBridgeModule.h>
+#import <RNCustomerIOSpec/RNCustomerIOSpec.h>
+
+// Objective-C wrapper for new architecture TurboModule implementation
+@interface RCTNativeLiveActivities : NSObject <NativeCustomerIOLiveActivitiesSpec>
+// Bridge to Swift implementation for cross-language compatibility
+@property(nonatomic, strong) id<NativeCustomerIOLiveActivitiesSpec> swiftBridge;
+@end
+
+@implementation RCTNativeLiveActivities
+
+RCT_EXPORT_MODULE()
+
+// Create TurboModule instance for new architecture JSI integration
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params {
+  return std::make_shared<facebook::react::NativeCustomerIOLiveActivitiesSpecJSI>(params);
+}
+
+- (instancetype)init {
+  if (self = [super init]) {
+    // Runtime class lookup - the Swift class only exists when the liveactivities subspec is installed.
+    Class swiftClass = NSClassFromString(@"NativeCustomerIOLiveActivities");
+    if (swiftClass) {
+      _swiftBridge = [[swiftClass alloc] init];
+    }
+  }
+  return self;
+}
+
+// Module initialization can happen on background thread
++ (BOOL)requiresMainQueueSetup {
+  return NO;
+}
+
+- (void)start:(NSDictionary *)payload
+      resolve:(RCTPromiseResolveBlock)resolve
+       reject:(RCTPromiseRejectBlock)reject {
+  if (!_swiftBridge) {
+    reject(@"live_activity_module_unavailable", @"Live Activities are unavailable.", nil);
+    return;
+  }
+  [_swiftBridge start:payload resolve:resolve reject:reject];
+}
+
+- (void)update:(NSString *)activityId
+       payload:(NSDictionary *)payload
+       resolve:(RCTPromiseResolveBlock)resolve
+        reject:(RCTPromiseRejectBlock)reject {
+  if (!_swiftBridge) {
+    reject(@"live_activity_module_unavailable", @"Live Activities are unavailable.", nil);
+    return;
+  }
+  [_swiftBridge update:activityId payload:payload resolve:resolve reject:reject];
+}
+
+- (void)end:(NSString *)activityId
+    resolve:(RCTPromiseResolveBlock)resolve
+     reject:(RCTPromiseRejectBlock)reject {
+  if (!_swiftBridge) {
+    reject(@"live_activity_module_unavailable", @"Live Activities are unavailable.", nil);
+    return;
+  }
+  [_swiftBridge end:activityId resolve:resolve reject:reject];
+}
+
+- (void)startCustom:(NSString *)activityType
+            payload:(NSDictionary *)payload
+            resolve:(RCTPromiseResolveBlock)resolve
+             reject:(RCTPromiseRejectBlock)reject {
+  if (!_swiftBridge) {
+    reject(@"live_activity_module_unavailable", @"Live Activities are unavailable.", nil);
+    return;
+  }
+  [_swiftBridge startCustom:activityType payload:payload resolve:resolve reject:reject];
+}
+
+// Export class factory function for React Native component registration
+Class<RCTBridgeModule> NativeCustomerIOLiveActivitiesCls(void) {
+  return RCTNativeLiveActivities.class;
+}
+
+@end

--- a/ios/wrappers/liveactivities/NativeLiveActivities.mm
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.mm
@@ -55,13 +55,14 @@ RCT_EXPORT_MODULE()
 }
 
 - (void)end:(NSString *)activityId
+    payload:(NSDictionary *)payload
     resolve:(RCTPromiseResolveBlock)resolve
      reject:(RCTPromiseRejectBlock)reject {
   if (!_swiftBridge) {
     reject(@"live_activity_module_unavailable", @"Live Activities are unavailable.", nil);
     return;
   }
-  [_swiftBridge end:activityId resolve:resolve reject:reject];
+  [_swiftBridge end:activityId payload:payload resolve:resolve reject:reject];
 }
 
 - (void)startCustom:(NSString *)activityType

--- a/ios/wrappers/liveactivities/NativeLiveActivities.swift
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.swift
@@ -20,11 +20,6 @@ public class NativeLiveActivities: NSObject {
         static let custom = "custom"
     }
 
-    /// The app's own identifier for the custom template, captured from config at init. Kept only so
-    /// `start` can explain *why* a custom payload was refused; the SDK resolves the identifier it
-    /// reports from the registration itself.
-    private static var customActivityType: String?
-
     /// Type-erased handles keyed by activity id. The native `start` returns a generic
     /// `CIOLiveActivity<Attributes>` that can't cross the bridge, so we keep closures that capture
     /// the concrete handle and rebuild its content-state from a JS map on update.
@@ -73,12 +68,9 @@ public class NativeLiveActivities: NSObject {
         // The custom template registers one SDK-owned Swift type under the app's own identifier.
         // That indirection is what lets a JavaScript app have a custom activity at all: the SDK needs
         // a metatype to register and to observe push-to-start for, and a metatype can't cross a bridge.
-        // Assigned unconditionally: a re-initialize that drops `customType` must clear it, or `start`
-        // would keep accepting custom payloads for a type that is no longer registered.
         let trimmedCustomType = (liveConfig["customType"] as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let customType = (trimmedCustomType?.isEmpty == false) ? trimmedCustomType : nil
-        customActivityType = customType
         if let customType {
             builder = builder.register(CIOCustomAttributes.self, identifier: customType)
         }
@@ -124,20 +116,15 @@ public class NativeLiveActivities: NSObject {
                 Self.store(handle: handle, contentBuilder: Self.countdownState)
                 id = handle.id
             case TypeIdentifier.custom:
-                guard Self.customActivityType != nil else {
-                    return reject(
-                        Self.notRegisteredCode,
-                        "No custom Live Activity type is configured. Set `liveNotifications.customType` " +
-                            "in your Customer.io SDK config to your own reverse-DNS identifier, and render " +
-                            "CIOCustomAttributes in your Widget Extension.",
-                        nil
-                    )
-                }
+                // No pre-check on the stored identifier: the SDK config can also be built by generated
+                // native code that never calls `module(from:)` — the Expo config plugin does exactly
+                // that — so a nil stored value doesn't mean the type is unregistered. Attempt the start
+                // and let the SDK answer; a nil handle means it genuinely isn't registered.
                 guard let handle = try CustomerIO.liveActivities.start(
                     CIOCustomAttributes(),
                     contentState: Self.customState(from: map)
                 ) else {
-                    return reject(Self.notRegisteredCode, Self.notRegisteredMessage(type), nil)
+                    return reject(Self.notRegisteredCode, Self.customNotRegisteredMessage, nil)
                 }
                 Self.store(handle: handle, contentBuilder: Self.customState)
                 id = handle.id
@@ -323,6 +310,11 @@ public class NativeLiveActivities: NSObject {
     private static let unavailableCode = "live_activity_module_unavailable"
     private static let unavailableMessage =
         "Live Activities require iOS 16.2 or later."
+
+    private static let customNotRegisteredMessage =
+        "No custom Live Activity type is registered. Set `liveNotifications.customType` in your " +
+        "Customer.io SDK config to your own reverse-DNS identifier, and render CIOCustomAttributes " +
+        "in your Widget Extension."
 
     private static let notRegisteredCode = "live_activity_type_not_registered"
     private static func notRegisteredMessage(_ type: String) -> String {

--- a/ios/wrappers/liveactivities/NativeLiveActivities.swift
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.swift
@@ -1,6 +1,7 @@
 #if CIO_LIVEACTIVITIES_ENABLED
 import ActivityKit
 import CioDataPipelines
+import CioInternalCommon
 import CioLiveActivities
 import CioLiveActivities_Attributes
 import CioLiveActivities_Templates
@@ -26,6 +27,16 @@ public class NativeLiveActivities: NSObject {
 
     private static var activities: [String: ActivityBox] = [:]
     private static let lock = NSLock()
+
+    /// Records an `update`/`end` aimed at an activity this process never started. Not surfaced to
+    /// JavaScript — see the call sites — but worth a log, because the same message covers both a
+    /// genuine caller mistake and the expected post-restart / push-started cases.
+    private static func logUnknownActivity(_ activityId: String, method: String) {
+        DIGraphShared.shared.logger.info(
+            "Live Activities: \(method) ignored — no activity with id \(activityId) was started by this app session. " +
+                "Activities started before an app restart, or started by a push, are not tracked in-process."
+        )
+    }
 
     // MARK: - Module registration
 
@@ -113,8 +124,13 @@ public class NativeLiveActivities: NSObject {
         Self.lock.lock()
         let box = Self.activities[activityId]
         Self.lock.unlock()
+        // An id this process didn't start resolves rather than rejects, matching `end` here and both
+        // methods on Android (which routes the id to the native SDK and never learns it was unknown).
+        // "Unknown" is not proof of caller error: the map is process-local, so an activity started
+        // before an app restart, or started by a push, legitimately isn't in it. Logged, not thrown.
         guard let box else {
-            return reject("live_activity_update_failed", "No live activity found for id \(activityId)", nil)
+            Self.logUnknownActivity(activityId, method: "update")
+            return resolve(nil)
         }
         guard let map = payload as? [String: Any] else {
             return reject("live_activity_update_failed", "payload is required", nil)
@@ -139,8 +155,12 @@ public class NativeLiveActivities: NSObject {
         Self.lock.lock()
         let box = Self.activities.removeValue(forKey: activityId)
         Self.lock.unlock()
-        // Unknown/already-ended id is treated as success (idempotent end).
-        guard let box else { return resolve(nil) }
+        // Unknown/already-ended id is treated as success (idempotent end). See `update` for why an
+        // unknown id is not an error.
+        guard let box else {
+            Self.logUnknownActivity(activityId, method: "end")
+            return resolve(nil)
+        }
         let map = payload as? [String: Any]
         Task {
             do {

--- a/ios/wrappers/liveactivities/NativeLiveActivities.swift
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.swift
@@ -1,0 +1,200 @@
+#if CIO_LIVEACTIVITIES_ENABLED
+import ActivityKit
+import CioDataPipelines
+import CioLiveActivities
+import CioLiveActivities_Attributes
+import CioLiveActivities_Templates
+import Foundation
+
+@objc(NativeCustomerIOLiveActivities)
+public class NativeLiveActivities: NSObject {
+    /// The held Live Activities module (not a singleton in the native SDK), created during SDK init.
+    private static var module: LiveActivitiesModule?
+
+    /// Type-erased handles keyed by activity id. The native `start` returns a generic
+    /// `CIOLiveActivity<Attributes>` that can't cross the bridge, so we keep closures that capture
+    /// the concrete handle and rebuild its content-state from a JS map on update.
+    private struct ActivityBox {
+        let update: ([String: Any]) async throws -> Void
+        let end: () async -> Void
+    }
+
+    private static var activities: [String: ActivityBox] = [:]
+    private static let lock = NSLock()
+
+    // MARK: - Init from SDK config
+
+    /// Initialize the Live Activities module from the SDK config's `liveActivities` key. Registers
+    /// the enabled built-in template attribute types so `start` can request them.
+    static func initializeModule(from config: [String: Any]) {
+        guard let laConfig = config["liveActivities"] as? [String: Any] else { return }
+        guard #available(iOS 16.2, *) else { return }
+        let templates = (laConfig["templates"] as? [String]) ?? []
+        var builder = LiveActivityConfigBuilder()
+        if templates.contains("segments") {
+            builder = builder.register(CIOSegmentsAttributes.self)
+        }
+        if templates.contains("countdownTimer") {
+            builder = builder.register(CIOCountdownTimerAttributes.self)
+        }
+        module = LiveActivitiesModule.initialize(builder.build())
+    }
+
+    // MARK: - Bridge methods
+
+    @objc(start:resolve:reject:)
+    public func start(
+        _ payload: NSDictionary,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        guard #available(iOS 16.2, *), let module = Self.module else {
+            return reject(Self.unavailableCode, Self.unavailableMessage, nil)
+        }
+        guard let map = payload as? [String: Any], let type = map["type"] as? String else {
+            return reject("live_activity_start_failed", "payload.type is required", nil)
+        }
+        do {
+            let id: String
+            switch type {
+            case "segments":
+                let handle = try module.start(
+                    CIOSegmentsAttributes(header: map["header"] as? String ?? ""),
+                    contentState: Self.segmentsState(from: map)
+                )
+                Self.store(handle: handle, contentBuilder: Self.segmentsState)
+                id = handle.id
+            case "countdownTimer":
+                let handle = try module.start(
+                    CIOCountdownTimerAttributes(header: map["header"] as? String ?? ""),
+                    contentState: Self.countdownState(from: map)
+                )
+                Self.store(handle: handle, contentBuilder: Self.countdownState)
+                id = handle.id
+            default:
+                return reject("live_activity_start_failed", "Unknown live activity template type: \(type)", nil)
+            }
+            resolve(id)
+        } catch {
+            reject("live_activity_start_failed", error.localizedDescription, error)
+        }
+    }
+
+    @objc(update:payload:resolve:reject:)
+    public func update(
+        _ activityId: String,
+        payload: NSDictionary,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        Self.lock.lock()
+        let box = Self.activities[activityId]
+        Self.lock.unlock()
+        guard let box else {
+            return reject("live_activity_update_failed", "No live activity found for id \(activityId)", nil)
+        }
+        guard let map = payload as? [String: Any] else {
+            return reject("live_activity_update_failed", "payload is required", nil)
+        }
+        Task {
+            do {
+                try await box.update(map)
+                resolve(nil)
+            } catch {
+                reject("live_activity_update_failed", error.localizedDescription, error)
+            }
+        }
+    }
+
+    @objc(end:resolve:reject:)
+    public func end(
+        _ activityId: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject _: @escaping RCTPromiseRejectBlock
+    ) {
+        Self.lock.lock()
+        let box = Self.activities.removeValue(forKey: activityId)
+        Self.lock.unlock()
+        // Unknown/already-ended id is treated as success (idempotent end).
+        guard let box else { return resolve(nil) }
+        Task {
+            await box.end()
+            resolve(nil)
+        }
+    }
+
+    @objc(startCustom:payload:resolve:reject:)
+    public func startCustom(
+        _: String,
+        payload _: NSDictionary,
+        resolve _: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        // Custom activity types on iOS require a native Widget Extension + ActivityAttributes and an
+        // `adopt(_:)` call; they cannot be data-driven across the bridge.
+        reject(
+            "live_activity_custom_unsupported_ios",
+            "Custom live activity types are not supported from JavaScript on iOS. Use a native Widget Extension and adopt().",
+            nil
+        )
+    }
+
+    /// Report an `opened` metric when the app is opened from a tapped Live Activity.
+    ///
+    /// Not exposed to JavaScript: a Live Activity tap arrives through the app's native URL/scene
+    /// entry point, so call this from there (see the sample app's `AppDelegate`). Returns `true`
+    /// if `url` matched a Customer.io-tracked activity's deep link.
+    @discardableResult
+    public static func reportDeepLinkOpen(_ url: URL) -> Bool {
+        module?.handleDeepLinkOpen(url) ?? false
+    }
+
+    // MARK: - Helpers
+
+    @available(iOS 16.2, *)
+    private static func store<A: ActivityAttributes>(
+        handle: CIOLiveActivity<A>,
+        contentBuilder: @escaping ([String: Any]) throws -> A.ContentState
+    ) {
+        let box = ActivityBox(
+            update: { map in await handle.update(try contentBuilder(map)) },
+            end: { await handle.end() }
+        )
+        lock.lock()
+        activities[handle.id] = box
+        lock.unlock()
+    }
+
+    @available(iOS 16.2, *)
+    private static func segmentsState(from map: [String: Any]) throws -> CIOSegmentsAttributes.ContentState {
+        CIOSegmentsAttributes.ContentState(
+            status: map["status"] as? String ?? "",
+            substatus: map["substatus"] as? String,
+            segmentsTotal: intValue(map["segmentsTotal"]),
+            segmentsComplete: intValue(map["segmentsComplete"]),
+            trailingText: map["trailingText"] as? String
+        )
+    }
+
+    @available(iOS 16.2, *)
+    private static func countdownState(from map: [String: Any]) throws -> CIOCountdownTimerAttributes.ContentState {
+        var endTime: EpochSecondsDate?
+        if let seconds = map["endTime"] as? NSNumber {
+            endTime = EpochSecondsDate(Date(timeIntervalSince1970: seconds.doubleValue))
+        }
+        return CIOCountdownTimerAttributes.ContentState(
+            title: map["title"] as? String ?? "",
+            statusMessage: map["statusMessage"] as? String,
+            endTime: endTime
+        )
+    }
+
+    private static func intValue(_ any: Any?) -> Int {
+        (any as? NSNumber)?.intValue ?? 0
+    }
+
+    private static let unavailableCode = "live_activity_module_unavailable"
+    private static let unavailableMessage =
+        "Live Activities are unavailable. Enable live activity templates in the SDK config and add the widget extension."
+}
+#endif

--- a/ios/wrappers/liveactivities/NativeLiveActivities.swift
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.swift
@@ -73,9 +73,13 @@ public class NativeLiveActivities: NSObject {
         // The custom template registers one SDK-owned Swift type under the app's own identifier.
         // That indirection is what lets a JavaScript app have a custom activity at all: the SDK needs
         // a metatype to register and to observe push-to-start for, and a metatype can't cross a bridge.
-        if let customType = (liveConfig["customType"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !customType.isEmpty {
-            customActivityType = customType
+        // Assigned unconditionally: a re-initialize that drops `customType` must clear it, or `start`
+        // would keep accepting custom payloads for a type that is no longer registered.
+        let trimmedCustomType = (liveConfig["customType"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let customType = (trimmedCustomType?.isEmpty == false) ? trimmedCustomType : nil
+        customActivityType = customType
+        if let customType {
             builder = builder.register(CIOCustomAttributes.self, identifier: customType)
         }
         return LiveActivitiesModule(config: builder.build())
@@ -103,7 +107,7 @@ public class NativeLiveActivities: NSObject {
             switch type {
             case TypeIdentifier.segments:
                 guard let handle = try CustomerIO.liveActivities.start(
-                    CIOSegmentsAttributes(header: map["header"] as? String ?? ""),
+                    CIOSegmentsAttributes(header: try Self.requireString(map, "header")),
                     contentState: Self.segmentsState(from: map)
                 ) else {
                     return reject(Self.notRegisteredCode, Self.notRegisteredMessage(type), nil)
@@ -112,7 +116,7 @@ public class NativeLiveActivities: NSObject {
                 id = handle.id
             case TypeIdentifier.countdownTimer:
                 guard let handle = try CustomerIO.liveActivities.start(
-                    CIOCountdownTimerAttributes(header: map["header"] as? String ?? ""),
+                    CIOCountdownTimerAttributes(header: try Self.requireString(map, "header")),
                     contentState: Self.countdownState(from: map)
                 ) else {
                     return reject(Self.notRegisteredCode, Self.notRegisteredMessage(type), nil)
@@ -193,7 +197,7 @@ public class NativeLiveActivities: NSObject {
         reject: @escaping RCTPromiseRejectBlock
     ) {
         Self.lock.lock()
-        let box = Self.activities.removeValue(forKey: activityId)
+        let box = Self.activities[activityId]
         Self.lock.unlock()
         // Unknown/already-ended id is treated as success (idempotent end). See `update` for why an
         // unknown id is not an error.
@@ -205,6 +209,10 @@ public class NativeLiveActivities: NSObject {
         Task {
             do {
                 try await box.end(map)
+                // Dropped only once the end succeeded. Removing up front would lose the handle on a
+                // throw, and the retry would then take the unknown-id path above and report success
+                // for an activity still on screen.
+                Self.forget(activityId)
                 resolve(nil)
             } catch {
                 reject("live_activity_end_failed", error.localizedDescription, error)
@@ -244,13 +252,38 @@ public class NativeLiveActivities: NSObject {
         lock.unlock()
     }
 
+    private static func forget(_ activityId: String) {
+        lock.lock()
+        activities.removeValue(forKey: activityId)
+        lock.unlock()
+    }
+
+    /// Thrown for a missing required field so the caller sees a rejected promise naming it, rather
+    /// than an activity rendering with a blank line. Matches Android, whose `requireString` /
+    /// `requireDouble` already reject — an untyped JavaScript caller should not get a silent
+    /// half-rendered card on one platform and an error on the other.
+    private struct MissingFieldError: LocalizedError {
+        let field: String
+        var errorDescription: String? { "\(field) is required" }
+    }
+
+    private static func requireString(_ map: [String: Any], _ key: String) throws -> String {
+        guard let value = map[key] as? String else { throw MissingFieldError(field: key) }
+        return value
+    }
+
+    private static func requireInt(_ map: [String: Any], _ key: String) throws -> Int {
+        guard let value = map[key] as? NSNumber else { throw MissingFieldError(field: key) }
+        return value.intValue
+    }
+
     @available(iOS 16.2, *)
     private static func segmentsState(from map: [String: Any]) throws -> CIOSegmentsAttributes.ContentState {
         CIOSegmentsAttributes.ContentState(
-            status: map["status"] as? String ?? "",
+            status: try requireString(map, "status"),
             substatus: map["substatus"] as? String,
-            segmentsTotal: intValue(map["segmentsTotal"]),
-            segmentsComplete: intValue(map["segmentsComplete"]),
+            segmentsTotal: try requireInt(map, "segmentsTotal"),
+            segmentsComplete: try requireInt(map, "segmentsComplete"),
             trailingText: map["trailingText"] as? String
         )
     }
@@ -262,7 +295,7 @@ public class NativeLiveActivities: NSObject {
             endTime = EpochSecondsDate(Date(timeIntervalSince1970: seconds.doubleValue))
         }
         return CIOCountdownTimerAttributes.ContentState(
-            title: map["title"] as? String ?? "",
+            title: try requireString(map, "title"),
             statusMessage: map["statusMessage"] as? String,
             endTime: endTime
         )
@@ -285,10 +318,6 @@ public class NativeLiveActivities: NSObject {
             }
         }
         return CIOCustomAttributes.ContentState(data: data)
-    }
-
-    private static func intValue(_ any: Any?) -> Int {
-        (any as? NSNumber)?.intValue ?? 0
     }
 
     private static let unavailableCode = "live_activity_module_unavailable"

--- a/ios/wrappers/liveactivities/NativeLiveActivities.swift
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.swift
@@ -8,8 +8,13 @@ import Foundation
 
 @objc(NativeCustomerIOLiveActivities)
 public class NativeLiveActivities: NSObject {
-    /// The held Live Activities module (not a singleton in the native SDK), created during SDK init.
-    private static var module: LiveActivitiesModule?
+    /// Reverse-DNS activity type identifiers for the SDK's built-in templates. These are the same
+    /// strings the backend sends as `notificationType` and that Android's `LiveNotificationType`
+    /// exposes, so JS, both native SDKs, and the wire format share one vocabulary.
+    enum TypeIdentifier {
+        static let segments = "io.customer.livenotifications.segments"
+        static let countdownTimer = "io.customer.livenotifications.countdowntimer"
+    }
 
     /// Type-erased handles keyed by activity id. The native `start` returns a generic
     /// `CIOLiveActivity<Attributes>` that can't cross the bridge, so we keep closures that capture
@@ -22,22 +27,31 @@ public class NativeLiveActivities: NSObject {
     private static var activities: [String: ActivityBox] = [:]
     private static let lock = NSLock()
 
-    // MARK: - Init from SDK config
+    // MARK: - Module registration
 
-    /// Initialize the Live Activities module from the SDK config's `liveActivities` key. Registers
-    /// the enabled built-in template attribute types so `start` can request them.
-    static func initializeModule(from config: [String: Any]) {
-        guard let laConfig = config["liveActivities"] as? [String: Any] else { return }
-        guard #available(iOS 16.2, *) else { return }
-        let templates = (laConfig["templates"] as? [String]) ?? []
+    /// Build the Live Activities module from the SDK config's `liveNotifications` key, mirroring
+    /// ``NativeLocation/module(from:)``. Registers the enabled built-in template attribute types so
+    /// `CustomerIO.liveActivities.start` can request them, and so push-to-start tokens register for
+    /// them at SDK init.
+    ///
+    /// Unrecognized type identifiers are ignored: a newer native SDK may ship templates this
+    /// wrapper build doesn't know, and that must never break registration of the ones it does.
+    static func module(from config: [String: Any]) -> LiveActivitiesModule? {
+        guard let liveConfig = config["liveNotifications"] as? [String: Any] else { return nil }
+        guard #available(iOS 16.2, *) else { return nil }
+        let types = (liveConfig["types"] as? [String]) ?? []
         var builder = LiveActivityConfigBuilder()
-        if templates.contains("segments") {
-            builder = builder.register(CIOSegmentsAttributes.self)
+        for type in types {
+            switch type {
+            case TypeIdentifier.segments:
+                builder = builder.register(CIOSegmentsAttributes.self)
+            case TypeIdentifier.countdownTimer:
+                builder = builder.register(CIOCountdownTimerAttributes.self)
+            default:
+                continue
+            }
         }
-        if templates.contains("countdownTimer") {
-            builder = builder.register(CIOCountdownTimerAttributes.self)
-        }
-        module = LiveActivitiesModule.initialize(builder.build())
+        return LiveActivitiesModule(config: builder.build())
     }
 
     // MARK: - Bridge methods
@@ -48,31 +62,40 @@ public class NativeLiveActivities: NSObject {
         resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock
     ) {
-        guard #available(iOS 16.2, *), let module = Self.module else {
+        guard #available(iOS 16.2, *) else {
             return reject(Self.unavailableCode, Self.unavailableMessage, nil)
         }
         guard let map = payload as? [String: Any], let type = map["type"] as? String else {
             return reject("live_activity_start_failed", "payload.type is required", nil)
         }
         do {
+            // A nil handle means the module isn't registered or this type wasn't enabled. The
+            // native SDK logs and returns nil rather than throwing, so surface it as a rejected
+            // promise — never a crash.
             let id: String
             switch type {
-            case "segments":
-                let handle = try module.start(
+            case TypeIdentifier.segments:
+                guard let handle = try CustomerIO.liveActivities.start(
                     CIOSegmentsAttributes(header: map["header"] as? String ?? ""),
                     contentState: Self.segmentsState(from: map)
-                )
+                ) else {
+                    return reject(Self.notRegisteredCode, Self.notRegisteredMessage(type), nil)
+                }
                 Self.store(handle: handle, contentBuilder: Self.segmentsState)
                 id = handle.id
-            case "countdownTimer":
-                let handle = try module.start(
+            case TypeIdentifier.countdownTimer:
+                guard let handle = try CustomerIO.liveActivities.start(
                     CIOCountdownTimerAttributes(header: map["header"] as? String ?? ""),
                     contentState: Self.countdownState(from: map)
-                )
+                ) else {
+                    return reject(Self.notRegisteredCode, Self.notRegisteredMessage(type), nil)
+                }
                 Self.store(handle: handle, contentBuilder: Self.countdownState)
                 id = handle.id
             default:
-                return reject("live_activity_start_failed", "Unknown live activity template type: \(type)", nil)
+                // A newer native SDK may know this type even though this wrapper build doesn't.
+                // Fail softly so an unrecognized template can never crash the host app.
+                return reject(Self.unsupportedTypeCode, "Unsupported Live Activity template: \(type)", nil)
             }
             resolve(id)
         } catch {
@@ -139,14 +162,17 @@ public class NativeLiveActivities: NSObject {
         )
     }
 
-    /// Report an `opened` metric when the app is opened from a tapped Live Activity.
+    /// Report an `opened` metric for a tapped Live Activity and return the deep link to route to.
     ///
     /// Not exposed to JavaScript: a Live Activity tap arrives through the app's native URL/scene
-    /// entry point, so call this from there (see the sample app's `AppDelegate`). Returns `true`
-    /// if `url` matched a Customer.io-tracked activity's deep link.
+    /// entry point, so call this from there (see the sample app's `AppDelegate`).
+    ///
+    /// - Returns: the customer's redirect URL for a Customer.io widget URL (`nil` when it carries
+    ///   none), or `url` unchanged when it isn't a Customer.io URL — so existing routing still
+    ///   handles non-CIO links.
     @discardableResult
-    public static func reportDeepLinkOpen(_ url: URL) -> Bool {
-        module?.handleDeepLinkOpen(url) ?? false
+    public static func handleWidgetUrl(_ url: URL) -> URL? {
+        CustomerIO.liveActivities.handleWidgetUrl(url)
     }
 
     // MARK: - Helpers
@@ -195,6 +221,14 @@ public class NativeLiveActivities: NSObject {
 
     private static let unavailableCode = "live_activity_module_unavailable"
     private static let unavailableMessage =
-        "Live Activities are unavailable. Enable live activity templates in the SDK config and add the widget extension."
+        "Live Activities require iOS 16.2 or later."
+
+    private static let notRegisteredCode = "live_activity_type_not_registered"
+    private static func notRegisteredMessage(_ type: String) -> String {
+        "Live Activity type '\(type)' is not registered. Add it to `liveNotifications.types` in your " +
+            "Customer.io SDK config, and make sure your widget extension renders it."
+    }
+
+    private static let unsupportedTypeCode = "live_activity_type_unsupported"
 }
 #endif

--- a/ios/wrappers/liveactivities/NativeLiveActivities.swift
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.swift
@@ -15,7 +15,15 @@ public class NativeLiveActivities: NSObject {
     enum TypeIdentifier {
         static let segments = "io.customer.livenotifications.segments"
         static let countdownTimer = "io.customer.livenotifications.countdowntimer"
+        /// Discriminator JavaScript sends for the custom template. Not a wire identifier — the
+        /// activity is reported under the app's own `liveNotifications.customType`.
+        static let custom = "custom"
     }
+
+    /// The app's own identifier for the custom template, captured from config at init. Kept only so
+    /// `start` can explain *why* a custom payload was refused; the SDK resolves the identifier it
+    /// reports from the registration itself.
+    private static var customActivityType: String?
 
     /// Type-erased handles keyed by activity id. The native `start` returns a generic
     /// `CIOLiveActivity<Attributes>` that can't cross the bridge, so we keep closures that capture
@@ -62,6 +70,14 @@ public class NativeLiveActivities: NSObject {
                 continue
             }
         }
+        // The custom template registers one SDK-owned Swift type under the app's own identifier.
+        // That indirection is what lets a JavaScript app have a custom activity at all: the SDK needs
+        // a metatype to register and to observe push-to-start for, and a metatype can't cross a bridge.
+        if let customType = (liveConfig["customType"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !customType.isEmpty {
+            customActivityType = customType
+            builder = builder.register(CIOCustomAttributes.self, identifier: customType)
+        }
         return LiveActivitiesModule(config: builder.build())
     }
 
@@ -102,6 +118,24 @@ public class NativeLiveActivities: NSObject {
                     return reject(Self.notRegisteredCode, Self.notRegisteredMessage(type), nil)
                 }
                 Self.store(handle: handle, contentBuilder: Self.countdownState)
+                id = handle.id
+            case TypeIdentifier.custom:
+                guard Self.customActivityType != nil else {
+                    return reject(
+                        Self.notRegisteredCode,
+                        "No custom Live Activity type is configured. Set `liveNotifications.customType` " +
+                            "in your Customer.io SDK config to your own reverse-DNS identifier, and render " +
+                            "CIOCustomAttributes in your Widget Extension.",
+                        nil
+                    )
+                }
+                guard let handle = try CustomerIO.liveActivities.start(
+                    CIOCustomAttributes(),
+                    contentState: Self.customState(from: map)
+                ) else {
+                    return reject(Self.notRegisteredCode, Self.notRegisteredMessage(type), nil)
+                }
+                Self.store(handle: handle, contentBuilder: Self.customState)
                 id = handle.id
             default:
                 // A newer native SDK may know this type even though this wrapper build doesn't.
@@ -172,22 +206,6 @@ public class NativeLiveActivities: NSObject {
         }
     }
 
-    @objc(startCustom:payload:resolve:reject:)
-    public func startCustom(
-        _: String,
-        payload _: NSDictionary,
-        resolve _: @escaping RCTPromiseResolveBlock,
-        reject: @escaping RCTPromiseRejectBlock
-    ) {
-        // Custom activity types on iOS require a native Widget Extension + ActivityAttributes and an
-        // `adopt(_:)` call; they cannot be data-driven across the bridge.
-        reject(
-            "live_activity_custom_unsupported_ios",
-            "Custom live activity types are not supported from JavaScript on iOS. Use a native Widget Extension and adopt().",
-            nil
-        )
-    }
-
     /// Report an `opened` metric for a tapped Live Activity and return the deep link to route to.
     ///
     /// Not exposed to JavaScript: a Live Activity tap arrives through the app's native URL/scene
@@ -242,6 +260,25 @@ public class NativeLiveActivities: NSObject {
             statusMessage: map["statusMessage"] as? String,
             endTime: endTime
         )
+    }
+
+    /// Builds the custom template's content-state from the JS payload's `data` map.
+    ///
+    /// Values are coerced to strings rather than rejected: JavaScript numbers and booleans arrive as
+    /// `NSNumber`, and refusing them would make `{ eta: 5 }` fail for no reason a caller can see.
+    /// Anything without a sensible text form is dropped instead of stringifying as gibberish.
+    @available(iOS 16.2, *)
+    private static func customState(from map: [String: Any]) throws -> CIOCustomAttributes.ContentState {
+        let raw = map["data"] as? [String: Any] ?? [:]
+        var data: [String: String] = [:]
+        for (key, value) in raw {
+            switch value {
+            case let string as String: data[key] = string
+            case let number as NSNumber: data[key] = number.stringValue
+            default: continue
+            }
+        }
+        return CIOCustomAttributes.ContentState(data: data)
     }
 
     private static func intValue(_ any: Any?) -> Int {

--- a/ios/wrappers/liveactivities/NativeLiveActivities.swift
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.swift
@@ -21,7 +21,7 @@ public class NativeLiveActivities: NSObject {
     /// the concrete handle and rebuild its content-state from a JS map on update.
     private struct ActivityBox {
         let update: ([String: Any]) async throws -> Void
-        let end: () async -> Void
+        let end: ([String: Any]?) async throws -> Void
     }
 
     private static var activities: [String: ActivityBox] = [:]
@@ -129,20 +129,26 @@ public class NativeLiveActivities: NSObject {
         }
     }
 
-    @objc(end:resolve:reject:)
+    @objc(end:payload:resolve:reject:)
     public func end(
         _ activityId: String,
+        payload: NSDictionary?,
         resolve: @escaping RCTPromiseResolveBlock,
-        reject _: @escaping RCTPromiseRejectBlock
+        reject: @escaping RCTPromiseRejectBlock
     ) {
         Self.lock.lock()
         let box = Self.activities.removeValue(forKey: activityId)
         Self.lock.unlock()
         // Unknown/already-ended id is treated as success (idempotent end).
         guard let box else { return resolve(nil) }
+        let map = payload as? [String: Any]
         Task {
-            await box.end()
-            resolve(nil)
+            do {
+                try await box.end(map)
+                resolve(nil)
+            } catch {
+                reject("live_activity_end_failed", error.localizedDescription, error)
+            }
         }
     }
 
@@ -183,8 +189,11 @@ public class NativeLiveActivities: NSObject {
         contentBuilder: @escaping ([String: Any]) throws -> A.ContentState
     ) {
         let box = ActivityBox(
+            // ActivityKit keeps the last content-state on screen when `end` is given none, so a
+            // final payload is what lets the activity show a terminal state rather than freezing
+            // mid-progress.
             update: { map in await handle.update(try contentBuilder(map)) },
-            end: { await handle.end() }
+            end: { map in await handle.end(try map.map(contentBuilder)) }
         )
         lock.lock()
         activities[handle.id] = box

--- a/ios/wrappers/liveactivities/NativeLiveActivities.swift
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.swift
@@ -158,13 +158,19 @@ public class NativeLiveActivities: NSObject {
         Self.lock.lock()
         let box = Self.activities[activityId]
         Self.lock.unlock()
-        // An id this process didn't start resolves rather than rejects, matching `end` here and both
-        // methods on Android (which routes the id to the native SDK and never learns it was unknown).
-        // "Unknown" is not proof of caller error: the map is process-local, so an activity started
-        // before an app restart, or started by a push, legitimately isn't in it. Logged, not thrown.
+        // An unknown id means the update did not happen, so it must not report success. Unlike `end`
+        // — where re-ending an already-ended activity is a legitimate no-op — there is nothing
+        // idempotent about an update that never applied. Android *does* perform it (it routes the id
+        // straight to the native SDK), so resolving here would make the same call report success on
+        // both platforms while only one of them did anything.
         guard let box else {
             Self.logUnknownActivity(activityId, method: "update")
-            return resolve(nil)
+            return reject(
+                "live_activity_update_failed",
+                "No live activity found for id \(activityId). On iOS only activities started in this " +
+                    "app session can be updated.",
+                nil
+            )
         }
         guard let map = payload as? [String: Any] else {
             return reject("live_activity_update_failed", "payload is required", nil)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 4.5.3",
+  "cioNativeiOSSdkVersion": "= 4.6.0",
   "cioiOSFirebaseWrapperSdkVersion": "= 1.0.0",
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
       "modulesProvider": {
         "NativeCustomerIOLogging": "RCTNativeCustomerIOLogging",
         "NativeCustomerIO": "RCTNativeCustomerIO",
+        "NativeCustomerIOLiveActivities": "RCTNativeLiveActivities",
         "NativeCustomerIOLocation": "RCTNativeCustomerIOLocation",
         "NativeCustomerIOMessagingInApp": "RCTNativeMessagingInApp",
         "NativeCustomerIOMessagingPush": "RCTNativeMessagingPush"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 4.6.0",
+  "cioNativeiOSSdkVersion": "= 4.6.1",
   "cioiOSFirebaseWrapperSdkVersion": "= 1.0.0",
   "files": [
     "src",

--- a/src/customerio-cdp.ts
+++ b/src/customerio-cdp.ts
@@ -1,4 +1,5 @@
 import { CustomerIOInAppMessaging } from './customerio-inapp';
+import { CustomerIOLiveActivities } from './customerio-liveactivities';
 import { CustomerIOLocation } from './customerio-location';
 import { CustomerIOPushMessaging } from './customerio-push';
 import { NativeLoggerListener } from './native-logger-listener';
@@ -179,6 +180,7 @@ export class CustomerIO {
   static readonly isInitialized = () => _initialized;
 
   static readonly inAppMessaging = new CustomerIOInAppMessaging();
+  static readonly liveActivities = new CustomerIOLiveActivities();
   static readonly location = new CustomerIOLocation();
   static readonly pushMessaging = new CustomerIOPushMessaging();
 }

--- a/src/customerio-liveactivities.ts
+++ b/src/customerio-liveactivities.ts
@@ -1,0 +1,102 @@
+import { type TurboModule } from 'react-native';
+import {
+  default as NativeModule,
+  type Spec as CodegenSpec,
+} from './specs/modules/NativeCustomerIOLiveActivities';
+import type { LiveActivityPayload } from './types/live-activities';
+
+/**
+ * Ensures all methods defined in codegen spec are implemented by the public module
+ *
+ * @internal
+ */
+interface NativeLiveActivitiesSpec extends Omit<
+  CodegenSpec,
+  keyof TurboModule
+> {}
+
+// Live Activities is an optional module — NativeModule may be null when it is not
+// compiled in. Promise-returning methods reject with a clear error in that case.
+let hasWarnedNotEnabled = false;
+const withNativeModule = <T>(
+  fn: (native: CodegenSpec) => Promise<T>
+): Promise<T> => {
+  if (NativeModule) {
+    return fn(NativeModule);
+  }
+  if (__DEV__ && !hasWarnedNotEnabled) {
+    hasWarnedNotEnabled = true;
+    console.warn(
+      'Customer.io: Live Activities module is not available. ' +
+        'On iOS, add the CustomerIO Live Activities pods and a Widget Extension; ' +
+        'on Android it ships with messaging-push-fcm.'
+    );
+  }
+  return Promise.reject(
+    new Error('Customer.io: Live Activities module is not available.')
+  );
+};
+
+/**
+ * Live Activities (iOS) / Live Notifications (Android).
+ *
+ * Start, update, and end live, updating notifications from built-in templates
+ * (Segments, Countdown Timer). Enable templates via the `liveActivities` key of the
+ * SDK config passed to {@link CustomerIO.initialize}.
+ *
+ * @public
+ */
+export class CustomerIOLiveActivities implements NativeLiveActivitiesSpec {
+  /**
+   * Start a built-in-template activity.
+   *
+   * @param payload - Template payload; `payload.type` selects the template.
+   * @returns The SDK-minted activity id, used for later `update`/`end`.
+   */
+  start(payload: LiveActivityPayload): Promise<string> {
+    return withNativeModule((native) => native.start(payload));
+  }
+
+  /**
+   * Replace the whole content-state of a running activity.
+   *
+   * ActivityKit (iOS) replaces content-state wholesale, so pass the **full** desired
+   * state — not just the changed fields. Static attributes (e.g. `header`) cannot
+   * change after start and are ignored on iOS.
+   *
+   * @param activityId - Id returned by {@link start}.
+   * @param payload - The complete desired state.
+   */
+  update(activityId: string, payload: LiveActivityPayload): Promise<void> {
+    return withNativeModule((native) => native.update(activityId, payload));
+  }
+
+  /**
+   * End a running activity.
+   *
+   * @param activityId - Id returned by {@link start}.
+   */
+  end(activityId: string): Promise<void> {
+    return withNativeModule((native) => native.end(activityId));
+  }
+
+  /**
+   * Start a custom (app-defined) activity type.
+   *
+   * On **Android**, the host app renders it via its `createLiveNotification` callback.
+   * On **iOS**, custom types require a native `adopt` call, so this rejects — use a
+   * native Widget Extension + `ActivityAttributes` for custom iOS activities.
+   *
+   * @param activityType - Reverse-DNS identifier registered via config `customTypes`.
+   * @param payload - Flat key/value data passed to the native template/callback.
+   * @returns The SDK-minted activity id.
+   */
+  startCustom(
+    activityType: string,
+    payload: Record<string, unknown>
+  ): Promise<string> {
+    return withNativeModule((native) =>
+      native.startCustom(activityType, payload)
+    );
+  }
+}

--- a/src/customerio-liveactivities.ts
+++ b/src/customerio-liveactivities.ts
@@ -15,28 +15,6 @@ interface NativeLiveActivitiesSpec extends Omit<
   keyof TurboModule
 > {}
 
-// Live Activities is an optional module — NativeModule may be null when it is not
-// compiled in. Promise-returning methods reject with a clear error in that case.
-let hasWarnedNotEnabled = false;
-const withNativeModule = <T>(
-  fn: (native: CodegenSpec) => Promise<T>
-): Promise<T> => {
-  if (NativeModule) {
-    return fn(NativeModule);
-  }
-  if (__DEV__ && !hasWarnedNotEnabled) {
-    hasWarnedNotEnabled = true;
-    console.warn(
-      'Customer.io: Live Activities module is not available. ' +
-        'On iOS, add the CustomerIO Live Activities pods and a Widget Extension; ' +
-        'on Android it ships with messaging-push-fcm.'
-    );
-  }
-  return Promise.reject(
-    new Error('Customer.io: Live Activities module is not available.')
-  );
-};
-
 /**
  * Live Activities (iOS) / Live Notifications (Android).
  *
@@ -54,7 +32,7 @@ export class CustomerIOLiveActivities implements NativeLiveActivitiesSpec {
    * @returns The SDK-minted activity id, used for later `update`/`end`.
    */
   start(payload: LiveActivityPayload): Promise<string> {
-    return withNativeModule((native) => native.start(payload));
+    return NativeModule.start(payload);
   }
 
   /**
@@ -68,7 +46,7 @@ export class CustomerIOLiveActivities implements NativeLiveActivitiesSpec {
    * @param payload - The complete desired state.
    */
   update(activityId: string, payload: LiveActivityPayload): Promise<void> {
-    return withNativeModule((native) => native.update(activityId, payload));
+    return NativeModule.update(activityId, payload);
   }
 
   /**
@@ -81,6 +59,6 @@ export class CustomerIOLiveActivities implements NativeLiveActivitiesSpec {
    *   ignores this.
    */
   end(activityId: string, payload?: LiveActivityPayload): Promise<void> {
-    return withNativeModule((native) => native.end(activityId, payload));
+    return NativeModule.end(activityId, payload);
   }
 }

--- a/src/customerio-liveactivities.ts
+++ b/src/customerio-liveactivities.ts
@@ -72,12 +72,16 @@ export class CustomerIOLiveActivities implements NativeLiveActivitiesSpec {
   }
 
   /**
-   * End a running activity.
+   * End a running activity, optionally rendering a final content-state.
    *
    * @param activityId - Id returned by {@link start}.
+   * @param payload - **iOS only.** The final content-state to render as the activity ends.
+   *   ActivityKit keeps the last content-state on screen when none is given, so pass one to show
+   *   a terminal state (e.g. all segments complete). Android renders its own terminal state and
+   *   ignores this.
    */
-  end(activityId: string): Promise<void> {
-    return withNativeModule((native) => native.end(activityId));
+  end(activityId: string, payload?: LiveActivityPayload): Promise<void> {
+    return withNativeModule((native) => native.end(activityId, payload));
   }
 
   /**

--- a/src/customerio-liveactivities.ts
+++ b/src/customerio-liveactivities.ts
@@ -83,24 +83,4 @@ export class CustomerIOLiveActivities implements NativeLiveActivitiesSpec {
   end(activityId: string, payload?: LiveActivityPayload): Promise<void> {
     return withNativeModule((native) => native.end(activityId, payload));
   }
-
-  /**
-   * Start a custom (app-defined) activity type.
-   *
-   * On **Android**, the host app renders it via its `createLiveNotification` callback.
-   * On **iOS**, custom types require a native `adopt` call, so this rejects — use a
-   * native Widget Extension + `ActivityAttributes` for custom iOS activities.
-   *
-   * @param activityType - Reverse-DNS identifier registered via config `customTypes`.
-   * @param payload - Flat key/value data passed to the native template/callback.
-   * @returns The SDK-minted activity id.
-   */
-  startCustom(
-    activityType: string,
-    payload: Record<string, unknown>
-  ): Promise<string> {
-    return withNativeModule((native) =>
-      native.startCustom(activityType, payload)
-    );
-  }
 }

--- a/src/customerio-liveactivities.ts
+++ b/src/customerio-liveactivities.ts
@@ -64,7 +64,7 @@ export class CustomerIOLiveActivities implements NativeLiveActivitiesSpec {
    * state — not just the changed fields. Static attributes (e.g. `header`) cannot
    * change after start and are ignored on iOS.
    *
-   * @param activityId - Id returned by {@link start}.
+   * @param activityId - Id returned by {@link CustomerIOLiveActivities.start}.
    * @param payload - The complete desired state.
    */
   update(activityId: string, payload: LiveActivityPayload): Promise<void> {
@@ -74,7 +74,7 @@ export class CustomerIOLiveActivities implements NativeLiveActivitiesSpec {
   /**
    * End a running activity, optionally rendering a final content-state.
    *
-   * @param activityId - Id returned by {@link start}.
+   * @param activityId - Id returned by {@link CustomerIOLiveActivities.start}.
    * @param payload - **iOS only.** The final content-state to render as the activity ends.
    *   ActivityKit keeps the last content-state on screen when none is given, so pass one to show
    *   a terminal state (e.g. all segments complete). Android renders its own terminal state and

--- a/src/customerio-liveactivities.ts
+++ b/src/customerio-liveactivities.ts
@@ -41,8 +41,8 @@ const withNativeModule = <T>(
  * Live Activities (iOS) / Live Notifications (Android).
  *
  * Start, update, and end live, updating notifications from built-in templates
- * (Segments, Countdown Timer). Enable templates via the `liveActivities` key of the
- * SDK config passed to {@link CustomerIO.initialize}.
+ * (Segments, Countdown Timer). Enable the activity types via the `liveNotifications`
+ * key of the SDK config passed to {@link CustomerIO.initialize}.
  *
  * @public
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
  */
 export * from './customerio-cdp';
 export * from './customerio-inapp';
+export * from './customerio-liveactivities';
 export * from './customerio-location';
 export * from './customerio-push';
 export * from './types';

--- a/src/specs/modules/NativeCustomerIOLiveActivities.ts
+++ b/src/specs/modules/NativeCustomerIOLiveActivities.ts
@@ -18,8 +18,13 @@ export interface Spec extends TurboModule {
   start(payload: NativeBridgeObject): Promise<string>;
   /** Replace the whole content-state of a running activity. Pass the full desired state. */
   update(activityId: string, payload: NativeBridgeObject): Promise<void>;
-  /** End a running activity. */
-  end(activityId: string): Promise<void>;
+  /**
+   * End a running activity, optionally rendering a final content-state.
+   *
+   * `payload` is iOS-only: ActivityKit keeps the last content-state on screen unless a final one
+   * is supplied. Android renders its own terminal state, so it ignores the payload.
+   */
+  end(activityId: string, payload?: NativeBridgeObject): Promise<void>;
   /**
    * Start a custom (app-defined) activity type. Android renders it via the host app's
    * `createLiveNotification` callback; on iOS custom types require a native `adopt` call,

--- a/src/specs/modules/NativeCustomerIOLiveActivities.ts
+++ b/src/specs/modules/NativeCustomerIOLiveActivities.ts
@@ -28,5 +28,10 @@ export interface Spec extends TurboModule {
   end(activityId: string, payload?: NativeBridgeObject): Promise<void>;
 }
 
-// Optional module — NativeModule may be null when Live Activities is not compiled in.
-export default TurboModuleRegistry.get<Spec>('NativeCustomerIOLiveActivities');
+// Registered unconditionally on both platforms — Android in CustomerIOReactNativePackage, iOS via
+// an ObjC bridge that is always compiled. When the Live Activities pods are absent the module is
+// still present and its methods reject with `live_activity_module_unavailable`, so `getEnforcing`
+// is accurate here (unlike Location, which really can be absent and uses `get`).
+export default TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeCustomerIOLiveActivities'
+);

--- a/src/specs/modules/NativeCustomerIOLiveActivities.ts
+++ b/src/specs/modules/NativeCustomerIOLiveActivities.ts
@@ -1,0 +1,35 @@
+import { TurboModuleRegistry, type TurboModule } from 'react-native';
+import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
+
+/**
+ * Native module specification for CustomerIO Live Activities React Native SDK
+ *
+ * Live Activities (iOS) / Live Notifications (Android) let you show a live,
+ * updating notification driven by a built-in template (Segments, Countdown Timer).
+ *
+ * @see NativeCustomerIO.ts for detailed documentation on TurboModule patterns,
+ * Codegen compatibility, and type safety approach.
+ */
+
+type NativeBridgeObject = UnsafeObject;
+
+export interface Spec extends TurboModule {
+  /** Start a built-in-template activity. Resolves with the SDK-minted activity id. */
+  start(payload: NativeBridgeObject): Promise<string>;
+  /** Replace the whole content-state of a running activity. Pass the full desired state. */
+  update(activityId: string, payload: NativeBridgeObject): Promise<void>;
+  /** End a running activity. */
+  end(activityId: string): Promise<void>;
+  /**
+   * Start a custom (app-defined) activity type. Android renders it via the host app's
+   * `createLiveNotification` callback; on iOS custom types require a native `adopt` call,
+   * so this rejects on iOS.
+   */
+  startCustom(
+    activityType: string,
+    payload: NativeBridgeObject
+  ): Promise<string>;
+}
+
+// Optional module — NativeModule may be null when Live Activities is not compiled in.
+export default TurboModuleRegistry.get<Spec>('NativeCustomerIOLiveActivities');

--- a/src/specs/modules/NativeCustomerIOLiveActivities.ts
+++ b/src/specs/modules/NativeCustomerIOLiveActivities.ts
@@ -5,7 +5,8 @@ import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
  * Native module specification for CustomerIO Live Activities React Native SDK
  *
  * Live Activities (iOS) / Live Notifications (Android) let you show a live,
- * updating notification driven by a built-in template (Segments, Countdown Timer).
+ * updating notification driven by a built-in template (Segments, Countdown Timer)
+ * or by a custom type you render yourself.
  *
  * @see NativeCustomerIO.ts for detailed documentation on TurboModule patterns,
  * Codegen compatibility, and type safety approach.
@@ -14,7 +15,7 @@ import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
 type NativeBridgeObject = UnsafeObject;
 
 export interface Spec extends TurboModule {
-  /** Start a built-in-template activity. Resolves with the SDK-minted activity id. */
+  /** Start an activity. Resolves with the SDK-minted activity id. */
   start(payload: NativeBridgeObject): Promise<string>;
   /** Replace the whole content-state of a running activity. Pass the full desired state. */
   update(activityId: string, payload: NativeBridgeObject): Promise<void>;
@@ -25,15 +26,6 @@ export interface Spec extends TurboModule {
    * is supplied. Android renders its own terminal state, so it ignores the payload.
    */
   end(activityId: string, payload?: NativeBridgeObject): Promise<void>;
-  /**
-   * Start a custom (app-defined) activity type. Android renders it via the host app's
-   * `createLiveNotification` callback; on iOS custom types require a native `adopt` call,
-   * so this rejects on iOS.
-   */
-  startCustom(
-    activityType: string,
-    payload: NativeBridgeObject
-  ): Promise<string>;
 }
 
 // Optional module — NativeModule may be null when Live Activities is not compiled in.

--- a/src/types/data-pipelines.ts
+++ b/src/types/data-pipelines.ts
@@ -78,7 +78,7 @@ export type CioConfig = {
     trackingMode?: CioLocationTrackingMode;
   };
   /** Live Activities (iOS) / Live Notifications (Android) configuration. */
-  liveActivities?: LiveActivitiesConfig;
+  liveNotifications?: LiveActivitiesConfig;
 };
 
 /**

--- a/src/types/data-pipelines.ts
+++ b/src/types/data-pipelines.ts
@@ -1,3 +1,4 @@
+import type { LiveActivitiesConfig } from './live-activities';
 import type { PushClickBehaviorAndroid } from './push';
 
 /**
@@ -76,6 +77,8 @@ export type CioConfig = {
     /** Location tracking mode. Defaults to 'manual' if location config is provided. */
     trackingMode?: CioLocationTrackingMode;
   };
+  /** Live Activities (iOS) / Live Notifications (Android) configuration. */
+  liveActivities?: LiveActivitiesConfig;
 };
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './data-pipelines';
 export * from './in-app';
+export * from './live-activities';
 export * from './push';

--- a/src/types/live-activities.ts
+++ b/src/types/live-activities.ts
@@ -4,8 +4,6 @@
  * Live Activities (iOS) / Live Notifications (Android) render live, updating
  * notifications from built-in templates. Two templates ship today: Segments and
  * Countdown Timer. Field names and identifiers are identical across platforms.
- *
- * @public
  */
 
 /**
@@ -18,6 +16,8 @@
  *
  * Use these enum members (not raw strings) for `LiveActivitiesConfig.types` and a
  * payload's `type` to avoid typos.
+ *
+ * @public
  */
 export enum LiveActivityTemplate {
   Segments = 'io.customer.livenotifications.segments',
@@ -27,6 +27,8 @@ export enum LiveActivityTemplate {
 /**
  * Segments template — a progress activity split into N segments.
  * `header` is a static attribute (fixed at start); the rest are content-state.
+ *
+ * @public
  */
 export interface LiveActivitySegmentsPayload {
   type: LiveActivityTemplate.Segments;
@@ -47,6 +49,8 @@ export interface LiveActivitySegmentsPayload {
 /**
  * Countdown Timer template — a live countdown to a target time.
  * `header` is a static attribute (fixed at start); the rest are content-state.
+ *
+ * @public
  */
 export interface LiveActivityCountdownTimerPayload {
   type: LiveActivityTemplate.CountdownTimer;
@@ -85,7 +89,8 @@ export interface LiveActivitiesBranding {
   accentColorHex?: string;
   /**
    * Bundled Android drawable resource name for the logo, resolved natively.
-   * Preferred over {@link logoUrl} when both are set — it needs no network.
+   * Preferred over {@link LiveActivitiesBranding.logoUrl} when both are set — it
+   * needs no network.
    */
   logoResource?: string;
   /** Remote logo URL (downloaded and cached natively). */

--- a/src/types/live-activities.ts
+++ b/src/types/live-activities.ts
@@ -22,6 +22,14 @@
 export enum LiveActivityTemplate {
   Segments = 'io.customer.livenotifications.segments',
   CountdownTimer = 'io.customer.livenotifications.countdowntimer',
+  /**
+   * Your own activity type, rendered by SwiftUI you write.
+   *
+   * Unlike the members above, this value is a marker rather than an identifier — your activity is
+   * named by {@link LiveActivitiesConfig.customType}, and the SDK reports it under that name. It
+   * belongs in a payload's `type`, never in {@link LiveActivitiesConfig.types}.
+   */
+  Custom = 'custom',
 }
 
 /**
@@ -44,6 +52,28 @@ export interface LiveActivitySegmentsPayload {
   segmentsComplete: number;
   /** Optional trailing text (e.g. an ETA). */
   trailingText?: string;
+}
+
+/**
+ * Custom template — your own activity type, rendered by SwiftUI you write.
+ *
+ * Unlike the built-in templates there is no schema: `data` is an untyped map, because a bridge
+ * payload carries nothing for the SDK to validate against. Every value is a string, so your widget
+ * parses whichever ones it needs.
+ *
+ * Requires {@link LiveActivitiesConfig.customType} to be set. On iOS you must also render
+ * `CIOCustomAttributes` in your Widget Extension; on Android your `createLiveNotification`
+ * callback receives the same map.
+ *
+ * @public
+ */
+export interface LiveActivityCustomPayload {
+  type: LiveActivityTemplate.Custom;
+  /**
+   * The full content-state, re-sent in its entirety on every update. Neither platform keeps a
+   * static/dynamic split for custom types, so include anything your widget needs each time.
+   */
+  data: Record<string, string>;
 }
 
 /**
@@ -74,7 +104,9 @@ export interface LiveActivityCountdownTimerPayload {
  * @public
  */
 export type LiveActivityPayload =
-  LiveActivitySegmentsPayload | LiveActivityCountdownTimerPayload;
+  | LiveActivitySegmentsPayload
+  | LiveActivityCountdownTimerPayload
+  | LiveActivityCustomPayload;
 
 /**
  * Live Activities branding (Android only). On iOS, branding is compiled into the
@@ -112,14 +144,20 @@ export interface LiveActivitiesConfig {
    */
   types?: LiveActivityTemplate[];
   /**
-   * Reverse-DNS identifiers for custom (app-defined) activity types.
+   * Your own reverse-DNS identifier for the custom activity type, e.g.
+   * `'com.myapp.rideshare'`. Setting it enables the custom template on both platforms.
    *
-   * **Android only in practice.** Android renders these through the app's
-   * `createLiveNotification` callback. On iOS a custom type needs a native Widget
-   * Extension and an `adopt()` call, so it cannot be started from JavaScript —
-   * `startCustom` always rejects there and this list is ignored.
+   * Start one with `{ type: LiveActivityTemplate.Custom, data: { … } }`; the SDK reports it
+   * under this identifier, and your campaigns target it by the same name.
+   *
+   * Singular by design: iOS resolves an activity's type from its Swift attributes type, and
+   * every custom activity shares one. A second identifier could not be told apart, so one
+   * identifier is the limit rather than a silent mis-attribution.
+   *
+   * You must also render it yourself — `CIOCustomAttributes` in an iOS Widget Extension, and
+   * the `createLiveNotification` callback on Android.
    */
-  customTypes?: string[];
+  customType?: string;
   /** Android Live Notification branding (ignored on iOS). */
   branding?: LiveActivitiesBranding;
 }

--- a/src/types/live-activities.ts
+++ b/src/types/live-activities.ts
@@ -111,7 +111,14 @@ export interface LiveActivitiesConfig {
    * ignored, so a newer native template can't break an older wrapper build.
    */
   types?: LiveActivityTemplate[];
-  /** Reverse-DNS identifiers for custom (app-defined) activity types. */
+  /**
+   * Reverse-DNS identifiers for custom (app-defined) activity types.
+   *
+   * **Android only in practice.** Android renders these through the app's
+   * `createLiveNotification` callback. On iOS a custom type needs a native Widget
+   * Extension and an `adopt()` call, so it cannot be started from JavaScript —
+   * `startCustom` always rejects there and this list is ignored.
+   */
   customTypes?: string[];
   /** Android Live Notification branding (ignored on iOS). */
   branding?: LiveActivitiesBranding;

--- a/src/types/live-activities.ts
+++ b/src/types/live-activities.ts
@@ -9,14 +9,19 @@
  */
 
 /**
- * Built-in template identifiers usable from the wrapper.
+ * Built-in activity type identifiers usable from the wrapper.
  *
- * Use these enum members (not raw strings) for `LiveActivitiesConfig.templates`
- * and a payload's `type` to avoid typos.
+ * The values are the reverse-DNS identifiers Customer.io uses everywhere — the
+ * `notificationType` on the wire, Android's `LiveNotificationType`, and iOS's
+ * `CIOSegmentsAttributes.identifier` — so JS, both native SDKs, and the backend
+ * share one vocabulary.
+ *
+ * Use these enum members (not raw strings) for `LiveActivitiesConfig.types` and a
+ * payload's `type` to avoid typos.
  */
 export enum LiveActivityTemplate {
-  Segments = 'segments',
-  CountdownTimer = 'countdownTimer',
+  Segments = 'io.customer.livenotifications.segments',
+  CountdownTimer = 'io.customer.livenotifications.countdowntimer',
 }
 
 /**
@@ -79,6 +84,11 @@ export interface LiveActivitiesBranding {
   companyName?: string;
   /** Accent color as "#RRGGBB". */
   accentColorHex?: string;
+  /**
+   * Bundled Android drawable resource name for the logo, resolved natively.
+   * Preferred over {@link logoUrl} when both are set — it needs no network.
+   */
+  logoResource?: string;
   /** Remote logo URL (downloaded and cached natively). */
   logoUrl?: string;
   /** Android drawable resource name, resolved natively. */
@@ -86,13 +96,17 @@ export interface LiveActivitiesBranding {
 }
 
 /**
- * Live Activities configuration, passed under the `liveActivities` key of the SDK config.
+ * Live Activities configuration, passed under the `liveNotifications` key of the SDK config.
  *
  * @public
  */
 export interface LiveActivitiesConfig {
-  /** Built-in templates to enable. Enables the matching native type on each platform. */
-  templates?: LiveActivityTemplate[];
+  /**
+   * Built-in activity types to enable. Enables the matching native type on each
+   * platform and registers push-to-start for it. Unrecognized identifiers are
+   * ignored, so a newer native template can't break an older wrapper build.
+   */
+  types?: LiveActivityTemplate[];
   /** Reverse-DNS identifiers for custom (app-defined) activity types. */
   customTypes?: string[];
   /** Android Live Notification branding (ignored on iOS). */

--- a/src/types/live-activities.ts
+++ b/src/types/live-activities.ts
@@ -1,0 +1,100 @@
+/**
+ * Public types for the Live Activities module.
+ *
+ * Live Activities (iOS) / Live Notifications (Android) render live, updating
+ * notifications from built-in templates. Two templates ship today: Segments and
+ * Countdown Timer. Field names and identifiers are identical across platforms.
+ *
+ * @public
+ */
+
+/**
+ * Built-in template identifiers usable from the wrapper.
+ *
+ * Use these enum members (not raw strings) for `LiveActivitiesConfig.templates`
+ * and a payload's `type` to avoid typos.
+ */
+export enum LiveActivityTemplate {
+  Segments = 'segments',
+  CountdownTimer = 'countdownTimer',
+}
+
+/**
+ * Segments template — a progress activity split into N segments.
+ * `header` is a static attribute (fixed at start); the rest are content-state.
+ */
+export interface LiveActivitySegmentsPayload {
+  type: LiveActivityTemplate.Segments;
+  /** Static header line (set at start, never changes). */
+  header: string;
+  /** Primary status line. */
+  status: string;
+  /** Optional secondary status line. */
+  substatus?: string;
+  /** Total number of segments. */
+  segmentsTotal: number;
+  /** Number of completed segments (clamped to 0..segmentsTotal). */
+  segmentsComplete: number;
+  /** Optional trailing text (e.g. an ETA). */
+  trailingText?: string;
+}
+
+/**
+ * Countdown Timer template — a live countdown to a target time.
+ * `header` is a static attribute (fixed at start); the rest are content-state.
+ */
+export interface LiveActivityCountdownTimerPayload {
+  type: LiveActivityTemplate.CountdownTimer;
+  /** Static header line (set at start, never changes). */
+  header: string;
+  /** Primary title line. */
+  title: string;
+  /** Optional status message. */
+  statusMessage?: string;
+  /** Target time as epoch **seconds**. Omit to render the finished state. */
+  endTime?: number;
+}
+
+/**
+ * Payload for {@link CustomerIOLiveActivities.start} and
+ * {@link CustomerIOLiveActivities.update}.
+ *
+ * Because ActivityKit replaces content-state wholesale on update, `update` takes the
+ * same full payload as `start` — pass the complete desired state each time.
+ *
+ * @public
+ */
+export type LiveActivityPayload =
+  | LiveActivitySegmentsPayload
+  | LiveActivityCountdownTimerPayload;
+
+/**
+ * Live Activities branding (Android only). On iOS, branding is compiled into the
+ * widget extension's SwiftUI, so these values are ignored there.
+ *
+ * @public
+ */
+export interface LiveActivitiesBranding {
+  /** Reserved for future use. */
+  companyName?: string;
+  /** Accent color as "#RRGGBB". */
+  accentColorHex?: string;
+  /** Remote logo URL (downloaded and cached natively). */
+  logoUrl?: string;
+  /** Android drawable resource name, resolved natively. */
+  smallIconResource?: string;
+}
+
+/**
+ * Live Activities configuration, passed under the `liveActivities` key of the SDK config.
+ *
+ * @public
+ */
+export interface LiveActivitiesConfig {
+  /** Built-in templates to enable. Enables the matching native type on each platform. */
+  templates?: LiveActivityTemplate[];
+  /** Reverse-DNS identifiers for custom (app-defined) activity types. */
+  customTypes?: string[];
+  /** Android Live Notification branding (ignored on iOS). */
+  branding?: LiveActivitiesBranding;
+}

--- a/src/types/live-activities.ts
+++ b/src/types/live-activities.ts
@@ -72,6 +72,10 @@ export interface LiveActivityCustomPayload {
   /**
    * The full content-state, re-sent in its entirety on every update. Neither platform keeps a
    * static/dynamic split for custom types, so include anything your widget needs each time.
+   *
+   * Values must be strings. Numbers and booleans are coerced, but nested objects and arrays are
+   * not supported and the platforms disagree on them — iOS drops them, Android stringifies them —
+   * so flatten anything structured before sending it.
    */
   data: Record<string, string>;
 }
@@ -141,8 +145,11 @@ export interface LiveActivitiesConfig {
    * Built-in activity types to enable. Enables the matching native type on each
    * platform and registers push-to-start for it. Unrecognized identifiers are
    * ignored, so a newer native template can't break an older wrapper build.
+   *
+   * `Custom` is excluded on purpose — it is enabled by {@link LiveActivitiesConfig.customType},
+   * and both platforms would silently drop it from this list.
    */
-  types?: LiveActivityTemplate[];
+  types?: Exclude<LiveActivityTemplate, LiveActivityTemplate.Custom>[];
   /**
    * Your own reverse-DNS identifier for the custom activity type, e.g.
    * `'com.myapp.rideshare'`. Setting it enables the custom template on both platforms.

--- a/src/types/live-activities.ts
+++ b/src/types/live-activities.ts
@@ -70,8 +70,7 @@ export interface LiveActivityCountdownTimerPayload {
  * @public
  */
 export type LiveActivityPayload =
-  | LiveActivitySegmentsPayload
-  | LiveActivityCountdownTimerPayload;
+  LiveActivitySegmentsPayload | LiveActivityCountdownTimerPayload;
 
 /**
  * Live Activities branding (Android only). On iOS, branding is compiled into the


### PR DESCRIPTION
Exposes Live Activities (iOS) / Live Notifications (Android) on the React Native SDK, consuming the native SDK-managed module so registration happens at SDK init.

Config lives under `liveNotifications` — `types` are the reverse-DNS identifiers shared with both native SDKs; unrecognized ones are ignored. `end` optionally takes a final content-state so iOS can render a terminal card.

Depends on customerio-ios#1178.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large cross-platform surface (push init, notifications, ActivityKit) with unreleased native SDK pins; iOS URL forwarding is required for correct tap attribution.
> 
> **Overview**
> Adds **Live Activities (iOS) / Live Notifications (Android)** to the React Native SDK via `CustomerIO.liveActivities` (`start`, `update`, `end`) and a new `liveNotifications` key on `CioConfig` (enabled template types, optional `customType`, Android branding).
> 
> On **JavaScript**, new public types (`LiveActivityTemplate`, segment/countdown/custom payloads) and a TurboModule spec; `end` optionally accepts a final content-state for iOS terminal UI. On **Android**, a new native module forwards to the FCM push module, applies `liveNotifications` at init, and supports a pre-init `setLiveNotificationCallback` for custom notifications. On **iOS**, an optional `liveactivities` pod subspec gates Swift/ObjC bridge code; SDK init registers enabled types, and apps must forward widget tap URLs through `NativeLiveActivities.handleWidgetUrl` in `AppDelegate`.
> 
> Builds temporarily pin **unreleased** native SDK snapshots (Android Maven + example iOS git branch). The **example app** adds a Live Activities screen, iOS Widget Extension (built-in + rideshare custom), and Android rideshare callback; README documents setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 425e65a9b09c49d7f5846ab82693153ec5f92f97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->