### PR TITLE
fix: pin npm to 11.x in the npm deploy job

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -138,8 +138,11 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      # Pinned to the 11.x line rather than @latest. OIDC needs >= 11.5.1, which 11.x satisfies,
+      # while npm 12 requires node >= 22.22.2 and so fails EBADENGINE against the node 20 above.
+      # Raise this deliberately alongside node-version, not by drifting with @latest.
       - name: Install npm 11.5.1+ for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The 6.6.0 deploy created its git tag but never published: `Deploy to npm` failed with `EBADENGINE`.

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

`deploy-sdk.yml` sets up node 20 and then installs npm globally with `@latest`. `npm@latest` is now **12.0.2**, and npm 12 dropped node 20 — so the install fails before publishing starts.

The step exists to get OIDC support, which needs `>= 11.5.1`. `@latest` was therefore asking for more than the job needs, and this would have broken **every** deploy from the day npm 12 shipped, not just this one. Pinning to the 11.x line keeps OIDC working and makes any move to npm 12 a deliberate change alongside `node-version`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to the npm install version in the release workflow; no runtime SDK or auth logic changes.
> 
> **Overview**
> **Fixes SDK npm publish failures** after git tags were created but `Deploy to npm` never ran.
> 
> The `deploy-npm` job still uses **Node 20**, but the global npm install step was changed from `npm@latest` to **`npm@11`**. npm 12 (what `@latest` resolves to now) requires Node ≥ 22.22.2, which triggered **EBADENGINE** before `npm publish` could run. Pinning to the 11.x line keeps **OIDC support** (needs npm ≥ 11.5.1) while staying compatible with Node 20.
> 
> Inline comments in `deploy-sdk.yml` document that npm 12 should only be adopted together with a deliberate `node-version` bump, not via drifting `@latest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a4dc518c896fd941e40adefa3b9f6c76ac18ff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->