### PR TITLE
ci: pin semantic-release and changelog preset versions

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -41,9 +41,12 @@ jobs:
         uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4.2.0
         id: semantic-release
         with:
-          semantic_version: latest
+          # Both pinned deliberately. The conventionalcommits 10.x line renders through
+          # @conventional-changelog/template, which needs conventional-changelog-writer@9;
+          # every released semantic-release resolves writer@8, so 10.x cannot render here.
+          semantic_version: 25.0.9
           extra_plugins: |
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@9.3.1
             @semantic-release/github
             @semantic-release/exec
         env:


### PR DESCRIPTION
Unblocks the 6.6.3 release. `Deploy SDK` failed on the #638 merge ([run 32482771165](https://github.com/customerio/customerio-reactnative/actions/runs/32482771165)) and no tag was created, so nothing shipped.

No Linear ticket — CI hotfix. Same fix as customerio-android#817, but the analysis below was reproduced independently against this repo; where it disagrees with that PR, the differences are called out.

## What broke

`extra_plugins` installs `conventional-changelog-conventionalcommits` **unpinned**, so every run resolves npm's newest at that moment. Since preset `10.0.0` (2026-06-26) the preset renders through `@conventional-changelog/template`, which requires `conventional-changelog-writer@9`. No released semantic-release resolves writer@9:

| package | writer range |
|---|---|
| `semantic-release@25.0.9` → `release-notes-generator@^14.1.0` | — |
| `@semantic-release/release-notes-generator@14.1.0` | `^8.0.0` |
| `@semantic-release/release-notes-generator@14.1.1` | `^8.0.0` |
| `@semantic-release/release-notes-generator@15.0.0-beta.1` | `^8.0.0` |

`semantic-release@26.0.0-beta.1` also depends on `release-notes-generator@^14.1.0`, so **bumping semantic-release cannot fix this.**

## Reproduction

Replicated the action's tree locally (`semantic-release@25.0.9` + preset, calling `generateNotes` with #638's actual commit):

| preset | resolved template | result |
|---|---|---|
| **9.3.1** | none | ✅ renders correct notes |
| 10.2.1 | 1.4.0 | ⚠️ empty notes, no error |
| 10.3.0 | 1.4.0 | ⚠️ empty notes, no error |
| 10.4.0 | 1.4.0 | ❌ throws — matches CI byte-for-byte |

The 10.4.0 failure reproduces the CI error string exactly:

```
Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer ..."
```

**Two refinements to the Android PR's account.** It attributes the hard throw to `@conventional-changelog/template@1.4.0` alone; in fact template 1.4.0 is necessary but not sufficient — presets 10.2.1 and 10.3.0 resolve that same 1.4.0 and stay silent, because only 10.4.0 routes through the `dist/legacy.js` guard where the throw lives. And "pinning anywhere in 10.x does not work" is right about the outcome but not the failure mode: 10.0.0–10.3.0 don't throw, they silently emit header-only notes. Preset 10.4.0 and template 1.4.0 were published seconds apart (21:37:10Z and 21:37:06Z on 2026-08-18), so the practical timeline in that PR still holds.

## Why it surfaced on this merge

Nothing in this repo changed — `deploy-sdk.yml` and `.releaserc.json` were untouched. The preset reinstalls unpinned on every run, and the previous `Deploy SDK` run (2026-08-19) carried only `ci:` commits, so semantic-release found nothing releasable and exited **before** `generateNotes`. #638 was the first releasable commit after preset 10.4.0 shipped.

## The silent phase is visible in our own CHANGELOG

`CHANGELOG.md` is unedited machine output, and the boundary lands exactly on preset 10.0.0 (2026-06-26):

| release | date | `###` sections |
|---|---|---|
| 6.6.2 | 2026-08-07 | **0** |
| 6.6.1 | 2026-07-30 | **0** |
| 6.6.0 | 2026-07-30 | **0** |
| 6.5.2 | 2026-06-23 | 1 |

Those three GitHub Release pages read fine only because they were edited by hand afterward. Empty notes never blocked a release — a *crashing* notes step is a different failure.

## Why the tag "failed"

It never got that far. `generateNotes` sits upstream of tagging, so the exception aborted the run before `prepare`/`publish`:

```
Completed step "verifyRelease"
Start step "generateNotes"
Failed step "generateNotes"      <- no prepare, no publish, no tag
```

Confirmed clean: no `6.6.3` git tag, and npm `latest` is still `6.6.2`. Nothing to roll back.

## The fix

Pin the preset to `9.3.1` — the last version with no `@conventional-changelog/template` dependency at all (its only dep is `compare-func`), so it renders on writer@8, which is what we actually resolve. This is the last known-good combination: 9.3.1 was published 2026-03-29 and 10.0.0 on 2026-06-26, so every release in that window resolved it unpinned, including 6.5.0/6.5.1/6.5.2, which all rendered correct notes through this same pipeline.

`extra_plugins` is a plain npm install list, so npm `overrides` aren't available to force a compatible template version instead.

`semantic_version` is pinned in the same change. This is **defensive, not required** for the immediate fix — `latest` already resolves to 25.0.9 today, so it's a no-op right now. It stops the other half of the tree from drifting onto a future semantic-release that ships writer@9, which would break preset 9.3.1's Handlebars templates in the opposite direction. Both halves now move only when we choose to move them.

## Verification

- `generateNotes` reproduction above — fails on the current config, succeeds on the pinned one
- Rendered output on the fixed tree is exactly the notes 6.6.3 should get:

```markdown
## [6.6.3](https://github.com/customerio/customerio-reactnative/compare/6.6.2...6.6.3) (2026-08-21)

### Bug Fixes

* update Customer.io native SDKs (iOS 4.7.5, Android 4.20.2) ([#638](https://github.com/customerio/customerio-reactnative/issues/638)) ([b7b3203](https://github.com/customerio/customerio-reactnative/commit/b7b3203a0f65715131a2d013fecd7e0c1b19134f))
```

- Workflow YAML re-parsed after the edit; `semantic_version` reads as the string `"25.0.9"`, not a float

## Shipping 6.6.3 after this merges

Merging this PR is sufficient — no manual re-run needed. semantic-release analyses every commit since the last tag, not just the pushed one, so the `Deploy SDK` run triggered by this merge will still find #638's `fix:` commit unreleased and cut 6.6.3. The failed run confirms it already reasons over the whole range:

```
Found git tag 6.6.2 associated with version 6.6.2 on branch main
Found 5 commits since last release
```

Do **not** re-run the `Deploy git tag` job on [run 32482771165](https://github.com/customerio/customerio-reactnative/actions/runs/32482771165) — a re-run checks out that run's commit (`b7b3203`), which predates this pin, so it would install the unpinned preset and fail identically. The re-run path documented on the `deploy-npm` job applies only when a tag was created and the npm publish failed, which is not what happened here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that pins release tooling to known-good versions; no application code or security-sensitive logic is modified.
> 
> **Overview**
> Pins the `semantic-release` action to `25.0.9` and the `conventional-changelog-conventionalcommits` preset to `9.3.1` in the `Deploy SDK` workflow. The unpinned preset had started resolving to the `10.x` line, which depends on `conventional-changelog-writer@9` — a version no released `semantic-release` resolves — causing `generateNotes` to fail and blocking git tag creation. This restores a known-good dependency combination so the release pipeline can create tags again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 185296e4d0d11381485aae623e953db59682111c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->