### PR TITLE
fix: update Customer.io native SDKs (iOS 4.7.5, Android 4.20.2)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ customerio.reactnative.kotlinVersion=2.1.20
 customerio.reactnative.compileSdkVersion=36
 customerio.reactnative.targetSdkVersion=36
 customerio.reactnative.minSdkVersion=21
-customerio.reactnative.cioSDKVersionAndroid=4.20.1
+customerio.reactnative.cioSDKVersionAndroid=4.20.2

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -109,6 +109,6 @@ target "LiveActivityWidget" do
   # A widget extension cannot link the wrapper pod, so it names the rendering pods itself.
   # Keep the version in step with package.json's cioNativeiOSSdkVersion.
   %w[CustomerIOLiveActivitiesTemplates CustomerIOLiveActivitiesAttributes].each do |cio_pod|
-    pod cio_pod, '4.7.2'
+    pod cio_pod, '4.7.5'
   end
 end

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "./package.json": "./package.json"
   },
-  "cioNativeiOSSdkVersion": "= 4.7.2",
+  "cioNativeiOSSdkVersion": "= 4.7.5",
   "cioiOSFirebaseWrapperSdkVersion": "= 1.0.0",
   "files": [
     "src",


### PR DESCRIPTION
## Summary

Updates the pinned Customer.io native SDKs so the wrapper picks up in-app **multi-app support** (the app identifier header for app filtering).

- **iOS**: 4.7.2 → [4.7.5](https://github.com/customerio/customerio-ios/releases/tag/4.7.5)
- **Android**: 4.20.1 → [4.20.2](https://github.com/customerio/customerio-android/releases/tag/4.20.2)

Ticket: [INAPP-14655](https://linear.app/customerio/issue/INAPP-14655/mobile-add-app-identifier-header-for-app-filtering)

## Native changes picked up

**iOS**
- [4.7.5](https://github.com/customerio/customerio-ios/releases/tag/4.7.5) — In-App: added multi-app support ([#1210](https://github.com/customerio/customerio-ios/issues/1210))
- [4.7.4](https://github.com/customerio/customerio-ios/releases/tag/4.7.4) — compose notification center delegates ([#1211](https://github.com/customerio/customerio-ios/issues/1211))
- [4.7.3](https://github.com/customerio/customerio-ios/releases/tag/4.7.3) — prioritize SDK background work ([#1198](https://github.com/customerio/customerio-ios/issues/1198))

**Android**
- [4.20.2](https://github.com/customerio/customerio-android/releases/tag/4.20.2) — In-App: added multi-app support ([#812](https://github.com/customerio/customerio-android/issues/812))

## Files changed

- `package.json` — `cioNativeiOSSdkVersion` → `= 4.7.5`
- `example/ios/Podfile` — Live Activities widget pods → `4.7.5` (kept in step with `cioNativeiOSSdkVersion`)
- `android/gradle.properties` — `customerio.reactnative.cioSDKVersionAndroid` → `4.20.2`

No wrapper API changes; `cioiOSFirebaseWrapperSdkVersion` is unchanged.

## Validation

- `npm ci`, `npm run typecheck`, `npm run lint`, `npm test` (4/4) — all pass
- **Android**: `:customerio-reactnative:dependencies --configuration releaseCompileClasspath` resolves the full graph at `4.20.2` (datapipelines, messaging-push-fcm, messaging-in-app, messaging-inbox, location, geofence, base, core) — `BUILD SUCCESSFUL`
- **iOS**: `pod install` in `example/ios` resolves every CIO pod at `4.7.5`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk dependency version bumps with no wrapper API or business-logic changes; only pins newer native SDK releases.
> 
> **Overview**
> Bumps the pinned Customer.io native SDK versions to pick up in-app multi-app support (app identifier header for app filtering).
> 
> - **iOS**: `4.7.2` → `4.7.5` in `package.json` (`cioNativeiOSSdkVersion`) and the example app's `LiveActivityWidget` pods.
> - **Android**: `4.20.1` → `4.20.2` in `android/gradle.properties` (`customerio.reactnative.cioSDKVersionAndroid`).
> 
> No wrapper API changes; `cioiOSFirebaseWrapperSdkVersion` remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a09604dd991083bdc8bcc5abcf4381e376bc4f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->