### PR TITLE
ci: move iOS sample-app build to macos-26 and drop simulator-runtime download

### DIFF
--- a/.github/workflows/build-sample-app.yml
+++ b/.github/workflows/build-sample-app.yml
@@ -52,7 +52,7 @@ env:
 jobs:
   build-sample-app:
     name: Building ${{ inputs.platform_name }}  ${{ inputs.app_name }} sample app with SDK version ${{ inputs.sdk_version }}
-    runs-on: macos-15
+    runs-on: macos-26
     defaults:
       run:
         working-directory: example # sets working directory for all steps in this job
@@ -238,7 +238,7 @@ jobs:
 
       - name: Setup ${{ inputs.platform_name }} environment for the ${{ inputs.platform }} sample app
         if: ${{ inputs.platform == 'ios' }}
-        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@MacOS-15+iOS-26
+        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
 
       - name: Build and upload ${{ inputs.platform_name }} ${{ inputs.app_name }} sample app via Fastlane
         id: build_app

--- a/.github/workflows/build-sample-app.yml
+++ b/.github/workflows/build-sample-app.yml
@@ -238,7 +238,7 @@ jobs:
 
       - name: Setup ${{ inputs.platform_name }} environment for the ${{ inputs.platform }} sample app
         if: ${{ inputs.platform == 'ios' }}
-        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@macos-26
+        uses: customerio/mobile-ci-tools/github-actions/ios/setup-ios/v1@main
 
       - name: Build and upload ${{ inputs.platform_name }} ${{ inputs.app_name }} sample app via Fastlane
         id: build_app

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   deploy-cocoapods:
     name: Deploy SDK to Cocoapods 
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - name: Checkout existing tag if manually running CI task  

--- a/.github/workflows/deploy-npm.yml
+++ b/.github/workflows/deploy-npm.yml
@@ -18,7 +18,10 @@ env:
 jobs:
   deploy-cocoapods:
     name: Deploy SDK to Cocoapods 
-    runs-on: macos-26
+    # Despite the job name, nothing here touches CocoaPods: the steps are checkout, npm ci and
+    # an npm publish. It does not need a macOS runner, and the macOS pool is capped org-wide.
+    # Job id left alone on purpose — renaming it would change the check name.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Checkout existing tag if manually running CI task  


### PR DESCRIPTION
> ✅ **Unblocked.** [mobile-ci-tools#13](https://github.com/customerio/mobile-ci-tools/pull/13) is merged and the `setup-ios` ref here now points at `@main`, so nothing depends on the transitional `macos-26` branch.

[MBL-2224: Migrate iOS CI to `macos-26` + Xcode 26.6, and stop downloading simulator runtimes we already have](https://linear.app/customerio/issue/MBL-2224/migrate-ios-ci-to-macos-26-xcode-266-and-stop-downloading-simulator)

---

Our iOS jobs spend roughly 157 minutes of macOS runner time a week downloading a simulator runtime that is not on the image, is not needed, and is never used — these jobs produce device archives and touch no simulator at all.

Moves the macOS runner from 15 to 26 and repins the shared iOS setup to a version that does not perform that download.

Also moves the npm deploy job to ubuntu. Despite its name it never invokes `pod` — it checks out, runs `npm ci` and publishes — so it does not belong on the org-capped macOS pool.