### PR TITLE
fix: gate iOS geofence enablement on a dictionary config

### DIFF
--- a/ios/wrappers/NativeCustomerIO.swift
+++ b/ios/wrappers/NativeCustomerIO.swift
@@ -53,7 +53,9 @@ public class NativeCustomerIO: NSObject {
             // config is provided or geofence is enabled, since geofence relies on the
             // location module's fixes.
             #if CIO_GEOFENCE_ENABLED
-            let geofenceConfigured = config["geofence"] != nil
+            // Match NativeGeofence.module(from:): only a dictionary counts as configured,
+            // so a non-map value (e.g. null bridged from JS) doesn't imply location.
+            let geofenceConfigured = config["geofence"] as? [String: Any] != nil
             #else
             let geofenceConfigured = false
             #endif
@@ -71,7 +73,9 @@ public class NativeCustomerIO: NSObject {
 
             // Customer value wins; default on when the geofence module is added, off otherwise.
             #if CIO_GEOFENCE_ENABLED
-            let geofenceAdded = config["geofence"] != nil
+            // Match NativeGeofence.module(from:): only a dictionary adds the module, so
+            // background delivery shouldn't default on for a non-map geofence value.
+            let geofenceAdded = config["geofence"] as? [String: Any] != nil
             #else
             let geofenceAdded = false
             #endif


### PR DESCRIPTION
### Summary

Fixes the iOS-only inconsistency Bugbot flagged on #620.

The geofence *enablement* checks used key presence (`config["geofence"] != nil`), while the module builder `NativeGeofence.module(from:)` only builds the module for a **dictionary** value (`config["geofence"] as? [String: Any]`). So a non-map `geofence` value — e.g. `null` bridged from JS — would:
- register the implied **Location** module (`NativeLocation.module(..., geofenceEnabled: true)`), and
- default **`allowBackgroundDelivery`** on,

…without actually adding the geofence module.

Both checks now use the same `as? [String: Any]` cast. Normal cases (`geofence: {}`, `{ locationMode }`, or absent) are unchanged; only a malformed/non-map value now correctly reads as not-configured.

Android already gates on `getTypedValue<Map<String, Any>>` for both the enable check and the module, so no change there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow initialization guard change; only affects malformed/non-map `geofence` config, with normal dictionary or absent config unchanged.
> 
> **Overview**
> **Fixes inconsistent iOS geofence gating** when `geofence` is present in init config but not a map (e.g. `null` from JS).
> 
> `geofenceConfigured` and `geofenceAdded` now use `config["geofence"] as? [String: Any] != nil`, matching `NativeGeofence.module(from:)`. Previously, key presence alone could turn on implied **Location** registration and default **`allowBackgroundDelivery`** without actually adding the geofence module. Valid `geofence` objects and omitted config behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7241dd80e81c440d7fac301ad66595d6fa37f41c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->