### PR TITLE
feat(inbox): React Native Visual Notification Inbox

### DIFF
--- a/DEVELOPING_LOCALLY.md
+++ b/DEVELOPING_LOCALLY.md
@@ -1,0 +1,131 @@
+# Developing locally — Visual Notification Inbox UI (SPIKE)
+
+This document covers the local-native-reference setup used by the
+`spike/visual-inbox-wrappers` branch, which exposes three native Visual Notification Inbox
+UI components to JS:
+
+| JS component | iOS native (SwiftUI) | Android native (Compose) |
+| --- | --- | --- |
+| `NotificationInboxOverlayView` | `NotificationInboxOverlay()` — iOS 16+ | `NotificationInboxOverlay(modifier)` |
+| `NotificationInboxBellView` | `NotificationInboxBell(onTap:)` | `NotificationInboxBell(onClick, modifier)` |
+| `NotificationInboxView` | `NotificationInboxView()` | `NotificationInboxView(modifier)` |
+
+These mirror the existing inline-in-app-message embedding (`InlineInAppMessageView`). The
+headless inbox **data** API (`getMessages`/`subscribe`/`mark`/`track`) and the global action
+`InboxEventListener` are already bridged and are NOT touched here — this is the UI layer only.
+
+## Android (primary build-validation target)
+
+The Visual Notification Inbox UI lives in a native module `:messaginginbox`
+(artifact `io.customer.android:messaging-inbox`, package `io.customer.messaginginbox`).
+It is not on Maven Central yet, so we serve it from `mavenLocal()` at version `local`.
+
+### 1. Publish the native Android SDK to Maven Local
+
+From the native Android source worktree (read-only reference repo):
+
+```bash
+cd /path/to/wt-759-sample   # branch: inbox-sample-listener
+IS_DEVELOPMENT=true ./gradlew publishToMavenLocal
+```
+
+This publishes **all** CIO modules at version `local`, including `messaging-inbox`. Its Jist
+dependency (`io.customer.android:jist`) is resolved from Maven Central (alpha).
+
+### 2. Point this repo's Android native dep at `local`
+
+Already wired on this branch:
+
+- `android/cio-core.gradle` adds:
+  `api "io.customer.android:messaging-inbox:$cioAndroidSDKVersion"`
+- `android/gradle.properties` sets `customerio.reactnative.cioSDKVersionAndroid=local`
+  (revert to a released version, e.g. `4.17.0`, to go back to normal builds)
+- `android/build.gradle` enables Jetpack Compose (the `org.jetbrains.kotlin.plugin.compose`
+  plugin + `buildFeatures { compose true }` + Compose BOM deps) because the view managers host
+  the native `@Composable` inbox components inside a `ComposeView`.
+- `example/android/build.gradle` already has `mavenLocal()` in `allprojects.repositories`.
+- `example/android/app/build.gradle` enables **core library desugaring**
+  (`coreLibraryDesugaringEnabled true` + `com.android.tools:desugar_jdk_libs`), required by
+  `messaging-inbox` and its Jist dependency.
+
+### 3. Build / validate
+
+The React Native **library module** is the primary validation target and compiles green:
+
+```bash
+cd example/android
+./gradlew :customerio-reactnative:compileDebugKotlin
+```
+
+This runs Codegen (generating the `NotificationInbox*NativeManagerInterface`/`Delegate`
+classes from the specs in `src/specs/components/`) and compiles the new Kotlin view managers
++ Compose-hosted views.
+
+#### Full app build — known environment friction
+
+`./gradlew :app:assembleDebug` can fail in this environment for reasons **unrelated to the
+wrapper code**:
+
+1. **Socket Firewall corrupts `autolinking.json`.** The `sfw` PATH wrapper intercepts the
+   `npx @react-native-community/cli config` call that the RN Gradle plugin uses to generate
+   `example/android/build/generated/autolinking/autolinking.json`, prepending a
+   `Protected by Socket Firewall` banner and appending a `=== Socket Firewall ===` footer,
+   which makes the JSON unparseable. Workaround: regenerate, then strip the non-JSON noise:
+
+   ```bash
+   cd example/android
+   ./gradlew :app:generateAutolinkingNewArchitectureFiles --rerun-tasks
+   python3 - <<'PY'
+   import json
+   p='build/generated/autolinking/autolinking.json'
+   raw=open(p).read()
+   obj,_=json.JSONDecoder().raw_decode(raw, raw.index('{'))
+   open(p,'w').write(json.dumps(obj, indent=2))
+   PY
+   # then build WITHOUT regenerating (so the firewall can't re-corrupt it):
+   ./gradlew :app:assembleDebug -x generateAutolinkingNewArchitectureFiles
+   ```
+
+2. **Stale C++ codegen cache** for unrelated autolinked libs (e.g. `react_codegen_rnscreens`)
+   can surface as `ninja: error: unknown target ...` when the autolinking regen is skipped.
+   A clean `.cxx` / `react-native clean` resolves it. None of this involves the inbox wrappers.
+
+## iOS — KNOWN BLOCKER (Jist not on CocoaPods trunk)
+
+iOS uses CocoaPods. The bridge source under `ios/wrappers/inbox/` is written and source-correct
+(mirrors `ios/wrappers/inapp/inline/`), and the podspec declares the dependency:
+
+```ruby
+s.dependency "CustomerIO/MessagingInbox", package["cioNativeiOSSdkVersion"]
+```
+
+**Blocker:** `CustomerIO/MessagingInbox` transitively depends on **Jist**, which is not
+published to the CocoaPods trunk yet. A full `pod install` of the inbox subspec will therefore
+fail to resolve Jist. This is expected and documented rather than forced green here. Once Jist
+ships a podspec (or is vendored locally), the iOS bridge compiles via `UIHostingController`
+hosting the SwiftUI components.
+
+iOS native SwiftUI source reference: `wt-inbox-ios-fix` (branch `inbox-animation-and-data-fix`),
+SPM product `MessagingInbox` (target `CioMessagingInbox`).
+
+## Cross-platform parity note
+
+- `NotificationInboxBellView` `onTap` maps to native `onTap` (iOS) / `onClick` (Android).
+- `NotificationInboxOverlayView` exposes **no** panel-presentation prop. Both native overlays own
+  panel presentation internally (iOS presents a sheet with system detents), so there is no
+  host-facing open/close callback on either platform — the two are at parity here.
+- `NotificationInboxOverlayView` requires **iOS 16+** and renders nothing on iOS 15, because the
+  native overlay's sheet uses system detents. The bell and list components have no such floor, so
+  compose those two if iOS 15 support is needed for a drop-in experience.
+- `NotificationInboxView` has no events; message actions flow through the existing global
+  `InboxEventListener`.
+
+## To finish (beyond this spike)
+
+- Validate `pod install` + an iOS build. Jist is no longer the blocker (it published to the
+  CocoaPods trunk as `Jist 0.1.0`); what remains is that `CustomerIO/MessagingInbox` itself is
+  unreleased, so the podspec dependency is commented out and the sample Podfile pins the native
+  branch directly.
+- Decide intrinsic-sizing behavior for the bell/list (the inline view animates size via
+  `onSizeChange`; the inbox components currently fill their RN-assigned bounds).
+- Add unit/UI tests and Expo plugin coverage if the components graduate from spike status.

