### PR TITLE
feat!: require iOS 15 (MBL-1773)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
           node-version: '20'
       - run: npm ci
 
+      - name: Verify iOS deployment target manifests
+        run: npm test -- --runInBand __tests__/ios-deployment-target-manifests.test.ts
+
       - name: Compile
         run: npm run typescript
 

--- a/__tests__/ios-deployment-target-manifests.test.ts
+++ b/__tests__/ios-deployment-target-manifests.test.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('iOS deployment target manifests', () => {
+  it('enforces iOS 15 without lowering React Native higher floors', () => {
+    const repositoryRoot = path.resolve(__dirname, '..');
+    const expectedManifests = new Set([
+      'customerio-reactnative-richpush.podspec',
+      'customerio-reactnative.podspec',
+    ]);
+    const discoveredManifests = new Set(
+      fs
+        .readdirSync(repositoryRoot)
+        .filter((fileName) => fileName.endsWith('.podspec'))
+    );
+
+    expect(discoveredManifests).toEqual(expectedManifests);
+
+    const expectedFloorDeclaration =
+      'minimum_ios_version = [min_ios_version_supported, "15.0"]';
+
+    for (const manifest of expectedManifests) {
+      const contents = fs.readFileSync(
+        path.join(repositoryRoot, manifest),
+        'utf8'
+      );
+      expect(contents).toContain(expectedFloorDeclaration);
+      expect(contents).toContain(
+        '.map { |version| Pod::Version.new(version) }'
+      );
+      expect(contents).toContain('    .max');
+      expect(contents).toContain(
+        's.platforms    = { :ios => minimum_ios_version }'
+      );
+    }
+  });
+});

--- a/customerio-reactnative-richpush.podspec
+++ b/customerio-reactnative-richpush.podspec
@@ -11,7 +11,11 @@ Pod::Spec.new do |s|
   s.homepage     = package["homepage"]
   s.license      = package["license"]
   s.authors      = package["author"]
-  s.platforms    = { :ios => min_ios_version_supported }
+  minimum_ios_version = [min_ios_version_supported, "15.0"]
+    .map { |version| Pod::Version.new(version) }
+    .max
+    .to_s
+  s.platforms    = { :ios => minimum_ios_version }
 
   s.source       = { :git => "https://github.com/customerio/customerio-ios.git", :tag => "#{s.version}" }
 

--- a/customerio-reactnative.podspec
+++ b/customerio-reactnative.podspec
@@ -11,7 +11,11 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported }
+  minimum_ios_version = [min_ios_version_supported, "15.0"]
+    .map { |version| Pod::Version.new(version) }
+    .max
+    .to_s
+  s.platforms    = { :ios => minimum_ios_version }
   s.source       = { :git => "https://github.com/customerio/customerio-ios.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/wrappers/**/*.{h,m,mm,swift}"

--- a/ios/wrappers/inbox/ReactNotificationInboxView.swift
+++ b/ios/wrappers/inbox/ReactNotificationInboxView.swift
@@ -6,8 +6,8 @@ import UIKit
 /// React Native wrapper hosting the SwiftUI `NotificationInboxView` (the Jist-rendered message
 /// list) inside a `UIHostingController`. No events; sizing is driven by the JS `style` prop.
 /// Message actions are handled by the existing global InboxEventListener.
-/// No `@available` annotation, matching `ReactInlineMessageView`: the native list view is iOS 13+,
-/// so the pod's own floor (`min_ios_version_supported`) governs.
+/// No `@available` annotation, matching `ReactInlineMessageView`: the podspec enforces the
+/// Customer.io iOS 15 floor while preserving a higher minimum required by React Native.
 @objc(ReactNotificationInboxView)
 class ReactNotificationInboxView: NSObject {
     private weak var containerView: UIView?


### PR DESCRIPTION
## What changed

- make both published podspecs select max(React Native minimum iOS version, 15.0)
- add a focused Jest policy test, including the max-floor behavior
- run that policy test in the existing CI test job
- correct a stale iOS compatibility comment

## Validation

- focused Jest policy test passed
- TypeScript, full ESLint, actionlint, Ruby syntax, and npm publish dry-run passed
- real CocoaPods evaluation passed for host floors 13.4, 15.1, 15.10, and 16.0
- Fable exact-diff review and independent root verification completed

## Known unrelated boundary

The current main sample generated Pods project represents customerio-reactnative as an empty aggregate, so the full sample app reaches compile and then cannot import customerio_reactnative. The production podspec floor evaluates correctly and its dependency aggregate builds. This PR does not claim to fix that existing sample-generation issue.

## Release boundary

This is a breaking iOS package contract and must ship only in the coordinated major release owned by MBL-2235. Generated transitive Pods target normalization and hosted Xcode 27 proof belong to MBL-2278.

Linear: https://linear.app/customerio/issue/MBL-1773/support-xcode-27-decide-and-validate-the-minimum-ios-deployment-target