### PR TITLE
fix: update Customer.io iOS SDK to 4.7.1

### DIFF
--- a/.github/workflows/auto-update-native-sdks.yml
+++ b/.github/workflows/auto-update-native-sdks.yml
@@ -239,7 +239,9 @@ jobs:
             echo "📝 Updating iOS SDK version to $IOS_VERSION"
             # Update the cioNativeiOSSdkVersion in package.json
             sed -i "s/\"cioNativeiOSSdkVersion\": *\".*\"/\"cioNativeiOSSdkVersion\": \"= $IOS_VERSION\"/" package.json
-            echo "✅ iOS version updated"
+            # Keep the sample app's Live Activities widget pods in sync with cioNativeiOSSdkVersion
+            sed -i "s/pod cio_pod, '.*'/pod cio_pod, '$IOS_VERSION'/" example/ios/Podfile
+            echo "✅ iOS version updated in package.json and the sample app"
           fi
           
           # Update Android version if needed  
@@ -384,6 +386,7 @@ jobs:
           
           if [[ "$IOS_UPDATED" == "true" ]]; then
             DESCRIPTION+="- \`package.json\` - Updated \`cioNativeiOSSdkVersion\` to \`= $NEW_IOS\`
+          - \`example/ios/Podfile\` - Updated the Live Activities widget pods to \`$NEW_IOS\`
           "
           fi
           

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ customerio.reactnative.kotlinVersion=2.1.20
 customerio.reactnative.compileSdkVersion=36
 customerio.reactnative.targetSdkVersion=36
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=4.20.0
+customerio.reactnative.cioSDKVersionAndroid=4.20.1

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -94,6 +94,6 @@ target "LiveActivityWidget" do
   # A widget extension cannot link the wrapper pod, so it names the rendering pods itself.
   # Keep the version in step with package.json's cioNativeiOSSdkVersion.
   %w[CustomerIOLiveActivitiesTemplates CustomerIOLiveActivitiesAttributes].each do |cio_pod|
-    pod cio_pod, '4.7.1'
+    pod cio_pod, '4.7.2'
   end
 end

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -94,6 +94,6 @@ target "LiveActivityWidget" do
   # A widget extension cannot link the wrapper pod, so it names the rendering pods itself.
   # Keep the version in step with package.json's cioNativeiOSSdkVersion.
   %w[CustomerIOLiveActivitiesTemplates CustomerIOLiveActivitiesAttributes].each do |cio_pod|
-    pod cio_pod, '4.7.0'
+    pod cio_pod, '4.7.1'
   end
 end

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 4.7.1",
+  "cioNativeiOSSdkVersion": "= 4.7.2",
   "cioiOSFirebaseWrapperSdkVersion": "= 1.0.0",
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 4.7.0",
+  "cioNativeiOSSdkVersion": "= 4.7.1",
   "cioiOSFirebaseWrapperSdkVersion": "= 1.0.0",
   "files": [
     "src",


### PR DESCRIPTION
Bumps the pinned native iOS SDK from 4.7.0 to 4.7.1 across every place a version is declared.

- `package.json` `cioNativeiOSSdkVersion` (drives both podspecs)
- `example/ios/Podfile` (sample app)

The sample-app pin belongs to the Live Activities widget extension, which cannot link the wrapper pod and so names the rendering pods itself. It was added after `auto-update-native-sdks.yml` was written, so the automation never moved it — this PR also teaches that workflow about it.

Android stays at 4.20.0, already the latest release.

> [!NOTE]
> The umbrella `CustomerIO` pod is still publishing 4.7.1 to CocoaPods trunk (the 4.7.1 deploy tagged the release but its CocoaPods job failed part-way; all 12 sub-pods are at 4.7.1, the umbrella spec is not yet). `pod install` checks will fail until it lands, then need a re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bumps and CI sed steps only; no changes to SDK bridge or app runtime logic.
> 
> **Overview**
> **Bumps pinned Customer.io native SDK versions** — iOS `cioNativeiOSSdkVersion` and the sample **Live Activities** widget pods move from **4.7.0** to **4.7.2**; Android `customerio.reactnative.cioSDKVersionAndroid` moves from **4.20.0** to **4.20.1**.
> 
> **Fixes native SDK automation** so iOS updates also rewrite `pod cio_pod, '…'` lines in `example/ios/Podfile` (widget extension pins that were added after the workflow was written). Auto-generated PR descriptions now list that file when iOS is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e19b83299cc22fa8feaa198a986b153afee9e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->