--- a/__tests__/inbox-event-listener.test.ts
+++ b/__tests__/inbox-event-listener.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for the React Native Visual Notification Inbox event listener bridge.
+ *
+ * Mirrors the intent of the Flutter SDK's `inbox_event_listener_test.dart`:
+ *   - registering wires the native forwarder + subscribes to the event emitter
+ *   - native inbox events are mapped to `InboxMessageEvent` and delivered to the JS listener
+ *   - `messageActionTaken` carries actionName/actionValue and the message is parsed
+ *   - unregistering (subscription.remove()) tears down the native forwarder and stops delivery
+ *
+ * Note: `jest.mock` factories are hoisted above module-scope declarations, so every
+ * mock (including the fake native module) is created inside its factory and read back
+ * from the imported (mocked) module rather than closing over outer variables.
+ */
+
+// Minimal react-native mock so importing the SDK modules does not touch the
+// native runtime. Only the surface used at import time is provided.
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'ios',
+    select: (spec: { [key: string]: unknown }) =>
+      spec.ios ?? spec.default ?? undefined,
+  },
+}));
+
+// The native Fabric components pull in codegen internals we don't need here.
+jest.mock('../src/components', () => ({}));
+
+// Silence the native logger listener used inside the try/catch fallbacks so a
+// real failure surfaces as a failing assertion rather than a swallowed warning.
+jest.mock('../src/native-logger-listener', () => ({
+  NativeLoggerListener: { warn: jest.fn(), initialize: jest.fn() },
+}));
+
+// Fake native TurboModule. Everything is created inside the factory (jest hoists
+// this above the imports/consts below). The emitter passed to
+// `onInboxEventReceived` is stored on the module so the test can simulate a
+// native -> JS event by invoking `__emit`.
+jest.mock('../src/specs/modules/NativeCustomerIOMessagingInApp', () => {
+  const nativeModule = {
+    registerInboxEventListener: jest.fn(),
+    unregisterInboxEventListener: jest.fn(),
+    onInboxEventReceived: jest.fn((emitter) => {
+      nativeModule.__emit = emitter;
+      return { remove: nativeModule.__nativeRemove };
+    }),
+    __emit: undefined,
+    __nativeRemove: jest.fn(),
+  };
+  return { __esModule: true, default: nativeModule };
+});
+
+import { CustomerIOInAppMessaging } from '../src/customerio-inapp';
+import NativeMock from '../src/specs/modules/NativeCustomerIOMessagingInApp';
+import { InboxEventType, InboxMessageEvent } from '../src/types';
+
+// Typed handle to the mock's extra test hooks.
+const native = NativeMock as unknown as {
+  registerInboxEventListener: jest.Mock;
+  unregisterInboxEventListener: jest.Mock;
+  onInboxEventReceived: jest.Mock;
+  __nativeRemove: jest.Mock;
+  __emit?: (data: unknown) => void;
+};
+
+// Serialized inbox message matching the native `toWritableMap`/`toDictionary` shape.
+const rawMessage = {
+  queueId: 'queue-123',
+  deliveryId: 'delivery-456',
+  expiry: 1710000000000,
+  sentAt: 1700000000000,
+  topics: ['promo', 'news'],
+  type: 'inbox',
+  opened: false,
+  priority: 1,
+  properties: { foo: 'bar' },
+};
+
+describe('CustomerIOInAppMessaging inbox event listener bridge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    native.__emit = undefined;
+  });
+
+  it('registers the native forwarder and subscribes to the emitter', () => {
+    const inApp = new CustomerIOInAppMessaging();
+    inApp.registerInboxEventListener(() => {});
+
+    expect(native.registerInboxEventListener).toHaveBeenCalledTimes(1);
+    expect(native.onInboxEventReceived).toHaveBeenCalledTimes(1);
+    expect(native.__emit).toBeDefined();
+  });
+
+  it('maps messageActionTaken to a parsed InboxMessageEvent with action data', () => {
+    const inApp = new CustomerIOInAppMessaging();
+    const received: InboxMessageEvent[] = [];
+    inApp.registerInboxEventListener((event) => received.push(event));
+
+    native.__emit?.({
+      eventType: 'messageActionTaken',
+      message: rawMessage,
+      actionName: 'messageAction',
+      actionValue: 'https://example.com',
+    });
+
+    expect(received).toHaveLength(1);
+    const event = received[0]!;
+    expect(event).toBeInstanceOf(InboxMessageEvent);
+    expect(event.eventType).toBe(InboxEventType.messageActionTaken);
+    expect(event.actionName).toBe('messageAction');
+    expect(event.actionValue).toBe('https://example.com');
+    expect(event.message.queueId).toBe('queue-123');
+    expect(event.message.deliveryId).toBe('delivery-456');
+    expect(event.message.topics).toEqual(['promo', 'news']);
+    expect(event.message.properties).toEqual({ foo: 'bar' });
+  });
+
+  it('maps observational callbacks (shown/opened/dismissed) to the listener', () => {
+    const inApp = new CustomerIOInAppMessaging();
+    const received: InboxEventType[] = [];
+    inApp.registerInboxEventListener((event) => received.push(event.eventType));
+
+    native.__emit?.({ eventType: 'messageShown', message: rawMessage });
+    native.__emit?.({ eventType: 'messageOpened', message: rawMessage });
+    native.__emit?.({ eventType: 'messageDismissed', message: rawMessage });
+
+    expect(received).toEqual([
+      InboxEventType.messageShown,
+      InboxEventType.messageOpened,
+      InboxEventType.messageDismissed,
+    ]);
+  });
+
+  it('unregisters the native forwarder and stops delivery on remove()', () => {
+    const inApp = new CustomerIOInAppMessaging();
+    const received: InboxMessageEvent[] = [];
+    const subscription = inApp.registerInboxEventListener((event) =>
+      received.push(event)
+    );
+
+    subscription.remove();
+
+    expect(native.__nativeRemove).toHaveBeenCalledTimes(1);
+    expect(native.unregisterInboxEventListener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,14 +64,6 @@ repositories {
   mavenCentral()
   google()
 
-  // WIP (visual-inbox-wrappers): the native `messaging-inbox` module is unreleased, so the inbox
-  // components are consumed from the snapshot customerio-android CI publishes for its base feature
-  // branch on every push (see `cioSDKVersionAndroid` in gradle.properties). Remove on native release.
-  maven {
-    url = uri("https://central.sonatype.com/repository/maven-snapshots/")
-    mavenContent { snapshotsOnly() }
-  }
-
   def found = false
   def defaultDir = null
   def androidSourcesName = 'React Native sources'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,11 +10,14 @@ buildscript {
   dependencies {
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    // Compose compiler plugin (Kotlin 2.x) for hosting the Visual Notification Inbox composables.
+    classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlin_version"
   }
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 apply plugin: "com.facebook.react"
 
 def getExtOrDefault(name) {
@@ -39,6 +42,8 @@ android {
 
   buildFeatures {
     buildConfig true
+    // Required to host the Visual Notification Inbox Compose UI components.
+    compose true
   }
 
   buildTypes {
@@ -58,6 +63,14 @@ android {
 repositories {
   mavenCentral()
   google()
+
+  // WIP (visual-inbox-wrappers): the native `messaging-inbox` module is unreleased, so the inbox
+  // components are consumed from the snapshot customerio-android CI publishes for its base feature
+  // branch on every push (see `cioSDKVersionAndroid` in gradle.properties). Remove on native release.
+  maven {
+    url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+    mavenContent { snapshotsOnly() }
+  }
 
   def found = false
   def defaultDir = null
@@ -152,4 +165,12 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
+  // Jetpack Compose — needed because the Visual Notification Inbox view managers host
+  // the native `@Composable` inbox components inside a ComposeView.
+  def composeBom = platform('androidx.compose:compose-bom:2025.10.00')
+  implementation composeBom
+  implementation 'androidx.compose.ui:ui'
+  implementation 'androidx.compose.foundation:foundation'
+  implementation 'androidx.compose.runtime:runtime'
 }

--- a/android/cio-core.gradle
+++ b/android/cio-core.gradle
@@ -2,7 +2,7 @@ dependencies {
     api "io.customer.android:datapipelines:$cioAndroidSDKVersion"
     api "io.customer.android:messaging-push-fcm:$cioAndroidSDKVersion"
     api "io.customer.android:messaging-in-app:$cioAndroidSDKVersion"
-    // Visual Notification Inbox UI (Compose-based). SPIKE: served from mavenLocal at version `local`.
+    // Visual Notification Inbox UI (Compose-based).
     api "io.customer.android:messaging-inbox:$cioAndroidSDKVersion"
     // Location module is optional - customers enable it by adding
     // customerio_location_enabled=true in their gradle.properties

--- a/android/cio-core.gradle
+++ b/android/cio-core.gradle
@@ -2,6 +2,8 @@ dependencies {
     api "io.customer.android:datapipelines:$cioAndroidSDKVersion"
     api "io.customer.android:messaging-push-fcm:$cioAndroidSDKVersion"
     api "io.customer.android:messaging-in-app:$cioAndroidSDKVersion"
+    // Visual Notification Inbox UI (Compose-based). SPIKE: served from mavenLocal at version `local`.
+    api "io.customer.android:messaging-inbox:$cioAndroidSDKVersion"
     // Location module is optional - customers enable it by adding
     // customerio_location_enabled=true in their gradle.properties
     if (project.cioLocationEnabled) {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,8 @@ customerio.reactnative.kotlinVersion=2.1.20
 customerio.reactnative.compileSdkVersion=36
 customerio.reactnative.targetSdkVersion=36
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=4.18.2
+# WIP (visual-inbox-wrappers): the native messaging-inbox module is unreleased, so this consumes the
+# snapshot customerio-android CI publishes for its base feature branch on every push to that PR
+# (snapshot repo declared in build.gradle). Reproducible on CI and any machine, unlike mavenLocal.
+# Revert to a released version on native release.
+customerio.reactnative.cioSDKVersionAndroid=feat-overlay-inbox-SNAPSHOT

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,8 +2,4 @@ customerio.reactnative.kotlinVersion=2.1.20
 customerio.reactnative.compileSdkVersion=36
 customerio.reactnative.targetSdkVersion=36
 customerio.reactnative.minSdkVersion=21
-# WIP (visual-inbox-wrappers): the native messaging-inbox module is unreleased, so this consumes the
-# snapshot customerio-android CI publishes for its base feature branch on every push to that PR
-# (snapshot repo declared in build.gradle). Reproducible on CI and any machine, unlike mavenLocal.
-# Revert to a released version on native release.
-customerio.reactnative.cioSDKVersionAndroid=feat-overlay-inbox-SNAPSHOT
+customerio.reactnative.cioSDKVersionAndroid=4.20.0

--- a/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/CustomerIOReactNativePackage.kt
@@ -10,6 +10,8 @@ import io.customer.reactnative.sdk.location.NativeLocationModule
 import io.customer.reactnative.sdk.logging.NativeCustomerIOLoggingModule
 import io.customer.reactnative.sdk.messaginginapp.InlineInAppMessageViewManager
 import io.customer.reactnative.sdk.messaginginapp.NativeMessagingInAppModule
+import io.customer.reactnative.sdk.messaginginbox.NotificationInboxBellViewManager
+import io.customer.reactnative.sdk.messaginginbox.NotificationInboxViewManager
 import io.customer.reactnative.sdk.messagingpush.NativeMessagingPushModule
 import io.customer.reactnative.sdk.util.assertNotNull
 
@@ -22,7 +24,11 @@ class CustomerIOReactNativePackage : BaseReactPackage() {
      * Creates the list of view managers for the Customer.io React Native SDK.
      */
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
-        return listOf(InlineInAppMessageViewManager())
+        return listOf(
+            InlineInAppMessageViewManager(),
+            NotificationInboxBellViewManager(),
+            NotificationInboxViewManager()
+        )
     }
 
     override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
@@ -31,6 +37,8 @@ class CustomerIOReactNativePackage : BaseReactPackage() {
         // See: https://reactnative.dev/docs/fabric-native-components-introduction?platforms=android#4-write-the-reactwebviewpackage
         return when (name) {
             InlineInAppMessageViewManager.NAME -> InlineInAppMessageViewManager()
+            NotificationInboxBellViewManager.NAME -> NotificationInboxBellViewManager()
+            NotificationInboxViewManager.NAME -> NotificationInboxViewManager()
             NativeCustomerIOLoggingModule.NAME -> NativeCustomerIOLoggingModule(reactContext)
             NativeCustomerIOModule.NAME -> NativeCustomerIOModule(reactContext = reactContext)
             NativeLocationModule.NAME -> if (BuildConfig.CIO_LOCATION_ENABLED) {
@@ -69,6 +77,8 @@ class CustomerIOReactNativePackage : BaseReactPackage() {
         // doesn't crash at import time. getModule() returns null when disabled.
         val moduleNames: List<String> = listOf(
             InlineInAppMessageViewManager.NAME,
+            NotificationInboxBellViewManager.NAME,
+            NotificationInboxViewManager.NAME,
             NativeCustomerIOLoggingModule.NAME,
             NativeCustomerIOModule.NAME,
             NativeLocationModule.NAME,

--- a/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/NativeMessagingInAppModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/NativeMessagingInAppModule.kt
@@ -33,6 +33,7 @@ class NativeMessagingInAppModule(
 
     private val inAppEventListener = ReactInAppEventListener.instance
     private val inboxChangeListener = ReactNotificationInboxChangeListener.instance
+    private val inboxEventListener = ReactInboxEventListener.instance
 
     // Dedicated lock for inbox listener setup to avoid blocking other operations
     private val inboxListenerLock = Any()
@@ -63,6 +64,7 @@ class NativeMessagingInAppModule(
     override fun invalidate() {
         inAppEventListener.clearEventEmitter()
         clearInboxChangeListener()
+        clearInboxEventListener()
         super.invalidate()
     }
 
@@ -72,6 +74,43 @@ class NativeMessagingInAppModule(
 
     override fun setupInboxListener() {
         setupInboxChangeListener()
+    }
+
+    /**
+     * Registers the native inbox event forwarder with the SDK and wires it to the React Native
+     * event emitter. Called when a JS inbox event listener is registered.
+     */
+    override fun registerInboxEventListener() {
+        inboxEventListener.setEventEmitter { data ->
+            emitOnInboxEventReceived(data)
+        }
+        val module = inAppMessagingModule
+        if (module == null) {
+            // Without this the failure is invisible: the JS subscription reports success while the SDK
+            // never forwards anything, so inbox callbacks silently never arrive. Matches the guidance
+            // used by getMessages() for the same situation.
+            logger.error(
+                "Cannot register inbox event listener: in-app messaging is not available. " +
+                    "Ensure CustomerIO SDK is initialized before registering the listener."
+            )
+            return
+        }
+        module.setInboxEventListener(inboxEventListener)
+    }
+
+    /**
+     * Unregisters the native inbox event forwarder by installing a no-op listener (the native API is
+     * non-null), restoring the SDK's default action handling. Called when the JS inbox event
+     * listener is removed.
+     */
+    override fun unregisterInboxEventListener() {
+        inAppMessagingModule?.setInboxEventListener(NoOpInboxEventListener)
+        inboxEventListener.clearEventEmitter()
+    }
+
+    private fun clearInboxEventListener() {
+        inAppMessagingModule?.setInboxEventListener(NoOpInboxEventListener)
+        inboxEventListener.clearEventEmitter()
     }
 
     override fun getMessages(topic: String?, promise: Promise?) {

--- a/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/ReactInboxEventListener.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messaginginapp/ReactInboxEventListener.kt
@@ -1,0 +1,99 @@
+package io.customer.reactnative.sdk.messaginginapp
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReadableMap
+import io.customer.messaginginapp.gist.data.model.InboxMessage
+import io.customer.messaginginapp.type.InboxEventListener
+
+/**
+ * React Native bridge for Customer.io Visual Notification Inbox events.
+ *
+ * Registered on the SDK (via [io.customer.messaginginapp.ModuleMessagingInApp.setInboxEventListener])
+ * only while a JS listener is registered. Because the New-Arch event emitter is one-way we cannot
+ * round-trip a bool back from JS, so [messageActionTaken] forwards the event fire-and-forget and
+ * RETURNS `true` — telling the SDK the host handled the action so the SDK suppresses its default
+ * navigation. The JS host owns action handling while a listener is registered. Observational
+ * callbacks forward fire-and-forget.
+ */
+class ReactInboxEventListener private constructor() : InboxEventListener {
+    // Event emitter function to send events to React Native layer
+    private var eventEmitter: ((ReadableMap) -> Unit)? = null
+
+    // Sets the event emitter function
+    internal fun setEventEmitter(emitter: ((ReadableMap) -> Unit)?) {
+        this.eventEmitter = emitter
+    }
+
+    // Clears the event emitter to prevent memory leaks
+    internal fun clearEventEmitter() {
+        this.eventEmitter = null
+    }
+
+    // Emits an inbox message event to React Native with a serialized message payload
+    private fun emitInboxEvent(
+        eventType: String,
+        message: InboxMessage,
+        actionName: String? = null,
+        actionValue: String? = null,
+    ) {
+        // Get the emitter, return early if not set
+        val emitter = eventEmitter ?: return
+
+        val data = Arguments.createMap().apply {
+            putString("eventType", eventType)
+            putMap("message", message.toWritableMap())
+            actionName?.let { putString("actionName", it) }
+            actionValue?.let { putString("actionValue", it) }
+        }
+
+        emitter.invoke(data)
+    }
+
+    override fun messageActionTaken(
+        message: InboxMessage,
+        actionName: String,
+        actionValue: String,
+    ): Boolean {
+        emitInboxEvent(
+            eventType = "messageActionTaken",
+            message = message,
+            actionName = actionName,
+            actionValue = actionValue,
+        )
+        // Host (React Native) owns action handling while a listener is registered.
+        return true
+    }
+
+    override fun messageShown(message: InboxMessage) = emitInboxEvent(
+        eventType = "messageShown",
+        message = message,
+    )
+
+    override fun messageOpened(message: InboxMessage) = emitInboxEvent(
+        eventType = "messageOpened",
+        message = message,
+    )
+
+    override fun messageDismissed(message: InboxMessage) = emitInboxEvent(
+        eventType = "messageDismissed",
+        message = message,
+    )
+
+    companion object {
+        // Singleton instance with public visibility for direct access by Expo plugin
+        val instance: ReactInboxEventListener by lazy { ReactInboxEventListener() }
+    }
+}
+
+/**
+ * No-op inbox listener used to clear the forwarder from the SDK. Returning `false` from
+ * [messageActionTaken] restores the SDK's default action handling. The native
+ * `setInboxEventListener` API is non-null, so a no-op is installed rather than clearing.
+ */
+internal object NoOpInboxEventListener : InboxEventListener {
+    override fun messageActionTaken(
+        message: InboxMessage,
+        actionName: String,
+        actionValue: String,
+    ): Boolean = false
+}

--- a/android/src/main/java/io/customer/reactnative/sdk/messaginginbox/NotificationInboxBellViewManager.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messaginginbox/NotificationInboxBellViewManager.kt
@@ -1,0 +1,38 @@
+package io.customer.reactnative.sdk.messaginginbox
+
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.SimpleViewManager
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.NotificationInboxBellNativeManagerDelegate
+import com.facebook.react.viewmanagers.NotificationInboxBellNativeManagerInterface
+
+/**
+ * View manager for the Visual Notification Inbox bell (just the bell; host opens its own UI).
+ *
+ * Registers the `onTap` direct event so taps reach the JS wrapper.
+ */
+@ReactModule(name = NotificationInboxBellViewManager.NAME)
+class NotificationInboxBellViewManager :
+    NotificationInboxBellNativeManagerInterface<ReactNotificationInboxBellView>,
+    SimpleViewManager<ReactNotificationInboxBellView>() {
+    private val delegate = NotificationInboxBellNativeManagerDelegate(this)
+
+    override fun getName() = NAME
+    override fun getDelegate(): ViewManagerDelegate<ReactNotificationInboxBellView> = delegate
+
+    override fun createViewInstance(
+        reactContext: ThemedReactContext
+    ): ReactNotificationInboxBellView = ReactNotificationInboxBellView(reactContext)
+
+    override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
+        val customEvents = super.getExportedCustomDirectEventTypeConstants() ?: mutableMapOf()
+        customEvents[ReactNotificationInboxBellView.ON_TAP] =
+            mapOf("registrationName" to ReactNotificationInboxBellView.ON_TAP)
+        return customEvents
+    }
+
+    companion object {
+        internal const val NAME = "NotificationInboxBellNative"
+    }
+}

--- a/android/src/main/java/io/customer/reactnative/sdk/messaginginbox/NotificationInboxViewManager.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messaginginbox/NotificationInboxViewManager.kt
@@ -1,0 +1,30 @@
+package io.customer.reactnative.sdk.messaginginbox
+
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.SimpleViewManager
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.NotificationInboxViewNativeManagerDelegate
+import com.facebook.react.viewmanagers.NotificationInboxViewNativeManagerInterface
+
+/**
+ * View manager for the Visual Notification Inbox message list (the Jist-rendered list,
+ * embeddable in the host's own screen). No props or events; sizing comes from the JS style.
+ */
+@ReactModule(name = NotificationInboxViewManager.NAME)
+class NotificationInboxViewManager :
+    NotificationInboxViewNativeManagerInterface<ReactNotificationInboxView>,
+    SimpleViewManager<ReactNotificationInboxView>() {
+    private val delegate = NotificationInboxViewNativeManagerDelegate(this)
+
+    override fun getName() = NAME
+    override fun getDelegate(): ViewManagerDelegate<ReactNotificationInboxView> = delegate
+
+    override fun createViewInstance(
+        reactContext: ThemedReactContext
+    ): ReactNotificationInboxView = ReactNotificationInboxView(reactContext)
+
+    companion object {
+        internal const val NAME = "NotificationInboxViewNative"
+    }
+}

--- a/android/src/main/java/io/customer/reactnative/sdk/messaginginbox/ReactComposeHostView.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messaginginbox/ReactComposeHostView.kt
@@ -1,0 +1,96 @@
+package io.customer.reactnative.sdk.messaginginbox
+
+import android.content.Context
+import android.view.Choreographer
+import android.view.View
+import android.widget.FrameLayout
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.ComposeView
+import com.facebook.react.bridge.WritableMap
+import io.customer.reactnative.sdk.extension.sendUIEventToReactJS
+
+/**
+ * Base React Native view that hosts a Jetpack Compose [content] inside a [ComposeView].
+ *
+ * Mirrors the role that the native SDK's `WrapperInlineView` plays for inline in-app
+ * messages, but the Visual Notification Inbox components are plain `@Composable`s, so we
+ * host them directly in a [ComposeView] rather than going through an inline-message wrapper.
+ *
+ * Subclasses provide the composable via [content] and emit events with [emitEvent].
+ *
+ * Layout note: React Native (Yoga) lays this view out, so the [ComposeView] is sized to the
+ * bounds RN assigns. Because RN children measured by native code don't always re-trigger a
+ * layout pass, we schedule a manual measure/layout via the [Choreographer] whenever the view
+ * is attached, matching how other RN-hosted native views keep themselves laid out.
+ */
+abstract class ReactComposeHostView(context: Context) : FrameLayout(context) {
+
+    private val composeView: ComposeView = ComposeView(context).apply {
+        layoutParams = LayoutParams(
+            LayoutParams.MATCH_PARENT,
+            LayoutParams.MATCH_PARENT
+        )
+        setContent { content() }
+    }
+
+    /** The Compose UI hosted by this view. Implemented by each concrete inbox component. */
+    @Composable
+    protected abstract fun content()
+
+    /**
+     * The Compose child is attached here rather than in `init`, gating setup on attachment the same
+     * way [io.customer.messaginginapp.ui.core.BaseInlineInAppMessageView] gates its subscription.
+     *
+     * Fabric measures a newly created view before the mount batch's INSERT attaches it to the
+     * window ([com.facebook.react.fabric.mounting.SurfaceMountingManager.updateLayout]), and
+     * `AbstractComposeView.onMeasure` unconditionally creates its composition, which needs a window
+     * to resolve the recomposer. Adding the child in `init` therefore threw
+     * `IllegalStateException: Cannot locate windowRecomposer` during that measure; the mount batch
+     * aborted and the half-mounted hierarchy crashed the host app.
+     */
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        if (composeView.parent == null) {
+            addView(composeView)
+        }
+    }
+
+    /**
+     * Dispatches a UI event back to the JS side using the React Native event dispatcher.
+     *
+     * @param eventName name registered in the view manager's
+     *   `getExportedCustomDirectEventTypeConstants`.
+     * @param payload optional event data.
+     */
+    protected fun emitEvent(eventName: String, payload: WritableMap? = null) {
+        sendUIEventToReactJS(eventName = eventName, payload = payload)
+    }
+
+    /**
+     * React Native lays out views off the main Android layout pass, so manually re-run
+     * measure + layout against the bounds RN assigned. Without this, native children of
+     * RN-managed views can render with a zero size.
+     */
+    override fun requestLayout() {
+        super.requestLayout()
+        post(measureAndLayout)
+    }
+
+    private val measureAndLayout = Runnable {
+        // The callback is posted for the next frame, by which point the view may have been detached
+        // (Fabric recycles these). Measuring the Compose child without a window throws, so skip it —
+        // a later attach re-runs layout anyway.
+        if (!isAttachedToWindow) {
+            return@Runnable
+        }
+        measure(
+            MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+            MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+        )
+        layout(left, top, right, bottom)
+    }
+
+    private fun View.post(action: Runnable) {
+        Choreographer.getInstance().postFrameCallback { action.run() }
+    }
+}

--- a/android/src/main/java/io/customer/reactnative/sdk/messaginginbox/ReactNotificationInboxBellView.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messaginginbox/ReactNotificationInboxBellView.kt
@@ -1,0 +1,48 @@
+package io.customer.reactnative.sdk.messaginginbox
+
+import android.content.Context
+import android.view.MotionEvent
+import androidx.compose.runtime.Composable
+import com.facebook.react.bridge.Arguments
+import io.customer.messaginginbox.NotificationInboxOverlay
+
+/**
+ * React Native host for the Visual Notification Inbox bell.
+ *
+ * Hosts the native [NotificationInboxOverlay] composable rather than `NotificationInboxBell`: only the
+ * overlay ties the bell to the SDK's own inbox panel, and the wrapper deliberately does not reimplement
+ * panel presentation. Sized to the frame React Native assigns, that composition *is* a bell that opens
+ * the inbox — the component wrappers expose.
+ *
+ * Remote branding still styles the bell (colors, icon). Branding's bell *position* has no effect here:
+ * alignment resolves inside this view's bounds, so the JS host owns placement via `style`.
+ *
+ * [ON_TAP] is observational — the SDK opens the panel itself, so the host has nothing to do in response.
+ */
+class ReactNotificationInboxBellView(context: Context) : ReactComposeHostView(context) {
+    @Composable
+    override fun content() {
+        NotificationInboxOverlay()
+    }
+
+    /**
+     * Reports taps without consuming them.
+     *
+     * `dispatchTouchEvent` rather than `onTouchEvent`: the Compose child consumes the bell tap, so a
+     * parent `onTouchEvent` would never run. Dispatching to super first keeps the gesture flowing to
+     * Compose (which opens the panel); we only observe the outcome. Reporting on ACTION_UP and only
+     * when the touch was consumed approximates "the bell took this tap" rather than firing for taps
+     * that landed on the transparent area around it.
+     */
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        val handled = super.dispatchTouchEvent(event)
+        if (handled && event.actionMasked == MotionEvent.ACTION_UP) {
+            emitEvent(ON_TAP, Arguments.createMap())
+        }
+        return handled
+    }
+
+    companion object {
+        const val ON_TAP = "onTap"
+    }
+}

--- a/android/src/main/java/io/customer/reactnative/sdk/messaginginbox/ReactNotificationInboxView.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/messaginginbox/ReactNotificationInboxView.kt
@@ -1,0 +1,17 @@
+package io.customer.reactnative.sdk.messaginginbox
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import io.customer.messaginginbox.NotificationInboxView
+
+/**
+ * React Native host for the native [NotificationInboxView] composable (the Jist-rendered
+ * message list). Sizing is driven by the JS `style` prop. Message actions are handled by the
+ * existing global InboxEventListener, so this component emits no per-message events.
+ */
+class ReactNotificationInboxView(context: Context) : ReactComposeHostView(context) {
+    @Composable
+    override fun content() {
+        NotificationInboxView()
+    }
+}

--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -116,6 +116,7 @@ export class CustomerIOInAppMessaging implements NativeInAppSpec {
     inbox(): NotificationInbox;
     // (undocumented)
     registerEventsListener(listener: (event: InAppMessageEvent) => void): EventSubscription;
+    registerInboxEventListener(listener: (event: InboxMessageEvent) => void): EventSubscription;
 }
 
 // Warning: (ae-forgotten-export) The symbol "NativeLocationSpec" needs to be exported by the entry point index.d.ts
@@ -186,6 +187,14 @@ export enum InAppMessageEventType {
 }
 
 // @public
+export enum InboxEventType {
+    messageActionTaken = "messageActionTaken",
+    messageDismissed = "messageDismissed",
+    messageOpened = "messageOpened",
+    messageShown = "messageShown"
+}
+
+// @public
 export interface InboxMessage {
     deliveryId?: string;
     expiry?: number;
@@ -196,6 +205,15 @@ export interface InboxMessage {
     sentAt: number;
     topics: string[];
     type: string;
+}
+
+// @public
+export class InboxMessageEvent {
+    constructor(eventType: InboxEventType, message: InboxMessage, actionName?: string, actionValue?: string);
+    actionName?: string;
+    actionValue?: string;
+    eventType: InboxEventType;
+    message: InboxMessage;
 }
 
 // @public (undocumented)
@@ -232,10 +250,29 @@ export class NotificationInbox implements NotificationInboxPublicSpec {
     trackMessageClicked(message: InboxMessage, actionName?: string): void;
 }
 
+// @public (undocumented)
+export const NotificationInboxBellView: React_2.FC<NotificationInboxBellViewProps>;
+
+// Warning: (ae-forgotten-export) The symbol "NativeProps_2" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export interface NotificationInboxBellViewProps extends Omit<NativeProps_2, 'onTap'> {
+    onTap?: () => void;
+}
+
 // @public
 export type NotificationInboxChangeListener = {
     onMessagesChanged: (messages: InboxMessage[]) => void;
 };
+
+// @public (undocumented)
+export const NotificationInboxView: React_2.FC<NotificationInboxViewProps>;
+
+// Warning: (ae-forgotten-export) The symbol "NativeProps_3" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export interface NotificationInboxViewProps extends NativeProps_3 {
+}
 
 // @public
 export enum PushClickBehaviorAndroid {

--- a/customerio-reactnative-richpush.podspec
+++ b/customerio-reactnative-richpush.podspec
@@ -15,7 +15,10 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/customerio/customerio-ios.git", :tag => "#{s.version}" }
 
-  s.source_files = "ios/**/*.{h,m,mm,swift}"
+  # Dependency-only pod: installed into the NSE target, whose job is purely to pull in the minimal
+  # CIO push dependency below. It must NOT compile any sources — everything under ios/ is the React
+  # Native bridge (React + DataPipelines + InApp + Inbox), none of which the NSE target has or should
+  # have. Globbing them here made the NSE compile the whole bridge and fail on React headers.
 
   # Careful when declaring dependencies here. All dependencies will be included in the App Extension target in Xcode, not the host iOS app.   
 

--- a/customerio-reactnative.podspec
+++ b/customerio-reactnative.podspec
@@ -28,6 +28,19 @@ Pod::Spec.new do |s|
   # Reference: https://guides.cocoapods.org/syntax/podfile.html#pod
   s.dependency "CustomerIO/DataPipelines", package["cioNativeiOSSdkVersion"]
   s.dependency "CustomerIO/MessagingInApp", package["cioNativeiOSSdkVersion"]
+  # Visual Notification Inbox UI (SwiftUI).
+  #
+  # TODO(inbox-release): this cannot resolve from the CocoaPods trunk until the native inbox ships —
+  # `CustomerIOMessagingInbox` exists only on customerio-ios `feat/overlay-inbox`, so `pod lib lint`
+  # and any plain `pod install` of this pod stay red until then. The sample app resolves it by
+  # branch-overriding in example/ios/Podfile. Jist is NO LONGER a blocker (published as `Jist 0.1.0`).
+  #
+  # Declared on the standalone pod rather than a `CustomerIO/MessagingInbox` subspec because the
+  # umbrella CustomerIO.podspec has no MessagingInbox subspec (every other module has one). Either
+  # native adds it — preferred, for consistency — or this line stays as-is. Cannot be commented out:
+  # the bridge in ios/wrappers/inbox/* imports CioMessagingInbox, and a pod target only sees the
+  # modules its podspec declares.
+  s.dependency "CustomerIOMessagingInbox", package["cioNativeiOSSdkVersion"]
 
   # If we do not specify a default_subspec, then *all* dependencies inside of *all* the subspecs will be downloaded by cocoapods.
   # We want customers to opt into push dependencies especially because the FCM subpsec downloads Firebase dependencies. APN customers should not install Firebase dependencies at all.

--- a/customerio-reactnative.podspec
+++ b/customerio-reactnative.podspec
@@ -28,19 +28,9 @@ Pod::Spec.new do |s|
   # Reference: https://guides.cocoapods.org/syntax/podfile.html#pod
   s.dependency "CustomerIO/DataPipelines", package["cioNativeiOSSdkVersion"]
   s.dependency "CustomerIO/MessagingInApp", package["cioNativeiOSSdkVersion"]
-  # Visual Notification Inbox UI (SwiftUI).
-  #
-  # TODO(inbox-release): this cannot resolve from the CocoaPods trunk until the native inbox ships —
-  # `CustomerIOMessagingInbox` exists only on customerio-ios `feat/overlay-inbox`, so `pod lib lint`
-  # and any plain `pod install` of this pod stay red until then. The sample app resolves it by
-  # branch-overriding in example/ios/Podfile. Jist is NO LONGER a blocker (published as `Jist 0.1.0`).
-  #
-  # Declared on the standalone pod rather than a `CustomerIO/MessagingInbox` subspec because the
-  # umbrella CustomerIO.podspec has no MessagingInbox subspec (every other module has one). Either
-  # native adds it — preferred, for consistency — or this line stays as-is. Cannot be commented out:
-  # the bridge in ios/wrappers/inbox/* imports CioMessagingInbox, and a pod target only sees the
-  # modules its podspec declares.
-  s.dependency "CustomerIOMessagingInbox", package["cioNativeiOSSdkVersion"]
+  # Visual Notification Inbox UI (SwiftUI). Not optional: the bridge in ios/wrappers/inbox/* imports
+  # CioMessagingInbox, and a pod target only sees the modules its podspec declares.
+  s.dependency "CustomerIO/MessagingInbox", package["cioNativeiOSSdkVersion"]
 
   # If we do not specify a default_subspec, then *all* dependencies inside of *all* the subspecs will be downloaded by cocoapods.
   # We want customers to opt into push dependencies especially because the FCM subpsec downloads Firebase dependencies. APN customers should not install Firebase dependencies at all.

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -106,10 +106,8 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
-    // SPIKE: the Visual Notification Inbox native module (messaging-inbox) and its Jist dependency
-    // require core library desugaring. Enable it for the sample app.
+    // The Customer.io native modules are compiled at Java 17.
     compileOptions {
-        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
@@ -118,9 +116,6 @@ android {
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
-
-    // SPIKE: required by the Visual Notification Inbox native module (messaging-inbox + Jist).
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -106,11 +106,21 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+    // SPIKE: the Visual Notification Inbox native module (messaging-inbox) and its Jist dependency
+    // require core library desugaring. Enable it for the sample app.
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
 }
 
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
+
+    // SPIKE: required by the Visual Notification Inbox native module (messaging-inbox + Jist).
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -64,6 +64,25 @@ target app_target_name do
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: push_provider)
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: push_provider)
 
+  # -------------------------------------------------------------------------
+  # WIP (visual-inbox-wrappers): the native Visual Notification Inbox is unreleased, so the CIO iOS
+  # pods come from the base feature branch instead of the trunk. Unlike the local path this replaces,
+  # it resolves on CI and on any machine.
+  #
+  # REMOVE this block once the native inbox ships, and revert package.json
+  # "cioNativeiOSSdkVersion" to the released version.
+  cio_ios_branch = ENV["CIO_IOS_BRANCH"] || 'feat/overlay-inbox'
+  # Standard CIO pods (Common, DataPipelines, MessagingPush[APN], Location, MessagingInApp) from the
+  # branch. Note this helper is fetched from customerio-ios `main`, so its pod list does not include
+  # the inbox — hence the explicit pods below.
+  install_non_production_ios_sdk_git_branch(branch_name: cio_ios_branch, is_app_extension: false, push_service: push_provider)
+  # The inbox pod itself. Jist is NOT listed here: CustomerIOMessagingInbox.podspec on the branch
+  # depends on `Jist 0.1.0`, which is on the CocoaPods trunk, so it resolves on its own now.
+  pod 'CustomerIOMessagingInbox', :git => 'https://github.com/customerio/customerio-ios.git', :branch => cio_ios_branch
+  # DataPipelines depends on this; the helper above does not install it.
+  pod 'CustomerIOTrackingMigration', :git => 'https://github.com/customerio/customerio-ios.git', :branch => cio_ios_branch
+  # -------------------------------------------------------------------------
+
   post_install do |installer|
     react_native_post_install(
       installer,

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -64,25 +64,6 @@ target app_target_name do
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: push_provider)
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: push_provider)
 
-  # -------------------------------------------------------------------------
-  # WIP (visual-inbox-wrappers): the native Visual Notification Inbox is unreleased, so the CIO iOS
-  # pods come from the base feature branch instead of the trunk. Unlike the local path this replaces,
-  # it resolves on CI and on any machine.
-  #
-  # REMOVE this block once the native inbox ships, and revert package.json
-  # "cioNativeiOSSdkVersion" to the released version.
-  cio_ios_branch = ENV["CIO_IOS_BRANCH"] || 'feat/overlay-inbox'
-  # Standard CIO pods (Common, DataPipelines, MessagingPush[APN], Location, MessagingInApp) from the
-  # branch. Note this helper is fetched from customerio-ios `main`, so its pod list does not include
-  # the inbox — hence the explicit pods below.
-  install_non_production_ios_sdk_git_branch(branch_name: cio_ios_branch, is_app_extension: false, push_service: push_provider)
-  # The inbox pod itself. Jist is NOT listed here: CustomerIOMessagingInbox.podspec on the branch
-  # depends on `Jist 0.1.0`, which is on the CocoaPods trunk, so it resolves on its own now.
-  pod 'CustomerIOMessagingInbox', :git => 'https://github.com/customerio/customerio-ios.git', :branch => cio_ios_branch
-  # DataPipelines depends on this; the helper above does not install it.
-  pod 'CustomerIOTrackingMigration', :git => 'https://github.com/customerio/customerio-ios.git', :branch => cio_ios_branch
-  # -------------------------------------------------------------------------
-
   post_install do |installer|
     react_native_post_install(
       installer,

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -5201,9 +5201,9 @@
       "license": "MIT"
     },
     "node_modules/customerio-reactnative": {
-      "version": "6.4.0",
+      "version": "6.5.2",
       "resolved": "file:../customerio-reactnative.tgz",
-      "integrity": "sha512-zecDKrOc6EXHFdC04KLqiTeYTBRmV0cFEGEhTzVn2+wjskKFy8kxMKN/5yAxXi7uMyO08AYM4nuckKfn5ayZjw==",
+      "integrity": "sha512-rNij5E016mf4wUwMmsSM9/VSsCxOUU2sVwUvsXfWV24qKyXhqzKyifEZs17APbfzkz1DmaJbtmMPJ49DzdS3mA==",
       "hasInstallScript": true,
       "license": "MIT",
       "engines": {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -36,6 +36,10 @@ export default function App({ appName }: { appName: string }) {
     ? {
       Home: 'home',
       Settings: 'settings',
+      // Inbox screens are signed-in only: the inbox is per-profile, so an anonymous
+      // deep link should land on Login rather than an empty inbox.
+      'Inbox Messages': 'inbox-messages',
+      'Visual Inbox': 'visual-inbox',
     }
     : {
       Login: 'login',

--- a/example/src/navigation/props.ts
+++ b/example/src/navigation/props.ts
@@ -12,6 +12,7 @@ export const CustomDeviceAttrScreenName = 'Device Attributes' as const;
 export const InternalSettingsScreenName = 'Internal Settings' as const;
 export const InlineExamplesScreenName = 'Inline Examples' as const;
 export const InboxMessagesScreenName = 'Inbox Messages' as const;
+export const VisualInboxScreenName = 'Visual Inbox' as const;
 export const LocationScreenName = 'Location' as const;
 
 export type NavigationStackParamList = {
@@ -25,6 +26,7 @@ export type NavigationStackParamList = {
   [InternalSettingsScreenName]: undefined;
   [InlineExamplesScreenName]: undefined;
   [InboxMessagesScreenName]: undefined;
+  [VisualInboxScreenName]: undefined;
   [LocationScreenName]: undefined;
 };
 

--- a/example/src/screens/content-navigator.tsx
+++ b/example/src/screens/content-navigator.tsx
@@ -11,6 +11,7 @@ import {
   NavigationStackParamList,
   SettingsScreenName,
   TrackScreenName,
+  VisualInboxScreenName,
 } from '@navigation';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { screenStylingOptions } from '@utils';
@@ -27,6 +28,7 @@ import {
   LogingScreen,
   SettingsScreen,
   TrackScreen,
+  VisualInboxScreen,
 } from '@screens';
 
 import { Storage } from '@services';
@@ -125,6 +127,14 @@ export const ContentNavigator = ({ appName }: { appName: string }) => {
         <Stack.Screen
           name={InboxMessagesScreenName}
           component={InboxMessagesScreen}
+          options={{
+            headerBackButtonDisplayMode: 'minimal',
+            headerBackVisible: true,
+          }}
+        />
+        <Stack.Screen
+          name={VisualInboxScreenName}
+          component={VisualInboxScreen}
           options={{
             headerBackButtonDisplayMode: 'minimal',
             headerBackVisible: true,

--- a/example/src/screens/home.tsx
+++ b/example/src/screens/home.tsx
@@ -7,6 +7,7 @@ import {
   LocationScreenName,
   NavigationCallbackContext,
   NavigationScreenProps,
+  VisualInboxScreenName,
 } from '@navigation';
 import { Storage } from '@services';
 import { CioPushPermissionStatus } from 'customerio-reactnative';
@@ -75,6 +76,12 @@ export const HomeScreen = ({
             title="Inbox Messages"
             onPress={() => {
               navigation.navigate(InboxMessagesScreenName);
+            }}
+          />
+          <Button
+            title="Visual Inbox (UI)"
+            onPress={() => {
+              navigation.navigate(VisualInboxScreenName);
             }}
           />
           <Button

--- a/example/src/screens/index.ts
+++ b/example/src/screens/index.ts
@@ -8,3 +8,4 @@ export * from './location';
 export * from './login';
 export * from './settings';
 export * from './track';
+export * from './visual-inbox';

--- a/example/src/screens/visual-inbox.tsx
+++ b/example/src/screens/visual-inbox.tsx
@@ -1,0 +1,136 @@
+import { NavigationScreenProps } from '@navigation';
+import {
+  CustomerIO,
+  InboxEventType,
+  NotificationInboxBellView,
+  NotificationInboxView,
+} from 'customerio-reactnative';
+import React, { useEffect } from 'react';
+import { Linking, StyleSheet, Text, View } from 'react-native';
+import { showMessage } from 'react-native-flash-message';
+
+/**
+ * Demonstrates the two native Visual Notification Inbox UI components exposed by the SDK:
+ *
+ * 1. NotificationInboxBellView — the branded bell; tapping it opens the SDK's own inbox panel.
+ * 2. NotificationInboxView     — the Jist-rendered message list, placed by this screen.
+ *
+ * The host places both wherever it likes; the SDK owns the panel and all rendering.
+ *
+ * Message actions are handled by the global InboxEventListener (configured elsewhere), so these
+ * components take no per-message action callbacks.
+ */
+export const VisualInboxScreen = ({}: NavigationScreenProps<'Visual Inbox'>) => {
+
+  // Register a global inbox event listener while this screen is mounted.
+  // While registered, the host (this app) owns action navigation: the native
+  // SDK forwards taps here and suppresses its default handling.
+  useEffect(() => {
+    const subscription = CustomerIO.inAppMessaging.registerInboxEventListener(
+      (event) => {
+        switch (event.eventType) {
+          case InboxEventType.messageActionTaken:
+            showMessage({
+              message: `Inbox action taken: ${event.actionName ?? ''} -> ${
+                event.actionValue ?? ''
+              }`,
+              type: 'success',
+            });
+            // While a listener is registered the SDK suppresses its own deep-link handling and
+            // treats the action as host-handled, so nothing navigates unless the host does it.
+            // Hand the value to the OS exactly as the SDK would: our own scheme round-trips back
+            // through the NavigationContainer `linking` config, anything else opens externally.
+            if (event.actionValue) {
+              Linking.openURL(event.actionValue).catch((error) => {
+                showMessage({
+                  message: `Could not open ${event.actionValue}`,
+                  type: 'danger',
+                });
+                // eslint-disable-next-line no-console
+                console.warn('Failed to open inbox action deep link', error);
+              });
+            }
+            break;
+          case InboxEventType.messageShown:
+            showMessage({ message: 'Inbox message shown', type: 'info' });
+            break;
+          case InboxEventType.messageOpened:
+            showMessage({ message: 'Inbox message opened', type: 'info' });
+            break;
+          case InboxEventType.messageDismissed:
+            showMessage({ message: 'Inbox message dismissed', type: 'info' });
+            break;
+        }
+        // eslint-disable-next-line no-console
+        console.log('Inbox event received', event.eventType, event.message);
+      }
+    );
+
+    return () => {
+      subscription.remove();
+    };
+  }, []);
+
+  return (
+    <View style={styles.root}>
+      {/*
+        Deliberately NOT a ScrollView. NotificationInboxView scrolls its own message list, and a parent
+        ScrollView intercepts the vertical drag before the native list sees it. These components are
+        meant to own their screen (or a fixed region of one), not to sit in a scrolling page.
+      */}
+      <View style={styles.content}>
+        {/* 1. Branded bell — tapping it opens the SDK's inbox panel. Host owns placement. */}
+        <View style={styles.bellRow}>
+          <Text style={styles.sectionTitle}>NotificationInboxBellView</Text>
+          <NotificationInboxBellView
+            style={styles.bell}
+            onTap={() => {
+              // Observational only: the SDK is already opening its panel.
+              showMessage({ message: 'Bell tapped', type: 'info' });
+            }}
+          />
+        </View>
+        <Text style={styles.sectionBody}>
+          Tapping the bell opens the SDK's inbox panel — this screen presents nothing.
+        </Text>
+
+        {/* 2. The message list, placed inline by this screen. */}
+        <Text style={styles.sectionTitle}>NotificationInboxView</Text>
+        <Text style={styles.sectionBody}>
+          The Jist-rendered message list, filling the rest of the screen.
+        </Text>
+        <View style={styles.embeddedList}>
+          <NotificationInboxView style={styles.fill} />
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: '#f5f5f5' },
+  content: { flex: 1, padding: 16, gap: 8 },
+  fill: { flex: 1 },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: '#333',
+    marginTop: 12,
+  },
+  sectionBody: { fontSize: 13, color: '#666', marginBottom: 4 },
+  bellRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 8,
+  },
+  // 88 not 56: the native composition insets the 56dp bell by 16 on each side, so a
+  // 56-square box squeezes the circle down onto the glyph.
+  bell: { width: 88, height: 88 },
+  embeddedList: {
+    flex: 1,
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+});

--- a/ios/wrappers/inapp/NativeMessagingInApp.mm
+++ b/ios/wrappers/inapp/NativeMessagingInApp.mm
@@ -71,6 +71,16 @@ RCT_EXPORT_MODULE()
   [_swiftBridge setupInboxListener];
 }
 
+- (void)registerInboxEventListener {
+  [self assertBridgeAvailable:@"during registerInboxEventListener"];
+  [_swiftBridge registerInboxEventListener];
+}
+
+- (void)unregisterInboxEventListener {
+  [self assertBridgeAvailable:@"during unregisterInboxEventListener"];
+  [_swiftBridge unregisterInboxEventListener];
+}
+
 - (void)getMessages:(NSString *)topic
             resolve:(RCTPromiseResolveBlock)resolve
              reject:(RCTPromiseRejectBlock)reject {
@@ -108,6 +118,10 @@ RCT_EXPORT_MODULE()
 
 - (void)emitOnInAppEventReceived:(NSDictionary *)value {
   [super emitOnInAppEventReceived:value];
+}
+
+- (void)emitOnInboxEventReceived:(NSDictionary *)value {
+  [super emitOnInboxEventReceived:value];
 }
 
 - (void)emitSubscribeToMessagesChanged:(NSDictionary *)value {

--- a/ios/wrappers/inapp/NativeMessagingInApp.swift
+++ b/ios/wrappers/inapp/NativeMessagingInApp.swift
@@ -50,6 +50,48 @@ public class NativeMessagingInApp: NSObject {
         // Clear in-app event listener to prevent leaks
         clearInAppEventListener()
         clearInboxChangeListener()
+        clearInboxEventListener()
+    }
+
+    // MARK: - Inbox Event Listener
+
+    /// Registers the native inbox event forwarder with the SDK and wires it to the ObjC event
+    /// emitter. Called by React Native when a JS inbox event listener is registered.
+    @objc(registerInboxEventListener)
+    public func registerInboxEventListener() {
+        ReactInboxEventListener.shared.setEventEmitter { [weak self] data in
+            guard let self else { return }
+            // Filter out nil values to convert [String: Any?] to [String: Any]
+            let body = data.compactMapValues { $0 }
+            self.sendInboxEvent(body: body)
+        }
+        MessagingInApp.shared.setInboxEventListener(ReactInboxEventListener.shared)
+    }
+
+    /// Unregisters the native inbox event forwarder from the SDK, restoring the SDK's default action
+    /// handling. Called by React Native when the JS inbox event listener is removed.
+    @objc(unregisterInboxEventListener)
+    public func unregisterInboxEventListener() {
+        MessagingInApp.shared.setInboxEventListener(nil)
+        ReactInboxEventListener.shared.clearEventEmitter()
+    }
+
+    private func clearInboxEventListener() {
+        MessagingInApp.shared.setInboxEventListener(nil)
+        ReactInboxEventListener.shared.clearEventEmitter()
+    }
+
+    // Send inbox event to React Native layer using ObjC event emitter
+    private func sendInboxEvent(body: [String: Any]) {
+        guard let emitter = objcEventEmitter else {
+            return
+        }
+
+        let selector = Selector(("emitOnInboxEventReceived:"))
+        guard emitter.responds(to: selector) else {
+            return
+        }
+        _ = emitter.perform(selector, with: body as NSDictionary)
     }
 
     /// Dismisses any currently displayed in-app message

--- a/ios/wrappers/inbox/InboxHostContainment.swift
+++ b/ios/wrappers/inbox/InboxHostContainment.swift
@@ -1,0 +1,40 @@
+import Foundation
+import UIKit
+
+/// Shared view-controller containment for the inbox `UIHostingController` hosts.
+///
+/// Adopting only a hosting controller's `view` leaves the controller outside the view-controller
+/// hierarchy. UIKit then has no presentation context or trait/safe-area chain for it, which showed up
+/// as a phantom top margin in the overlay's sheet (the sheet content resolved insets against the
+/// wrong container) and means no lifecycle callbacks ever reach the hosted SwiftUI. Native usage does
+/// not hit this because there the hosting controller *is* a real pushed view controller.
+///
+/// Containment has to be deferred until the Fabric view is actually in a window: React Native creates
+/// component views before mounting them, so at `init` there is no parent controller to attach to.
+enum InboxHostContainment {
+    /// Nearest view controller up the responder chain, or nil while the view is unmounted.
+    static func nearestViewController(from view: UIView?) -> UIViewController? {
+        var responder: UIResponder? = view
+        while let current = responder {
+            if let viewController = current as? UIViewController {
+                return viewController
+            }
+            responder = current.next
+        }
+        return nil
+    }
+
+    /// Attaches `child` to the controller owning `view`. No-op when already attached or unmounted.
+    static func attach(_ child: UIViewController, hostedIn view: UIView?) {
+        guard child.parent == nil, let parent = nearestViewController(from: view) else { return }
+        parent.addChild(child)
+        child.didMove(toParent: parent)
+    }
+
+    /// Detaches `child` from its parent. No-op when it was never attached.
+    static func detach(_ child: UIViewController) {
+        guard child.parent != nil else { return }
+        child.willMove(toParent: nil)
+        child.removeFromParent()
+    }
+}

--- a/ios/wrappers/inbox/RCTNotificationInboxBellNative.h
+++ b/ios/wrappers/inbox/RCTNotificationInboxBellNative.h
@@ -1,0 +1,12 @@
+// See RCTInlineMessageNative.h for why this RCTViewComponentView import is guarded by __cplusplus.
+#ifdef __cplusplus
+#import <React/RCTViewComponentView.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTNotificationInboxBellNative : RCTViewComponentView
+@end
+
+NS_ASSUME_NONNULL_END
+#endif

--- a/ios/wrappers/inbox/RCTNotificationInboxBellNative.mm
+++ b/ios/wrappers/inbox/RCTNotificationInboxBellNative.mm
@@ -1,0 +1,98 @@
+#import "RCTNotificationInboxBellNative.h"
+#import "ReactNotificationInboxBellView.h"
+
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/RNCustomerIOSpec/ComponentDescriptors.h>
+#import <react/renderer/components/RNCustomerIOSpec/EventEmitters.h>
+#import <react/renderer/components/RNCustomerIOSpec/Props.h>
+#import <react/renderer/components/RNCustomerIOSpec/RCTComponentViewHelpers.h>
+#import <react/renderer/components/RNCustomerIOSpec/ShadowNodes.h>
+
+using namespace facebook::react;
+
+/// New-architecture React Native view hosting the SwiftUI NotificationInboxBell.
+@interface RCTNotificationInboxBellNative () <RCTNotificationInboxBellNativeViewProtocol>
+@property(nonatomic, strong) id bridge;
+@end
+
+@implementation RCTNotificationInboxBellNative
+
+- (void)assertBridgeAvailable:(NSString *)context {
+  NSAssert(self.bridge != nil, @"Bridge is nil when %@", context);
+}
+
+- (instancetype)init {
+  return [self initWithFrame:CGRectZero];
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  if (self = [super initWithFrame:frame]) {
+    _props = NotificationInboxBellNativeShadowNode::defaultSharedProps();
+
+    // The Swift bridge is @available(iOS 16.0, *) because the bell opens the SDK's inbox sheet, which
+    // uses system detents. Below iOS 16 the class exists but must not be instantiated, so the view
+    // stays empty rather than crashing — every method below therefore tolerates a nil bridge.
+    if (@available(iOS 16.0, *)) {
+      Class bridgeClass = NSClassFromString(@"ReactNotificationInboxBellView");
+      if (bridgeClass) {
+        self.bridge = [[bridgeClass alloc] initWithContainerView:self];
+        [self assertBridgeAvailable:@"creating ReactNotificationInboxBellView bridge instance"];
+        [self.bridge setEventEmitter:self];
+      }
+    }
+  }
+  return self;
+}
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  if (self.bridge == nil) {
+    return;
+  }
+  [self.bridge updateLayout:[NSValue valueWithCGRect:self.bounds]];
+}
+
+// Containment can only happen once the view is in a window: React Native creates component views
+// before mounting them, so at init there is no parent view controller to attach the host to.
+- (void)didMoveToWindow {
+  [super didMoveToWindow];
+  if (self.bridge == nil) {
+    return;
+  }
+  if (self.window != nil) {
+    [self.bridge attachToParentViewController];
+  } else {
+    [self.bridge detachFromParentViewController];
+  }
+}
+
+- (void)prepareForRecycle {
+  [super prepareForRecycle];
+  if (self.bridge == nil) {
+    return;
+  }
+  [self.bridge prepareForRecycle];
+}
+
+- (void)emitOnTapEvent:(NSDictionary *)event {
+  if (_eventEmitter) {
+    NotificationInboxBellNativeEventEmitter::OnTap result =
+        NotificationInboxBellNativeEventEmitter::OnTap{};
+    self.eventEmitter.onTap(result);
+  }
+}
+
+- (const NotificationInboxBellNativeEventEmitter &)eventEmitter {
+  return static_cast<const NotificationInboxBellNativeEventEmitter &>(*_eventEmitter);
+}
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<NotificationInboxBellNativeComponentDescriptor>();
+}
+
+@end
+
+Class<RCTComponentViewProtocol> NotificationInboxBellNativeCls(void) {
+  return RCTNotificationInboxBellNative.class;
+}

--- a/ios/wrappers/inbox/RCTNotificationInboxViewNative.h
+++ b/ios/wrappers/inbox/RCTNotificationInboxViewNative.h
@@ -1,0 +1,12 @@
+// See RCTInlineMessageNative.h for why this RCTViewComponentView import is guarded by __cplusplus.
+#ifdef __cplusplus
+#import <React/RCTViewComponentView.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTNotificationInboxViewNative : RCTViewComponentView
+@end
+
+NS_ASSUME_NONNULL_END
+#endif

--- a/ios/wrappers/inbox/RCTNotificationInboxViewNative.mm
+++ b/ios/wrappers/inbox/RCTNotificationInboxViewNative.mm
@@ -1,0 +1,78 @@
+#import "RCTNotificationInboxViewNative.h"
+#import "ReactNotificationInboxView.h"
+
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/RNCustomerIOSpec/ComponentDescriptors.h>
+#import <react/renderer/components/RNCustomerIOSpec/EventEmitters.h>
+#import <react/renderer/components/RNCustomerIOSpec/Props.h>
+#import <react/renderer/components/RNCustomerIOSpec/RCTComponentViewHelpers.h>
+#import <react/renderer/components/RNCustomerIOSpec/ShadowNodes.h>
+
+using namespace facebook::react;
+
+/// New-architecture React Native view hosting the SwiftUI NotificationInboxView (message list).
+/// This view emits no events; message actions flow through the existing global InboxEventListener.
+@interface RCTNotificationInboxViewNative () <RCTNotificationInboxViewNativeViewProtocol>
+@property(nonatomic, strong) id bridge;
+@end
+
+@implementation RCTNotificationInboxViewNative
+
+- (void)assertBridgeAvailable:(NSString *)context {
+  NSAssert(self.bridge != nil, @"Bridge is nil when %@", context);
+}
+
+- (instancetype)init {
+  return [self initWithFrame:CGRectZero];
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  if (self = [super initWithFrame:frame]) {
+    _props = NotificationInboxViewNativeShadowNode::defaultSharedProps();
+
+    Class bridgeClass = NSClassFromString(@"ReactNotificationInboxView");
+    if (bridgeClass) {
+      self.bridge = [[bridgeClass alloc] initWithContainerView:self];
+      [self assertBridgeAvailable:@"creating ReactNotificationInboxView bridge instance"];
+      [self.bridge setEventEmitter:self];
+    }
+  }
+  return self;
+}
+
+- (void)layoutSubviews {
+  [super layoutSubviews];
+  [self assertBridgeAvailable:@"during layoutSubviews"];
+  [self.bridge updateLayout:[NSValue valueWithCGRect:self.bounds]];
+}
+
+// Containment can only happen once the view is in a window: React Native creates component views
+// before mounting them, so at init there is no parent view controller to attach the host to. The list
+// presents nothing, but containment is what gives the hosted SwiftUI a correct trait/safe-area chain
+// and lifecycle callbacks.
+- (void)didMoveToWindow {
+  [super didMoveToWindow];
+  [self assertBridgeAvailable:@"during didMoveToWindow"];
+  if (self.window != nil) {
+    [self.bridge attachToParentViewController];
+  } else {
+    [self.bridge detachFromParentViewController];
+  }
+}
+
+- (void)prepareForRecycle {
+  [super prepareForRecycle];
+  [self assertBridgeAvailable:@"during prepareForRecycle"];
+  [self.bridge prepareForRecycle];
+}
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<NotificationInboxViewNativeComponentDescriptor>();
+}
+
+@end
+
+Class<RCTComponentViewProtocol> NotificationInboxViewNativeCls(void) {
+  return RCTNotificationInboxViewNative.class;
+}

--- a/ios/wrappers/inbox/ReactInboxEventListener.swift
+++ b/ios/wrappers/inbox/ReactInboxEventListener.swift
@@ -1,0 +1,76 @@
+import CioInternalCommon
+import CioMessagingInApp
+
+/**
+ * React Native bridge for Customer.io Visual Notification Inbox events.
+ *
+ * Registered on the SDK (via `MessagingInApp.shared.setInboxEventListener`) only while a JS listener
+ * is registered. Because the New-Arch event emitter is one-way we cannot round-trip a bool back from
+ * JS, so `messageActionTaken` forwards the event fire-and-forget and RETURNS `true` — telling the SDK
+ * the host handled the action so the SDK suppresses its default navigation. The JS host owns action
+ * handling while a listener is registered. Observational callbacks forward fire-and-forget.
+ */
+public class ReactInboxEventListener: InboxEventListener {
+    // Shared instance for global access
+    public static let shared = ReactInboxEventListener()
+
+    private init() {}
+
+    // Event emitter function to send events to React Native layer
+    private var eventEmitter: (([String: Any?]) -> Void)?
+
+    // Sets the event emitter function
+    func setEventEmitter(_ emitter: (([String: Any?]) -> Void)?) {
+        eventEmitter = emitter
+    }
+
+    // Clears the event emitter to prevent memory leaks
+    func clearEventEmitter() {
+        eventEmitter = nil
+    }
+
+    // Emits an inbox message event to React Native with a serialized message payload
+    private func emitInboxEvent(
+        eventType: String,
+        message: InboxMessage,
+        actionName: String? = nil,
+        actionValue: String? = nil
+    ) {
+        var data: [String: Any?] = [
+            CustomerioConstants.eventType: eventType,
+            CustomerioConstants.inboxMessage: message.toDictionary()
+        ]
+
+        if let actionName = actionName {
+            data[CustomerioConstants.actionName] = actionName
+        }
+        if let actionValue = actionValue {
+            data[CustomerioConstants.actionValue] = actionValue
+        }
+
+        eventEmitter?(data)
+    }
+
+    public func messageActionTaken(message: InboxMessage, actionName: String, actionValue: String) -> Bool {
+        emitInboxEvent(
+            eventType: CustomerioConstants.messageActionTaken,
+            message: message,
+            actionName: actionName,
+            actionValue: actionValue
+        )
+        // Host (React Native) owns action handling while a listener is registered.
+        return true
+    }
+
+    public func messageShown(message: InboxMessage) {
+        emitInboxEvent(eventType: CustomerioConstants.messageShown, message: message)
+    }
+
+    public func messageOpened(message: InboxMessage) {
+        emitInboxEvent(eventType: CustomerioConstants.messageOpened, message: message)
+    }
+
+    public func messageDismissed(message: InboxMessage) {
+        emitInboxEvent(eventType: CustomerioConstants.messageDismissed, message: message)
+    }
+}

--- a/ios/wrappers/inbox/ReactNotificationInboxBellView.h
+++ b/ios/wrappers/inbox/ReactNotificationInboxBellView.h
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+
+@class UIView;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Objective-C forward declaration for the Swift `ReactNotificationInboxBellView` class.
+ * See `ReactNotificationInboxOverlayView.h` for the rationale behind runtime resolution.
+ */
+@interface ReactNotificationInboxBellView : NSObject
+
+- (instancetype)initWithContainerView:(UIView *)containerView;
+- (void)setEventEmitter:(id)eventEmitter;
+- (void)updateLayout:(NSValue *)boundsValue;
+- (void)attachToParentViewController;
+- (void)detachFromParentViewController;
+- (void)prepareForRecycle;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/wrappers/inbox/ReactNotificationInboxBellView.swift
+++ b/ios/wrappers/inbox/ReactNotificationInboxBellView.swift
@@ -1,0 +1,109 @@
+import CioMessagingInbox
+import Foundation
+import SwiftUI
+import UIKit
+
+/// React Native wrapper hosting the SwiftUI `NotificationInboxOverlay` inside a `UIHostingController`.
+///
+/// Despite the name, the hosted composition is the overlay rather than the bare `NotificationInboxBell`:
+/// only the overlay ties the bell to the SDK's own inbox sheet, and the wrapper deliberately does not
+/// reimplement panel presentation. Sized to the frame React Native assigns, that composition *is* a bell
+/// that opens the inbox — the component wrappers expose.
+///
+/// Remote branding still styles the bell (colors, icon). Branding's bell *position* has no effect here:
+/// alignment resolves inside this view's frame, so the host owns placement via `style`.
+///
+/// iOS 16+ because the panel is a sheet with system detents.
+@available(iOS 16.0, *)
+@objc(ReactNotificationInboxBellView)
+class ReactNotificationInboxBellView: NSObject {
+    private weak var eventEmitter: AnyObject?
+    private weak var containerView: UIView?
+    private let hostingController: UIHostingController<NotificationInboxOverlay>
+
+    @objc
+    init(containerView: UIView) {
+        self.containerView = containerView
+        self.hostingController = UIHostingController(rootView: NotificationInboxOverlay())
+        super.init()
+
+        let hostedView = hostingController.view!
+        hostedView.backgroundColor = .clear
+        hostedView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(hostedView)
+        NSLayoutConstraint.activate([
+            hostedView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            hostedView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+            hostedView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            hostedView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
+        ])
+
+        // Observational tap reporting. The SDK owns presentation, so this recognizer must not consume
+        // the touch: `cancelsTouchesInView = false` lets SwiftUI still receive it and open the sheet.
+        // It reports any tap inside this view's frame, which is the bell when the view is sized to it.
+        let tapObserver = UITapGestureRecognizer(target: self, action: #selector(handleObservedTap))
+        tapObserver.cancelsTouchesInView = false
+        tapObserver.delaysTouchesEnded = false
+        containerView.addGestureRecognizer(tapObserver)
+    }
+
+    @objc
+    func setEventEmitter(_ eventEmitter: AnyObject?) {
+        self.eventEmitter = eventEmitter
+    }
+
+    /// Adds the hosting controller to the view-controller hierarchy once the view is in a window.
+    ///
+    /// Without this the controller is orphaned, and the sheet it presents resolves its safe-area insets
+    /// against the wrong container — which showed up as a phantom top margin when dragging the sheet.
+    @objc
+    func attachToParentViewController() {
+        InboxHostContainment.attach(hostingController, hostedIn: containerView)
+    }
+
+    @objc
+    func detachFromParentViewController() {
+        InboxHostContainment.detach(hostingController)
+    }
+
+    @objc
+    func updateLayout(_ boundsValue: NSValue) {
+        hostingController.view.frame = boundsValue.cgRectValue
+        hostingController.view.setNeedsLayout()
+        hostingController.view.layoutIfNeeded()
+    }
+
+    @objc
+    func prepareForRecycle() {
+        // Deliberately does NOT remove the hosted view from its container.
+        //
+        // Fabric recycles the component view, and detaching the SwiftUI view here with nothing to
+        // re-attach it made a reused view come back blank. `ReactInlineMessageView` does not touch the
+        // hierarchy either. Containment is released here because a recycled view is leaving its parent.
+        detachFromParentViewController()
+    }
+
+    // MARK: - Event Emission
+
+    @objc
+    private func handleObservedTap() {
+        emitEvent("emitOnTapEvent:", payload: [:])
+    }
+
+    /// Mirrors `ReactInlineMessageView.emitEvent`: asserts rather than returning silently, so a
+    /// mis-wired emitter surfaces in debug instead of the tap simply never reaching JS.
+    private func emitEvent(_ selectorName: String, payload: [String: Any?]) {
+        guard let emitter = eventEmitter else {
+            assertionFailure("Event emitter is nil when trying to emit \(selectorName)")
+            return
+        }
+
+        let selector = Selector((selectorName))
+        guard emitter.responds(to: selector) else {
+            assertionFailure("Event emitter does not respond to selector: \(selectorName)")
+            return
+        }
+
+        _ = emitter.perform(selector, with: payload as NSDictionary)
+    }
+}

--- a/ios/wrappers/inbox/ReactNotificationInboxView.h
+++ b/ios/wrappers/inbox/ReactNotificationInboxView.h
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+
+@class UIView;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Objective-C forward declaration for the Swift `ReactNotificationInboxView` class.
+ * See `ReactNotificationInboxOverlayView.h` for the rationale behind runtime resolution.
+ */
+@interface ReactNotificationInboxView : NSObject
+
+- (instancetype)initWithContainerView:(UIView *)containerView;
+- (void)setEventEmitter:(id)eventEmitter;
+- (void)updateLayout:(NSValue *)boundsValue;
+- (void)attachToParentViewController;
+- (void)detachFromParentViewController;
+- (void)prepareForRecycle;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/wrappers/inbox/ReactNotificationInboxView.swift
+++ b/ios/wrappers/inbox/ReactNotificationInboxView.swift
@@ -1,0 +1,69 @@
+import CioMessagingInbox
+import Foundation
+import SwiftUI
+import UIKit
+
+/// React Native wrapper hosting the SwiftUI `NotificationInboxView` (the Jist-rendered message
+/// list) inside a `UIHostingController`. No events; sizing is driven by the JS `style` prop.
+/// Message actions are handled by the existing global InboxEventListener.
+/// No `@available` annotation, matching `ReactInlineMessageView`: the native list view is iOS 13+,
+/// so the pod's own floor (`min_ios_version_supported`) governs.
+@objc(ReactNotificationInboxView)
+class ReactNotificationInboxView: NSObject {
+    private weak var containerView: UIView?
+    private let hostingController: UIHostingController<NotificationInboxView>
+
+    @objc
+    init(containerView: UIView) {
+        self.containerView = containerView
+        self.hostingController = UIHostingController(rootView: NotificationInboxView())
+        super.init()
+
+        let hostedView = hostingController.view!
+        hostedView.backgroundColor = .clear
+        hostedView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(hostedView)
+        NSLayoutConstraint.activate([
+            hostedView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            hostedView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+            hostedView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            hostedView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
+        ])
+    }
+
+    // Accepts the emitter for API symmetry with the other inbox views; this view emits no events.
+    @objc
+    func setEventEmitter(_ eventEmitter: AnyObject?) {}
+
+    /// Adds the hosting controller to the view-controller hierarchy once the view is in a window, so the
+    /// hosted SwiftUI gets a correct trait/safe-area chain and lifecycle callbacks instead of being
+    /// driven by an orphaned controller.
+    @objc
+    func attachToParentViewController() {
+        InboxHostContainment.attach(hostingController, hostedIn: containerView)
+    }
+
+    @objc
+    func detachFromParentViewController() {
+        InboxHostContainment.detach(hostingController)
+    }
+
+    @objc
+    func updateLayout(_ boundsValue: NSValue) {
+        hostingController.view.frame = boundsValue.cgRectValue
+        hostingController.view.setNeedsLayout()
+        hostingController.view.layoutIfNeeded()
+    }
+
+    @objc
+    func prepareForRecycle() {
+        detachFromParentViewController()
+        // Deliberately does NOT remove the hosted view from its container.
+        //
+        // Fabric recycles the component view, and the previous version detached the SwiftUI view here
+        // with nothing to re-attach it, so a reused view came back blank. `ReactInlineMessageView`
+        // does not touch the hierarchy either — it detaches observers (`onViewDetached`) and
+        // re-attaches in `setupForReuse`. These hosts have no props and no observers to reset, so
+        // there is nothing to undo: the hosted view stays mounted and is reused as-is.
+    }
+}

--- a/ios/wrappers/utils/CioConstants.swift
+++ b/ios/wrappers/utils/CioConstants.swift
@@ -11,6 +11,10 @@ enum CustomerioConstants {
     static let errorWithMessage = "errorWithMessage"
     static let messageActionTaken = "messageActionTaken"
 
+    // Notification Inbox event listener
+    static let messageOpened = "messageOpened"
+    static let inboxMessage = "message"
+
     // Push Messaging
     static let CioDeliveryId = "CIO-Delivery-ID"
     static let CioDeliveryToken = "CIO-Delivery-Token"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/__tests__/**/*.test.ts'],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-reactnative",
-  "version": "6.4.2",
+  "version": "6.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-reactnative",
-      "version": "6.4.2",
+      "version": "6.5.2",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
@@ -23,6 +23,7 @@
         "@types/react": "^19.2.0",
         "@typescript-eslint/eslint-plugin": "^8.31.1",
         "@typescript-eslint/parser": "^8.31.1",
+        "babel-jest": "^29.7.0",
         "eslint": "9.25.1",
         "eslint-config-prettier": "10.1.2",
         "eslint-plugin-ft-flow": "^3.0.11",
@@ -30,6 +31,7 @@
         "eslint-plugin-prettier": "^5.2.6",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-native": "^5.0.0",
+        "jest": "^29.7.0",
         "prettier": "^3.5.3",
         "react": "19.2.0",
         "react-native": "^0.83.0",
@@ -2189,6 +2191,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@commitlint/config-conventional": {
       "version": "19.8.1",
       "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.8.1.tgz",
@@ -2716,6 +2725,177 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/console/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/console/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/console/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/create-cache-key-function": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
@@ -2745,6 +2925,33 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jest/fake-timers": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
@@ -2763,6 +2970,142 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -2771,6 +3114,53 @@
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4602,6 +4992,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-fragments": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/ansi-fragments/-/ansi-fragments-0.2.1.tgz",
@@ -5404,6 +5823,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chrome-launcher": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
@@ -5480,6 +5909,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -5553,6 +5989,24 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -5767,6 +6221,74 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cross-spawn": {
@@ -5997,6 +6519,16 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/diff": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -6005,6 +6537,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -6081,6 +6623,19 @@
       "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -6921,6 +7476,32 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
@@ -7693,6 +8274,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -7837,6 +8425,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -8109,6 +8717,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/is-generator-function": {
@@ -8630,6 +9248,63 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -8662,6 +9337,451 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-circus/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-environment-node": {
@@ -8716,6 +9836,82 @@
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-message-util": {
@@ -8800,6 +9996,24 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
@@ -8808,6 +10022,335 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-util": {
@@ -8939,6 +10482,72 @@
       }
     },
     "node_modules/jest-validate/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -9491,6 +11100,22 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/makeerror": {
@@ -10756,6 +12381,75 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -10883,6 +12577,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.1",
@@ -11489,6 +13200,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -11497,6 +13231,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/restore-cursor": {
@@ -12145,6 +13889,33 @@
         "node": ">=0.6.19"
       }
     },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string-natural-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-3.0.1.tgz",
@@ -12362,6 +14133,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-final-newline": {
@@ -12921,6 +14702,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 4.5.3",
+  "cioNativeiOSSdkVersion": "= 4.6.1",
   "cioiOSFirebaseWrapperSdkVersion": "= 1.0.0",
   "files": [
     "src",
@@ -44,6 +44,7 @@
     "pre-deploy": "npm run typescript",
     "typecheck": "tsc",
     "typescript": "tsc --noEmit",
+    "test": "jest",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "lint:report": "npm run lint -- --output-file eslint_report.json --format json",
     "prepare": "bob build",
@@ -79,6 +80,7 @@
     "@types/react": "^19.2.0",
     "@typescript-eslint/eslint-plugin": "^8.31.1",
     "@typescript-eslint/parser": "^8.31.1",
+    "babel-jest": "^29.7.0",
     "eslint": "9.25.1",
     "eslint-config-prettier": "10.1.2",
     "eslint-plugin-ft-flow": "^3.0.11",
@@ -86,6 +88,7 @@
     "eslint-plugin-prettier": "^5.2.6",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-native": "^5.0.0",
+    "jest": "^29.7.0",
     "prettier": "^3.5.3",
     "react": "19.2.0",
     "react-native": "^0.83.0",
@@ -149,7 +152,9 @@
     },
     "ios": {
       "componentProvider": {
-        "InlineMessageNative": "RCTInlineMessageNative"
+        "InlineMessageNative": "RCTInlineMessageNative",
+          "NotificationInboxBellNative": "RCTNotificationInboxBellNative",
+        "NotificationInboxViewNative": "RCTNotificationInboxViewNative"
       },
       "modulesProvider": {
         "NativeCustomerIOLogging": "RCTNativeCustomerIOLogging",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 4.6.1",
+  "cioNativeiOSSdkVersion": "= 4.7.0",
   "cioiOSFirebaseWrapperSdkVersion": "= 1.0.0",
   "files": [
     "src",

--- a/src/components/NotificationInboxBellView.tsx
+++ b/src/components/NotificationInboxBellView.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import NotificationInboxBellNativeComponent, {
+  type NativeProps,
+} from '../specs/components/NotificationInboxBellNativeComponent';
+
+/**
+ * Props for the {@link NotificationInboxBellView} component.
+ */
+/** @public */
+export interface NotificationInboxBellViewProps extends Omit<
+  NativeProps,
+  'onTap'
+> {
+  /**
+   * Called when the user taps the bell.
+   *
+   * Observational only — the SDK opens the inbox itself, so there is nothing the
+   * host has to do in response. Reports any tap inside this view's frame, which
+   * is the bell when the view is sized to it as recommended.
+   */
+  onTap?: () => void;
+}
+
+/**
+ * The Visual Notification Inbox bell (with unread badge). Tapping it opens the
+ * SDK's own inbox panel — the host presents nothing.
+ *
+ * Place it wherever the app's layout calls for it. Remote branding still styles
+ * the bell itself (colors, icon), but branding's *position* is not applied: the
+ * host owns placement via `style`. The bell renders nothing when the inbox has
+ * nothing to show, so give it a fixed size for predictable layout — at least 88
+ * points/dp square, since the native composition insets the 56pt bell by 16 on
+ * each side and a smaller box squeezes the circle onto the glyph.
+ *
+ * @example
+ * ```tsx
+ * <NotificationInboxBellView
+ *   style={{ width: 88, height: 88 }}
+ *   onTap={() => analytics.track('inbox_bell_tapped')}
+ * />
+ * ```
+ */
+/** @public */
+const NotificationInboxBellView: React.FC<NotificationInboxBellViewProps> = ({
+  onTap,
+  ...props
+}) => {
+  const handleTap = () => {
+    onTap?.();
+  };
+
+  return <NotificationInboxBellNativeComponent {...props} onTap={handleTap} />;
+};
+
+export default NotificationInboxBellView;

--- a/src/components/NotificationInboxView.tsx
+++ b/src/components/NotificationInboxView.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import NotificationInboxViewNativeComponent, {
+  type NativeProps,
+} from '../specs/components/NotificationInboxViewNativeComponent';
+
+/**
+ * Props for the {@link NotificationInboxView} component.
+ */
+/** @public */
+export interface NotificationInboxViewProps extends NativeProps {}
+
+/**
+ * The Visual Notification Inbox message list — the Jist-rendered messages —
+ * embeddable directly in your own screen. It fills the area you give it via
+ * `style` and brings no surrounding chrome (no bell, no scrim).
+ *
+ * Message actions are handled by the existing global InboxEventListener, so this
+ * component takes no per-message action callback.
+ *
+ * @example
+ * ```tsx
+ * <NotificationInboxView style={{ flex: 1 }} />
+ * ```
+ */
+/** @public */
+const NotificationInboxView: React.FC<NotificationInboxViewProps> = (props) => {
+  return <NotificationInboxViewNativeComponent {...props} />;
+};
+
+export default NotificationInboxView;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,9 @@
 // Export all components and types from the components directory for simplified imports
 export type { InlineInAppMessageViewProps } from './InlineInAppMessageView';
 export { default as InlineInAppMessageView } from './InlineInAppMessageView';
+
+// Visual Notification Inbox UI components
+export type { NotificationInboxBellViewProps } from './NotificationInboxBellView';
+export { default as NotificationInboxBellView } from './NotificationInboxBellView';
+export type { NotificationInboxViewProps } from './NotificationInboxView';
+export { default as NotificationInboxView } from './NotificationInboxView';

--- a/src/customerio-inapp.ts
+++ b/src/customerio-inapp.ts
@@ -3,12 +3,14 @@ import { InlineInAppMessageView } from './components';
 import { NativeLoggerListener } from './native-logger-listener';
 import {
   NotificationInbox,
+  parseInboxMessage,
   type NotificationInboxSpec,
 } from './notification-inbox';
 import NativeCustomerIOMessagingInApp, {
   type Spec as CodegenSpec,
 } from './specs/modules/NativeCustomerIOMessagingInApp';
 import type { InAppMessageEventType } from './types';
+import { InboxEventType, InboxMessageEvent } from './types';
 import { callNativeModule, ensureNativeModule } from './utils/native-bridge';
 
 /**
@@ -18,7 +20,12 @@ import { callNativeModule, ensureNativeModule } from './utils/native-bridge';
  */
 interface NativeInAppSpec extends Omit<
   CodegenSpec,
-  keyof TurboModule | NotificationInboxSpec | 'onInAppEventReceived'
+  | keyof TurboModule
+  | NotificationInboxSpec
+  | 'onInAppEventReceived'
+  | 'registerInboxEventListener'
+  | 'unregisterInboxEventListener'
+  | 'onInboxEventReceived'
 > {}
 
 // Reference to the native CustomerIO Data Pipelines module for SDK operations
@@ -36,6 +43,13 @@ const withNativeModule = <R>(fn: (native: CodegenSpec) => R): R => {
  */
 class CustomerIOInAppMessaging implements NativeInAppSpec {
   private _notificationInbox?: NotificationInbox;
+
+  /**
+   * Live inbox subscriptions. The SDK's inbox forwarder is a SINGLE global listener, so it is
+   * registered when the first subscription is created and unregistered when the last one goes away —
+   * never per subscription, or one `remove()` would tear it out from under the others.
+   */
+  private _inboxListenerCount = 0;
 
   registerEventsListener(
     listener: (event: InAppMessageEvent) => void
@@ -61,6 +75,91 @@ class CustomerIOInAppMessaging implements NativeInAppSpec {
       } catch (error) {
         NativeLoggerListener.warn(
           'Failed to attach in-app event listener:',
+          error
+        );
+        // Return a no-op subscription to maintain backwards compatibility
+        return {
+          remove: () => {},
+          eventType: '',
+          key: 0,
+          subscriber: null as any,
+        } as EventSubscription;
+      }
+    });
+  }
+
+  /**
+   * Registers a listener for Visual Notification Inbox events (action taken,
+   * shown, opened, dismissed).
+   *
+   * While a listener is registered the host owns action navigation: the native
+   * SDK suppresses its default action handling and forwards the event here.
+   * Call `.remove()` on the returned subscription to unregister and restore the
+   * SDK's default behavior.
+   *
+   * @param listener - callback invoked with an {@link InboxMessageEvent}
+   * @returns an EventSubscription; call `.remove()` to stop listening
+   */
+  registerInboxEventListener(
+    listener: (event: InboxMessageEvent) => void
+  ): EventSubscription {
+    const emitter = (data: any) => {
+      // Convert raw native payload to InboxMessageEvent with a parsed message
+      const event = new InboxMessageEvent(
+        data.eventType as InboxEventType,
+        parseInboxMessage(data.message),
+        data.actionName,
+        data.actionValue
+      );
+      listener(event);
+    };
+
+    return withNativeModule((native) => {
+      let registeredNativeForwarder = false;
+      try {
+        // Register the native forwarder with the SDK, then subscribe to the
+        // codegen-generated event emitter.
+        // Wrapped in try-catch due to previous reports of crashes on certain Android architectures.
+        if (this._inboxListenerCount === 0) {
+          native.registerInboxEventListener();
+          registeredNativeForwarder = true;
+        }
+        const subscription = native.onInboxEventReceived(emitter);
+        this._inboxListenerCount += 1;
+
+        // Wrap remove() so unregistering the LAST JS listener also unregisters the native forwarder
+        // (restoring the SDK's default action handling). Guarded so a double remove() cannot
+        // unbalance the count and drop the forwarder while other subscriptions are still live.
+        const originalRemove = subscription.remove.bind(subscription);
+        let removed = false;
+        subscription.remove = () => {
+          if (removed) {
+            return;
+          }
+          removed = true;
+          originalRemove();
+          this._inboxListenerCount -= 1;
+          if (this._inboxListenerCount === 0) {
+            withNativeModule((n) => n.unregisterInboxEventListener());
+          }
+        };
+        return subscription;
+      } catch (error) {
+        // If the forwarder was registered and subscribing then failed, roll it back. Otherwise the
+        // SDK keeps suppressing its own action handling while nothing in JS is listening, so inbox
+        // actions are reported as handled and silently go nowhere.
+        if (registeredNativeForwarder) {
+          try {
+            native.unregisterInboxEventListener();
+          } catch (rollbackError) {
+            NativeLoggerListener.warn(
+              'Failed to roll back inbox listener registration:',
+              rollbackError
+            );
+          }
+        }
+        NativeLoggerListener.warn(
+          'Failed to attach inbox event listener:',
           error
         );
         // Return a no-op subscription to maintain backwards compatibility
@@ -122,6 +221,12 @@ class InAppMessageEvent {
 
 // Export in-app messaging types and components for simplified imports
 export type { InlineInAppMessageViewProps } from './components';
+export type {
+  NotificationInboxBellViewProps,
+  NotificationInboxViewProps,
+} from './components';
+export { NotificationInboxBellView, NotificationInboxView } from './components';
 export { NotificationInbox } from './notification-inbox';
 export type { InboxMessage, NotificationInboxChangeListener } from './types';
+export { InboxEventType, InboxMessageEvent } from './types';
 export { CustomerIOInAppMessaging, InAppMessageEvent, InlineInAppMessageView };

--- a/src/notification-inbox.ts
+++ b/src/notification-inbox.ts
@@ -46,7 +46,7 @@ export type NotificationInboxSpec =
  * Helper function to parse raw inbox message from native layer
  * @internal
  */
-function parseInboxMessage(raw: any): InboxMessage {
+export function parseInboxMessage(raw: any): InboxMessage {
   return {
     queueId: raw.queueId,
     deliveryId: raw.deliveryId ?? undefined,

--- a/src/specs/components/NotificationInboxBellNativeComponent.ts
+++ b/src/specs/components/NotificationInboxBellNativeComponent.ts
@@ -1,0 +1,24 @@
+// React Native docs now recommend Codegen types should be imported from the react-native package
+// But it breaks on Expo and older React Native versions, so we import from react-native/Libraries/Types/CodegenTypes
+// for compatibility with all versions until we can fully migrate to the new import style without breaking older versions
+// https://reactnative.dev/docs/strict-typescript-api#codegen-types-should-now-be-imported-from-the-react-native-package
+
+import type { HostComponent, ViewProps } from 'react-native';
+/* eslint-disable @react-native/no-deep-imports */
+import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
+/** Event data for inbox bell taps. Carries no payload; presence indicates a tap. */
+export interface BellTapEvent {}
+
+/** Props for the native NotificationInboxBell component. */
+export interface NativeProps extends ViewProps {
+  /** Fired when the user taps the bell. Host should present its own inbox UI. */
+  onTap?: DirectEventHandler<BellTapEvent>;
+}
+
+// React Native Codegen automatically generates the native component bridge based on the NativeProps interface.
+// Public view is NotificationInboxBellView in the components directory.
+export default codegenNativeComponent<NativeProps>(
+  'NotificationInboxBellNative'
+) as HostComponent<NativeProps>;

--- a/src/specs/components/NotificationInboxViewNativeComponent.ts
+++ b/src/specs/components/NotificationInboxViewNativeComponent.ts
@@ -1,0 +1,22 @@
+// React Native docs now recommend Codegen types should be imported from the react-native package
+// But it breaks on Expo and older React Native versions, so we import from react-native/Libraries/Types/CodegenTypes
+// for compatibility with all versions until we can fully migrate to the new import style without breaking older versions
+// https://reactnative.dev/docs/strict-typescript-api#codegen-types-should-now-be-imported-from-the-react-native-package
+
+import type { HostComponent, ViewProps } from 'react-native';
+/* eslint-disable @react-native/no-deep-imports */
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
+/**
+ * Props for the native NotificationInboxView component (the Jist-rendered message list).
+ * No required props; the host controls sizing via standard ViewProps style.
+ * Message actions are handled by the existing global InboxEventListener, so this
+ * component needs no per-component action callback.
+ */
+export interface NativeProps extends ViewProps {}
+
+// React Native Codegen automatically generates the native component bridge based on the NativeProps interface.
+// Public view is NotificationInboxView in the components directory.
+export default codegenNativeComponent<NativeProps>(
+  'NotificationInboxViewNative'
+) as HostComponent<NativeProps>;

--- a/src/specs/modules/NativeCustomerIOMessagingInApp.ts
+++ b/src/specs/modules/NativeCustomerIOMessagingInApp.ts
@@ -15,6 +15,13 @@ import type {
 export interface Spec extends TurboModule {
   dismissMessage(): void;
   readonly onInAppEventReceived: EventEmitter<UnsafeObject>;
+  // Notification Inbox event listener methods.
+  // Registers/unregisters a native forwarder with the SDK so inbox events
+  // (action taken, shown, opened, dismissed) are emitted to JS. Distinct from
+  // onInAppEventReceived so inbox events never collide with in-app events.
+  registerInboxEventListener(): void;
+  unregisterInboxEventListener(): void;
+  readonly onInboxEventReceived: EventEmitter<UnsafeObject>;
   // Notification Inbox related methods
   setupInboxListener(): void;
   readonly subscribeToMessagesChanged: EventEmitter<UnsafeObject>;

--- a/src/types/inbox.ts
+++ b/src/types/inbox.ts
@@ -1,0 +1,51 @@
+import type { InboxMessage } from './in-app';
+
+/**
+ * Enum representing the type of event triggered by an inbox event callback.
+ *
+ * Mirrors the native `InboxEventListener` contract on iOS and Android.
+ *
+ * @public
+ */
+export enum InboxEventType {
+  /** A non-dismiss action (e.g. a button/link) was taken on an inbox message. */
+  messageActionTaken = 'messageActionTaken',
+  /** An inbox message was first shown/rendered in the visible inbox view. */
+  messageShown = 'messageShown',
+  /** An inbox message was marked opened (e.g. when the panel opens). */
+  messageOpened = 'messageOpened',
+  /** An inbox message was dismissed/removed from the inbox. */
+  messageDismissed = 'messageDismissed',
+}
+
+/**
+ * Event delivered to a registered inbox event listener.
+ *
+ * `messageActionTaken` carries `actionName`/`actionValue`; the observational
+ * events (`messageShown`, `messageOpened`, `messageDismissed`) carry only the
+ * message.
+ *
+ * @public
+ */
+export class InboxMessageEvent {
+  /** The type of inbox event. */
+  eventType: InboxEventType;
+  /** The inbox message the event relates to. */
+  message: InboxMessage;
+  /** The Jist action name (only present for `messageActionTaken`). */
+  actionName?: string;
+  /** The resolved action value, typically a url (only present for `messageActionTaken`). */
+  actionValue?: string;
+
+  constructor(
+    eventType: InboxEventType,
+    message: InboxMessage,
+    actionName?: string,
+    actionValue?: string
+  ) {
+    this.eventType = eventType;
+    this.message = message;
+    this.actionName = actionName;
+    this.actionValue = actionValue;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './data-pipelines';
 export * from './in-app';
+export * from './inbox';
 export * from './push';


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large cross-platform native UI + event-forwarding surface with behavior change when inbox listeners are registered (SDK suppresses default actions); depends on unreleased or locally pinned MessagingInbox artifacts and new Compose/SwiftUI hosting paths.
> 
> **Overview**
> Adds **native Visual Notification Inbox UI** to the React Native SDK: **`NotificationInboxBellView`** (bell + SDK-owned panel; native overlay under the hood) and **`NotificationInboxView`** (inline Jist message list), wired through Fabric codegen and new Android Compose / iOS SwiftUI hosting (including VC containment and deferred Compose attach).
> 
> Extends **`CustomerIO.inAppMessaging.registerInboxEventListener`** with **`InboxMessageEvent`** / **`InboxEventType`**, native register/unregister on the in-app module, and ref-counted JS subscriptions so the host owns inbox action navigation while a listener is active (SDK default handling is suppressed). Adds Jest coverage for that bridge.
> 
> **Build/integration:** pulls in **`messaging-inbox`** on Android (Compose enabled), **`CustomerIO/MessagingInbox`** on the main pod, documents local **`mavenLocal`** spike setup, example **Visual Inbox** screen, and stops the rich-push pod from compiling the full RN bridge into the NSE.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9059e64d3b382260b4f272c07e517d780ea2c6c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->