### PR TITLE
test: validate React Native scene host on Xcode 27 (MBL-2234)

### DIFF
--- a/.github/fixtures/react-native-scene/App.tsx
+++ b/.github/fixtures/react-native-scene/App.tsx
@@ -7,6 +7,8 @@ export default function App(): React.JSX.Element {
     const subscription = Linking.addEventListener('url', ({ url }) => {
       if (url === 'https://customer.io/react-native-scene-validation') {
         Linking.openURL('cio-rn-scene-validation://warm-received');
+      } else if (url === 'cio-rn-scene-validation://cold') {
+        Linking.openURL('cio-rn-scene-validation://cold-received');
       }
     });
 

--- a/.github/fixtures/react-native-scene/App.tsx
+++ b/.github/fixtures/react-native-scene/App.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+import { Text, View } from 'react-native';
+import { CioRegion, CustomerIO } from 'customerio-reactnative';
+
+export default function App(): React.JSX.Element {
+  useEffect(() => {
+    CustomerIO.initialize({
+      cdpApiKey: 'scene-validation-key',
+      region: CioRegion.US,
+    });
+  }, []);
+
+  return (
+    <View>
+      <Text>Customer.io React Native scene validation</Text>
+    </View>
+  );
+}

--- a/.github/fixtures/react-native-scene/App.tsx
+++ b/.github/fixtures/react-native-scene/App.tsx
@@ -1,13 +1,21 @@
 import React, { useEffect } from 'react';
-import { Text, View } from 'react-native';
+import { Linking, Text, View } from 'react-native';
 import { CioRegion, CustomerIO } from 'customerio-reactnative';
 
 export default function App(): React.JSX.Element {
   useEffect(() => {
+    const subscription = Linking.addEventListener('url', ({ url }) => {
+      if (url === 'https://customer.io/react-native-scene-validation') {
+        Linking.openURL('cio-rn-scene-validation://received');
+      }
+    });
+
     CustomerIO.initialize({
       cdpApiKey: 'scene-validation-key',
       region: CioRegion.US,
     });
+
+    return () => subscription.remove();
   }, []);
 
   return (

--- a/.github/fixtures/react-native-scene/App.tsx
+++ b/.github/fixtures/react-native-scene/App.tsx
@@ -7,21 +7,12 @@ export default function App(): React.JSX.Element {
     const subscription = Linking.addEventListener('url', ({ url }) => {
       if (url === 'https://customer.io/react-native-scene-validation') {
         Linking.openURL('cio-rn-scene-validation://warm-received');
-      } else if (url === 'cio-rn-scene-validation://cold') {
-        Linking.openURL('cio-rn-scene-validation://cold-received');
       }
     });
 
     CustomerIO.initialize({
       cdpApiKey: 'scene-validation-key',
       region: CioRegion.US,
-    });
-
-    Linking.getInitialURL().then((url) => {
-      if (url === 'cio-rn-scene-validation://cold') {
-        return Linking.openURL('cio-rn-scene-validation://cold-received');
-      }
-      return undefined;
     });
 
     return () => subscription.remove();

--- a/.github/fixtures/react-native-scene/App.tsx
+++ b/.github/fixtures/react-native-scene/App.tsx
@@ -6,13 +6,20 @@ export default function App(): React.JSX.Element {
   useEffect(() => {
     const subscription = Linking.addEventListener('url', ({ url }) => {
       if (url === 'https://customer.io/react-native-scene-validation') {
-        Linking.openURL('cio-rn-scene-validation://received');
+        Linking.openURL('cio-rn-scene-validation://warm-received');
       }
     });
 
     CustomerIO.initialize({
       cdpApiKey: 'scene-validation-key',
       region: CioRegion.US,
+    });
+
+    Linking.getInitialURL().then((url) => {
+      if (url === 'cio-rn-scene-validation://cold') {
+        return Linking.openURL('cio-rn-scene-validation://cold-received');
+      }
+      return undefined;
     });
 
     return () => subscription.remove();

--- a/.github/fixtures/react-native-scene/AppDelegate.swift
+++ b/.github/fixtures/react-native-scene/AppDelegate.swift
@@ -2,10 +2,18 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+  static let sceneConnectionProbeKey = "CIO_RN_SCENE_DID_CONNECT"
+
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    true
+    UserDefaults.standard.set(false, forKey: Self.sceneConnectionProbeKey)
+    DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+      guard UserDefaults.standard.bool(forKey: Self.sceneConnectionProbeKey) else {
+        fatalError("SceneDelegate did not receive willConnectTo")
+      }
+    }
+    return true
   }
 }

--- a/.github/fixtures/react-native-scene/AppDelegate.swift
+++ b/.github/fixtures/react-native-scene/AppDelegate.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    true
+  }
+}

--- a/.github/fixtures/react-native-scene/AppDelegate.swift
+++ b/.github/fixtures/react-native-scene/AppDelegate.swift
@@ -1,6 +1,9 @@
+import CioMessagingPushAPN
 import UIKit
 
 @main
+class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
+
 class AppDelegate: UIResponder, UIApplicationDelegate {
   static let sceneConnectionProbeKey = "CIO_RN_SCENE_DID_CONNECT"
 

--- a/.github/fixtures/react-native-scene/AppDelegate.swift
+++ b/.github/fixtures/react-native-scene/AppDelegate.swift
@@ -7,7 +7,6 @@ class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
 class AppDelegate: UIResponder, UIApplicationDelegate {
   static let sceneConnectionProbeKey = "CIO_RN_SCENE_DID_CONNECT"
   static let warmDeepLinkCountKey = "CIO_RN_WARM_DEEP_LINK_COUNT"
-  static let coldDeepLinkCountKey = "CIO_RN_COLD_DEEP_LINK_COUNT"
 
   func application(
     _ application: UIApplication,
@@ -15,7 +14,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   ) -> Bool {
     UserDefaults.standard.set(false, forKey: Self.sceneConnectionProbeKey)
     UserDefaults.standard.set(0, forKey: Self.warmDeepLinkCountKey)
-    UserDefaults.standard.set(0, forKey: Self.coldDeepLinkCountKey)
     DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
       guard UserDefaults.standard.bool(forKey: Self.sceneConnectionProbeKey) else {
         fatalError("SceneDelegate did not receive willConnectTo")

--- a/.github/fixtures/react-native-scene/AppDelegate.swift
+++ b/.github/fixtures/react-native-scene/AppDelegate.swift
@@ -6,12 +6,14 @@ class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
   static let sceneConnectionProbeKey = "CIO_RN_SCENE_DID_CONNECT"
+  static let deepLinkProbeKey = "CIO_RN_DEEP_LINK_RECEIVED"
 
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     UserDefaults.standard.set(false, forKey: Self.sceneConnectionProbeKey)
+    UserDefaults.standard.set(false, forKey: Self.deepLinkProbeKey)
     DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
       guard UserDefaults.standard.bool(forKey: Self.sceneConnectionProbeKey) else {
         fatalError("SceneDelegate did not receive willConnectTo")

--- a/.github/fixtures/react-native-scene/AppDelegate.swift
+++ b/.github/fixtures/react-native-scene/AppDelegate.swift
@@ -6,14 +6,16 @@ class AppDelegateWithCioIntegration: CioAppDelegateWrapper<AppDelegate> {}
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
   static let sceneConnectionProbeKey = "CIO_RN_SCENE_DID_CONNECT"
-  static let deepLinkProbeKey = "CIO_RN_DEEP_LINK_RECEIVED"
+  static let warmDeepLinkCountKey = "CIO_RN_WARM_DEEP_LINK_COUNT"
+  static let coldDeepLinkCountKey = "CIO_RN_COLD_DEEP_LINK_COUNT"
 
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     UserDefaults.standard.set(false, forKey: Self.sceneConnectionProbeKey)
-    UserDefaults.standard.set(false, forKey: Self.deepLinkProbeKey)
+    UserDefaults.standard.set(0, forKey: Self.warmDeepLinkCountKey)
+    UserDefaults.standard.set(0, forKey: Self.coldDeepLinkCountKey)
     DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
       guard UserDefaults.standard.bool(forKey: Self.sceneConnectionProbeKey) else {
         fatalError("SceneDelegate did not receive willConnectTo")

--- a/.github/fixtures/react-native-scene/AppDelegate.swift
+++ b/.github/fixtures/react-native-scene/AppDelegate.swift
@@ -9,7 +9,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     UserDefaults.standard.set(false, forKey: Self.sceneConnectionProbeKey)
-    DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
       guard UserDefaults.standard.bool(forKey: Self.sceneConnectionProbeKey) else {
         fatalError("SceneDelegate did not receive willConnectTo")
       }

--- a/.github/fixtures/react-native-scene/SceneDelegate.swift
+++ b/.github/fixtures/react-native-scene/SceneDelegate.swift
@@ -41,12 +41,6 @@ class SceneDelegate: RCTDefaultReactNativeFactoryDelegate, UIWindowSceneDelegate
           fatalError("Customer.io warm scene deep link was not delivered exactly once")
         }
       }
-    } else {
-      DispatchQueue.main.asyncAfter(deadline: .now() + 25) {
-        guard UserDefaults.standard.integer(forKey: AppDelegate.coldDeepLinkCountKey) == 1 else {
-          fatalError("Customer.io cold scene deep link was not delivered exactly once")
-        }
-      }
     }
   }
 
@@ -55,8 +49,6 @@ class SceneDelegate: RCTDefaultReactNativeFactoryDelegate, UIWindowSceneDelegate
       switch context.url.absoluteString {
       case "cio-rn-scene-validation://warm-received":
         increment(AppDelegate.warmDeepLinkCountKey)
-      case "cio-rn-scene-validation://cold-received":
-        increment(AppDelegate.coldDeepLinkCountKey)
       default:
         NativeLiveActivities.handleAndRouteWidgetUrl(context.url)
       }

--- a/.github/fixtures/react-native-scene/SceneDelegate.swift
+++ b/.github/fixtures/react-native-scene/SceneDelegate.swift
@@ -1,0 +1,47 @@
+import React
+import ReactAppDependencyProvider
+import React_RCTAppDelegate
+import UIKit
+
+class SceneDelegate: RCTDefaultReactNativeFactoryDelegate, UIWindowSceneDelegate {
+  var window: UIWindow?
+  var reactNativeFactory: RCTReactNativeFactory?
+
+  func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard let windowScene = scene as? UIWindowScene else {
+      return
+    }
+
+    dependencyProvider = RCTAppDependencyProvider()
+    reactNativeFactory = RCTReactNativeFactory(delegate: self)
+    window = UIWindow(windowScene: windowScene)
+
+    reactNativeFactory?.startReactNative(
+      withModuleName: "CioRnSceneHost",
+      in: window,
+      connectionOptions: connectionOptions
+    )
+
+    NSLog("CIO_RN_SCENE_WILL_CONNECT")
+  }
+
+  func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    RCTLinkingManager.scene(scene, openURLContexts: URLContexts)
+  }
+
+  func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+    RCTLinkingManager.scene(scene, continue: userActivity)
+  }
+
+  override func bundleURL() -> URL? {
+    #if DEBUG
+    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+    #else
+    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+    #endif
+  }
+}

--- a/.github/fixtures/react-native-scene/SceneDelegate.swift
+++ b/.github/fixtures/react-native-scene/SceneDelegate.swift
@@ -26,7 +26,7 @@ class SceneDelegate: RCTDefaultReactNativeFactoryDelegate, UIWindowSceneDelegate
       connectionOptions: connectionOptions
     )
 
-    NSLog("CIO_RN_SCENE_WILL_CONNECT")
+    UserDefaults.standard.set(true, forKey: AppDelegate.sceneConnectionProbeKey)
   }
 
   func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/.github/fixtures/react-native-scene/SceneDelegate.swift
+++ b/.github/fixtures/react-native-scene/SceneDelegate.swift
@@ -3,6 +3,7 @@ import React
 import ReactAppDependencyProvider
 import React_RCTAppDelegate
 import UIKit
+import customerio_reactnative
 
 class SceneDelegate: RCTDefaultReactNativeFactoryDelegate, UIWindowSceneDelegate {
   var window: UIWindow?
@@ -26,27 +27,40 @@ class SceneDelegate: RCTDefaultReactNativeFactoryDelegate, UIWindowSceneDelegate
     reactNativeFactory?.startReactNative(
       withModuleName: "CioRnSceneHost",
       in: window,
-      connectionOptions: connectionOptions
+      launchOptions: NativeLiveActivities.reactNativeLaunchOptions(from: connectionOptions)
     )
 
-    DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-      DIGraphShared.shared.deepLinkUtil.handleDeepLink(
-        URL(string: "https://customer.io/react-native-scene-validation")!
-      )
-    }
-    DispatchQueue.main.asyncAfter(deadline: .now() + 25) {
-      guard UserDefaults.standard.bool(forKey: AppDelegate.deepLinkProbeKey) else {
-        fatalError("Customer.io scene deep link did not reach React Native Linking")
+    if connectionOptions.urlContexts.isEmpty {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+        DIGraphShared.shared.deepLinkUtil.handleDeepLink(
+          URL(string: "https://customer.io/react-native-scene-validation")!
+        )
+      }
+      DispatchQueue.main.asyncAfter(deadline: .now() + 25) {
+        guard UserDefaults.standard.integer(forKey: AppDelegate.warmDeepLinkCountKey) == 1 else {
+          fatalError("Customer.io warm scene deep link was not delivered exactly once")
+        }
+      }
+    } else {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 25) {
+        guard UserDefaults.standard.integer(forKey: AppDelegate.coldDeepLinkCountKey) == 1 else {
+          fatalError("Customer.io cold scene deep link was not delivered exactly once")
+        }
       }
     }
   }
 
   func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-    if URLContexts.contains(where: { $0.url.absoluteString == "cio-rn-scene-validation://received" }) {
-      UserDefaults.standard.set(true, forKey: AppDelegate.deepLinkProbeKey)
-      return
+    for context in URLContexts {
+      switch context.url.absoluteString {
+      case "cio-rn-scene-validation://warm-received":
+        increment(AppDelegate.warmDeepLinkCountKey)
+      case "cio-rn-scene-validation://cold-received":
+        increment(AppDelegate.coldDeepLinkCountKey)
+      default:
+        NativeLiveActivities.handleAndRouteWidgetUrl(context.url)
+      }
     }
-    RCTLinkingManager.scene(scene, openURLContexts: URLContexts)
   }
 
   func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
@@ -59,5 +73,10 @@ class SceneDelegate: RCTDefaultReactNativeFactoryDelegate, UIWindowSceneDelegate
     #else
     Bundle.main.url(forResource: "main", withExtension: "jsbundle")
     #endif
+  }
+
+  private func increment(_ key: String) {
+    let defaults = UserDefaults.standard
+    defaults.set(defaults.integer(forKey: key) + 1, forKey: key)
   }
 }

--- a/.github/fixtures/react-native-scene/SceneDelegate.swift
+++ b/.github/fixtures/react-native-scene/SceneDelegate.swift
@@ -1,3 +1,4 @@
+import CioInternalCommon
 import React
 import ReactAppDependencyProvider
 import React_RCTAppDelegate
@@ -27,9 +28,24 @@ class SceneDelegate: RCTDefaultReactNativeFactoryDelegate, UIWindowSceneDelegate
       in: window,
       connectionOptions: connectionOptions
     )
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+      DIGraphShared.shared.deepLinkUtil.handleDeepLink(
+        URL(string: "https://customer.io/react-native-scene-validation")!
+      )
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 25) {
+      guard UserDefaults.standard.bool(forKey: AppDelegate.deepLinkProbeKey) else {
+        fatalError("Customer.io scene deep link did not reach React Native Linking")
+      }
+    }
   }
 
   func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    if URLContexts.contains(where: { $0.url.absoluteString == "cio-rn-scene-validation://received" }) {
+      UserDefaults.standard.set(true, forKey: AppDelegate.deepLinkProbeKey)
+      return
+    }
     RCTLinkingManager.scene(scene, openURLContexts: URLContexts)
   }
 

--- a/.github/fixtures/react-native-scene/SceneDelegate.swift
+++ b/.github/fixtures/react-native-scene/SceneDelegate.swift
@@ -12,6 +12,8 @@ class SceneDelegate: RCTDefaultReactNativeFactoryDelegate, UIWindowSceneDelegate
     willConnectTo session: UISceneSession,
     options connectionOptions: UIScene.ConnectionOptions
   ) {
+    UserDefaults.standard.set(true, forKey: AppDelegate.sceneConnectionProbeKey)
+
     guard let windowScene = scene as? UIWindowScene else {
       return
     }
@@ -25,8 +27,6 @@ class SceneDelegate: RCTDefaultReactNativeFactoryDelegate, UIWindowSceneDelegate
       in: window,
       connectionOptions: connectionOptions
     )
-
-    UserDefaults.standard.set(true, forKey: AppDelegate.sceneConnectionProbeKey)
   }
 
   func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/.github/fixtures/react-native-scene/configure.rb
+++ b/.github/fixtures/react-native-scene/configure.rb
@@ -1,0 +1,12 @@
+require 'xcodeproj'
+
+project_path, app_name = ARGV
+project = Xcodeproj::Project.open(project_path)
+target = project.targets.find { |candidate| candidate.name == app_name }
+raise "missing application target #{app_name}" unless target
+
+group = project.main_group.find_subpath(app_name, true)
+scene_delegate = group.files.find { |file| file.path == 'SceneDelegate.swift' }
+scene_delegate ||= group.new_file('SceneDelegate.swift')
+target.source_build_phase.add_file_reference(scene_delegate, true)
+project.save

--- a/.github/fixtures/react-native-scene/configure.rb
+++ b/.github/fixtures/react-native-scene/configure.rb
@@ -6,7 +6,7 @@ target = project.targets.find { |candidate| candidate.name == app_name }
 raise "missing application target #{app_name}" unless target
 
 group = project.main_group.find_subpath(app_name, true)
-scene_delegate = group.files.find { |file| file.path == 'SceneDelegate.swift' }
-scene_delegate ||= group.new_file('SceneDelegate.swift')
+scene_delegate = group.files.find { |file| File.basename(file.path) == 'SceneDelegate.swift' }
+scene_delegate ||= group.new_file("#{app_name}/SceneDelegate.swift")
 target.source_build_phase.add_file_reference(scene_delegate, true)
 project.save

--- a/.github/fixtures/react-native-scene/configure_podfile.rb
+++ b/.github/fixtures/react-native-scene/configure_podfile.rb
@@ -21,7 +21,7 @@ RUBY
 platform_line = "platform :ios, min_ios_version_supported\n"
 raise 'missing React Native platform declaration' unless podfile.include?(platform_line)
 
-apn_pod = "  pod 'customerio-reactnative', :path => customer_io_package_root, :subspecs => ['apn']\n"
+wrapper_subspecs = "  pod 'customerio-reactnative', :path => customer_io_package_root, :subspecs => ['apn', 'liveactivities']\n"
 post_install_line = "  post_install do |installer|\n"
 raise 'missing React Native post_install block' unless podfile.include?(post_install_line)
 
@@ -46,7 +46,7 @@ podfile.sub!(platform_line, "#{helper}\n#{platform_line}")
 # Keep the wrapper's APN opt-in after use_native_modules!, matching the supported
 # host setup. Adding the subspec first prevents CocoaPods from including the
 # autolinked root spec, leaving the wrapper target with no implementation files.
-podfile.sub!(post_install_line, "#{apn_pod}\n#{post_install_line}")
+podfile.sub!(post_install_line, "#{wrapper_subspecs}\n#{post_install_line}")
 podfile.delete_suffix!(post_install_end)
 podfile << normalizer
 File.write(podfile_path, podfile)

--- a/.github/fixtures/react-native-scene/configure_podfile.rb
+++ b/.github/fixtures/react-native-scene/configure_podfile.rb
@@ -21,10 +21,9 @@ RUBY
 platform_line = "platform :ios, min_ios_version_supported\n"
 raise 'missing React Native platform declaration' unless podfile.include?(platform_line)
 
-target_line = "target 'CioRnSceneHost' do\n"
-raise 'missing React Native application target' unless podfile.include?(target_line)
-
 apn_pod = "  pod 'customerio-reactnative', :path => customer_io_package_root, :subspecs => ['apn']\n"
+post_install_line = "  post_install do |installer|\n"
+raise 'missing React Native post_install block' unless podfile.include?(post_install_line)
 
 post_install_end = <<~'RUBY'
       )
@@ -44,7 +43,10 @@ RUBY
 raise 'unexpected React Native post_install block' unless podfile.end_with?(post_install_end)
 
 podfile.sub!(platform_line, "#{helper}\n#{platform_line}")
-podfile.sub!(target_line, "#{target_line}#{apn_pod}")
+# Keep the wrapper's APN opt-in after use_native_modules!, matching the supported
+# host setup. Adding the subspec first prevents CocoaPods from including the
+# autolinked root spec, leaving the wrapper target with no implementation files.
+podfile.sub!(post_install_line, "#{apn_pod}\n#{post_install_line}")
 podfile.delete_suffix!(post_install_end)
 podfile << normalizer
 File.write(podfile_path, podfile)

--- a/.github/fixtures/react-native-scene/configure_podfile.rb
+++ b/.github/fixtures/react-native-scene/configure_podfile.rb
@@ -2,13 +2,14 @@ podfile_path = ARGV.fetch(0)
 podfile = File.read(podfile_path)
 
 helper = <<~'RUBY'
-  customer_io_package_root = File.dirname(
-    Pod::Executable.execute_command('node', [
-      '-p',
-      "require.resolve('customerio-reactnative/package.json', {paths: [process.argv[1]]})",
+  def node_resolve(script)
+    Pod::Executable.execute_command('node', ['-p',
+      "require.resolve('#{script}', {paths: [process.argv[1]]})",
       __dir__
     ]).strip
-  )
+  end
+
+  customer_io_package_root = File.dirname(node_resolve('customerio-reactnative/package.json'))
   require File.join(customer_io_package_root, 'ios', 'cocoapods_deployment_target')
 
   customer_io_minimum_ios_version = CustomerIO::CocoaPodsDeploymentTarget.maximum(

--- a/.github/fixtures/react-native-scene/configure_podfile.rb
+++ b/.github/fixtures/react-native-scene/configure_podfile.rb
@@ -21,6 +21,11 @@ RUBY
 platform_line = "platform :ios, min_ios_version_supported\n"
 raise 'missing React Native platform declaration' unless podfile.include?(platform_line)
 
+target_line = "target 'CioRnSceneHost' do\n"
+raise 'missing React Native application target' unless podfile.include?(target_line)
+
+apn_pod = "  pod 'customerio-reactnative', :path => customer_io_package_root, :subspecs => ['apn']\n"
+
 post_install_end = <<~'RUBY'
       )
     end
@@ -39,6 +44,7 @@ RUBY
 raise 'unexpected React Native post_install block' unless podfile.end_with?(post_install_end)
 
 podfile.sub!(platform_line, "#{helper}\n#{platform_line}")
+podfile.sub!(target_line, "#{target_line}#{apn_pod}")
 podfile.delete_suffix!(post_install_end)
 podfile << normalizer
 File.write(podfile_path, podfile)

--- a/.github/fixtures/react-native-scene/configure_podfile.rb
+++ b/.github/fixtures/react-native-scene/configure_podfile.rb
@@ -21,7 +21,7 @@ RUBY
 platform_line = "platform :ios, min_ios_version_supported\n"
 raise 'missing React Native platform declaration' unless podfile.include?(platform_line)
 
-wrapper_subspecs = "  pod 'customerio-reactnative', :path => customer_io_package_root, :subspecs => ['apn', 'liveactivities']\n"
+wrapper_subspecs = "  pod 'customerio-reactnative', :path => '../node_modules/customerio-reactnative', :subspecs => ['apn', 'liveactivities']\n"
 post_install_line = "  post_install do |installer|\n"
 raise 'missing React Native post_install block' unless podfile.include?(post_install_line)
 

--- a/.github/fixtures/react-native-scene/configure_podfile.rb
+++ b/.github/fixtures/react-native-scene/configure_podfile.rb
@@ -1,0 +1,43 @@
+podfile_path = ARGV.fetch(0)
+podfile = File.read(podfile_path)
+
+helper = <<~'RUBY'
+  customer_io_package_root = File.dirname(
+    Pod::Executable.execute_command('node', [
+      '-p',
+      "require.resolve('customerio-reactnative/package.json', {paths: [process.argv[1]]})",
+      __dir__
+    ]).strip
+  )
+  require File.join(customer_io_package_root, 'ios', 'cocoapods_deployment_target')
+
+  customer_io_minimum_ios_version = CustomerIO::CocoaPodsDeploymentTarget.maximum(
+    min_ios_version_supported,
+    '15.0'
+  )
+RUBY
+
+platform_line = "platform :ios, min_ios_version_supported\n"
+raise 'missing React Native platform declaration' unless podfile.include?(platform_line)
+
+post_install_end = <<~'RUBY'
+      )
+    end
+  end
+RUBY
+normalizer = <<~'RUBY'
+      )
+
+      CustomerIO::CocoaPodsDeploymentTarget.normalize!(
+        installer,
+        minimum_ios_version: customer_io_minimum_ios_version
+      )
+    end
+  end
+RUBY
+raise 'unexpected React Native post_install block' unless podfile.end_with?(post_install_end)
+
+podfile.sub!(platform_line, "#{helper}\n#{platform_line}")
+podfile.delete_suffix!(post_install_end)
+podfile << normalizer
+File.write(podfile_path, podfile)

--- a/.github/workflows/react-native-scene-validation.yml
+++ b/.github/workflows/react-native-scene-validation.yml
@@ -103,6 +103,7 @@ jobs:
           /usr/libexec/PlistBuddy -c 'Add :CFBundleURLTypes:0 dict' "$plist"
           /usr/libexec/PlistBuddy -c 'Add :CFBundleURLTypes:0:CFBundleURLSchemes array' "$plist"
           /usr/libexec/PlistBuddy -c 'Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string cio-rn-scene-validation' "$plist"
+          /usr/libexec/PlistBuddy -c 'Add :CFBundleURLTypes:0:CFBundleURLSchemes:1 string cio-live-activity' "$plist"
 
           cd "$host"
           bundle install
@@ -140,12 +141,52 @@ jobs:
           fi
 
       - name: Install and launch scene host
+        id: warm-launch
         uses: customerio/mobile-ci-tools/github-actions/ios/launch-simulator-app/v1@main
         with:
           app-path: ${{ runner.temp }}/rn-scene-derived-data/Build/Products/Release-iphonesimulator/${{ env.APP_NAME }}.app
           expected-ios-major: '27'
           survival-seconds: '30'
           log-path: ${{ runner.temp }}/rn-scene-launch.log
+
+      - name: Cold launch from a Live Activity URL
+        shell: bash
+        env:
+          SIMULATOR_UDID: ${{ steps.warm-launch.outputs.simulator-udid }}
+        run: |
+          set -euo pipefail
+          app_path="$RUNNER_TEMP/rn-scene-derived-data/Build/Products/Release-iphonesimulator/$APP_NAME.app"
+          bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app_path/Info.plist")"
+          executable="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app_path/Info.plist")"
+          log_path="$RUNNER_TEMP/rn-scene-cold-launch.log"
+
+          xcrun simctl boot "$SIMULATOR_UDID" >/dev/null 2>&1 || true
+          xcrun simctl bootstatus "$SIMULATOR_UDID" -b
+          xcrun simctl install "$SIMULATOR_UDID" "$app_path"
+          trap 'xcrun simctl terminate "$SIMULATOR_UDID" "$bundle_id" >/dev/null 2>&1 || true; xcrun simctl uninstall "$SIMULATOR_UDID" "$bundle_id" >/dev/null 2>&1 || true' EXIT
+
+          tracking_url='cio-live-activity://open?cio_delivery_id=scene-validation&cio_redirect=cio-rn-scene-validation%3A%2F%2Fcold'
+          xcrun simctl openurl "$SIMULATOR_UDID" "$tracking_url"
+          sleep 30
+
+          xcrun simctl spawn "$SIMULATOR_UDID" log show \
+            --last 45s \
+            --style compact \
+            --predicate "process == '$executable'" > "$log_path" 2>&1 || true
+
+          process_status="$(/bin/ps -axo state=,comm= | /usr/bin/awk \
+            -v device="/Devices/$SIMULATOR_UDID/" \
+            -v suffix="/$executable" \
+            'index($0, device) && substr($0, length($0) - length(suffix) + 1) == suffix { print }')"
+          if [[ -z "$process_status" || "$process_status" == *$'\n'* ]]; then
+            echo "::error::cold-launched scene host did not remain alive"
+            exit 1
+          fi
+          read -r process_state _ <<< "$process_status"
+          if [[ "$process_state" != [RSIU]* ]]; then
+            echo "::error::cold-launched scene host is not runnable: $process_status"
+            exit 1
+          fi
 
       - name: Upload validation logs
         if: always()

--- a/.github/workflows/react-native-scene-validation.yml
+++ b/.github/workflows/react-native-scene-validation.yml
@@ -99,28 +99,12 @@ jobs:
             build 2>&1 | tee "$RUNNER_TEMP/rn-scene-build.log"
 
       - name: Install and launch scene host
-        id: launch
         uses: customerio/mobile-ci-tools/github-actions/ios/launch-simulator-app/v1@main
         with:
           app-path: ${{ runner.temp }}/rn-scene-derived-data/Build/Products/Release-iphonesimulator/CioRnSceneHost.app
           expected-ios-major: '27'
           survival-seconds: '10'
           log-path: ${{ runner.temp }}/rn-scene-launch.log
-
-      - name: Verify scene connection
-        shell: bash
-        env:
-          BUNDLE_ID: ${{ steps.launch.outputs.bundle-id }}
-          SIMULATOR_UDID: ${{ steps.launch.outputs.simulator-udid }}
-        run: |
-          set -euo pipefail
-          scene_log="$RUNNER_TEMP/rn-scene-callback.log"
-          xcrun simctl spawn "$SIMULATOR_UDID" log show \
-            --last 2m \
-            --style compact \
-            --predicate "process == '$APP_NAME' AND eventMessage CONTAINS 'CIO_RN_SCENE_WILL_CONNECT'" \
-            > "$scene_log"
-          grep -Fq 'CIO_RN_SCENE_WILL_CONNECT' "$scene_log"
 
       - name: Upload validation logs
         if: always()

--- a/.github/workflows/react-native-scene-validation.yml
+++ b/.github/workflows/react-native-scene-validation.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           set -euo pipefail
           npm ci
-          package_name="$(npm pack --silent --pack-destination "$RUNNER_TEMP")"
+          package_name="$(npm pack --silent --pack-destination "$RUNNER_TEMP" | tail -n 1)"
           echo "path=$RUNNER_TEMP/$package_name" >> "$GITHUB_OUTPUT"
 
       - name: Generate RN 0.88 scene host

--- a/.github/workflows/react-native-scene-validation.yml
+++ b/.github/workflows/react-native-scene-validation.yml
@@ -79,6 +79,7 @@ jobs:
 
           cd "$host"
           bundle install
+          bundle exec ruby "$fixture/configure_podfile.rb" ios/Podfile
           bundle exec ruby "$fixture/configure.rb" "ios/$APP_NAME.xcodeproj" "$APP_NAME"
           bundle exec pod install --project-directory=ios
 

--- a/.github/workflows/react-native-scene-validation.yml
+++ b/.github/workflows/react-native-scene-validation.yml
@@ -12,6 +12,8 @@ permissions:
 
 env:
   APP_NAME: CioRnSceneHost
+  REACT_NATIVE_CLI_VERSION: 20.2.0
+  REACT_NATIVE_TEMPLATE_VERSION: 0.83.0-nightly-2026724-ed3802b
   REACT_NATIVE_VERSION: 0.88.0-nightly-20260823-0c7f63a4e
 
 jobs:
@@ -50,17 +52,31 @@ jobs:
         working-directory: ${{ runner.temp }}
         run: |
           set -euo pipefail
-          npx @react-native-community/cli@latest init "$APP_NAME" \
+          npx "@react-native-community/cli@$REACT_NATIVE_CLI_VERSION" init "$APP_NAME" \
             --version "$REACT_NATIVE_VERSION" \
+            --template "@react-native-community/template@$REACT_NATIVE_TEMPLATE_VERSION" \
             --skip-install
           cd "$APP_NAME"
-          npm pkg set "dependencies.react-native=$REACT_NATIVE_VERSION"
+          npm pkg set \
+            "dependencies.react-native=$REACT_NATIVE_VERSION" \
+            "dependencies.@react-native/new-app-screen=$REACT_NATIVE_VERSION"
+          npm pkg set \
+            "devDependencies.@react-native/babel-preset=$REACT_NATIVE_VERSION" \
+            "devDependencies.@react-native/eslint-config=$REACT_NATIVE_VERSION" \
+            "devDependencies.@react-native/jest-preset=$REACT_NATIVE_VERSION" \
+            "devDependencies.@react-native/metro-config=$REACT_NATIVE_VERSION" \
+            "devDependencies.@react-native/typescript-config=$REACT_NATIVE_VERSION"
           npm install
-          installed_version="$(node -p "require('react-native/package.json').version")"
-          if [[ "$installed_version" != "$REACT_NATIVE_VERSION" ]]; then
-            echo "::error::expected react-native $REACT_NATIVE_VERSION, installed $installed_version"
-            exit 1
-          fi
+          for package_name in \
+            react-native \
+            @react-native/new-app-screen \
+            @react-native/babel-preset \
+            @react-native/eslint-config \
+            @react-native/jest-preset \
+            @react-native/metro-config \
+            @react-native/typescript-config; do
+            npm ls --depth=0 "$package_name@$REACT_NATIVE_VERSION" >/dev/null
+          done
           npm install "${{ steps.wrapper.outputs.path }}"
 
       - name: Apply upstream scene host shape
@@ -109,7 +125,7 @@ jobs:
         with:
           app-path: ${{ runner.temp }}/rn-scene-derived-data/Build/Products/Release-iphonesimulator/${{ env.APP_NAME }}.app
           expected-ios-major: '27'
-          survival-seconds: '10'
+          survival-seconds: '30'
           log-path: ${{ runner.temp }}/rn-scene-launch.log
 
       - name: Upload validation logs
@@ -117,6 +133,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: react-native-0.88-scene-validation-logs
-          path: ${{ runner.temp }}/rn-scene-*.log
+          path: |
+            ${{ runner.temp }}/rn-scene-*.log
+            ${{ runner.temp }}/${{ env.APP_NAME }}/package-lock.json
+            ${{ runner.temp }}/${{ env.APP_NAME }}/ios/Podfile.lock
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/react-native-scene-validation.yml
+++ b/.github/workflows/react-native-scene-validation.yml
@@ -1,0 +1,131 @@
+name: React Native scene host validation
+
+on:
+  pull_request:
+    paths:
+      - '.github/fixtures/react-native-scene/**'
+      - '.github/workflows/react-native-scene-validation.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  APP_NAME: CioRnSceneHost
+  REACT_NATIVE_VERSION: 0.88.0-nightly-20260823-0c7f63a4e
+
+jobs:
+  validate:
+    name: RN 0.88 scene host on Xcode 27
+    runs-on: xcode-27
+    timeout-minutes: 60
+
+    steps:
+      - name: Check out React Native SDK
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Report and verify toolchain family
+        uses: customerio/mobile-ci-tools/github-actions/ios/report-toolchain/v1@main
+        with:
+          expected-xcode-major: '27'
+          expected-ios-sdk-major: '27'
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Build wrapper package
+        id: wrapper
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci
+          package_name="$(npm pack --silent --pack-destination "$RUNNER_TEMP")"
+          echo "path=$RUNNER_TEMP/$package_name" >> "$GITHUB_OUTPUT"
+
+      - name: Generate RN 0.88 scene host
+        shell: bash
+        working-directory: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          npx @react-native-community/cli@latest init "$APP_NAME" \
+            --version "$REACT_NATIVE_VERSION" \
+            --skip-install
+          cd "$APP_NAME"
+          npm install
+          npm install "${{ steps.wrapper.outputs.path }}"
+
+      - name: Apply upstream scene host shape
+        shell: bash
+        run: |
+          set -euo pipefail
+          fixture="$GITHUB_WORKSPACE/.github/fixtures/react-native-scene"
+          host="$RUNNER_TEMP/$APP_NAME"
+          cp "$fixture/App.tsx" "$host/App.tsx"
+          cp "$fixture/AppDelegate.swift" "$host/ios/$APP_NAME/AppDelegate.swift"
+          cp "$fixture/SceneDelegate.swift" "$host/ios/$APP_NAME/SceneDelegate.swift"
+
+          plist="$host/ios/$APP_NAME/Info.plist"
+          /usr/libexec/PlistBuddy -c 'Delete :UIApplicationSceneManifest' "$plist" >/dev/null 2>&1 || true
+          /usr/libexec/PlistBuddy -c 'Add :UIApplicationSceneManifest dict' "$plist"
+          /usr/libexec/PlistBuddy -c 'Add :UIApplicationSceneManifest:UISceneConfigurations dict' "$plist"
+          /usr/libexec/PlistBuddy -c 'Add :UIApplicationSceneManifest:UISceneConfigurations:UIWindowSceneSessionRoleApplication array' "$plist"
+          /usr/libexec/PlistBuddy -c 'Add :UIApplicationSceneManifest:UISceneConfigurations:UIWindowSceneSessionRoleApplication:0 dict' "$plist"
+          /usr/libexec/PlistBuddy -c 'Add :UIApplicationSceneManifest:UISceneConfigurations:UIWindowSceneSessionRoleApplication:0:UISceneConfigurationName string Default Configuration' "$plist"
+          # shellcheck disable=SC2016
+          /usr/libexec/PlistBuddy -c 'Add :UIApplicationSceneManifest:UISceneConfigurations:UIWindowSceneSessionRoleApplication:0:UISceneDelegateClassName string $(PRODUCT_MODULE_NAME).SceneDelegate' "$plist"
+
+          cd "$host"
+          bundle install
+          bundle exec ruby "$fixture/configure.rb" "ios/$APP_NAME.xcodeproj" "$APP_NAME"
+          bundle exec pod install --project-directory=ios
+
+      - name: Build scene host
+        shell: bash
+        run: |
+          set -o pipefail
+          host="$RUNNER_TEMP/$APP_NAME"
+          xcodebuild \
+            -workspace "$host/ios/$APP_NAME.xcworkspace" \
+            -scheme "$APP_NAME" \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath "$RUNNER_TEMP/rn-scene-derived-data" \
+            CODE_SIGNING_ALLOWED=NO \
+            build 2>&1 | tee "$RUNNER_TEMP/rn-scene-build.log"
+
+      - name: Install and launch scene host
+        id: launch
+        uses: customerio/mobile-ci-tools/github-actions/ios/launch-simulator-app/v1@main
+        with:
+          app-path: ${{ runner.temp }}/rn-scene-derived-data/Build/Products/Release-iphonesimulator/CioRnSceneHost.app
+          expected-ios-major: '27'
+          survival-seconds: '10'
+          log-path: ${{ runner.temp }}/rn-scene-launch.log
+
+      - name: Verify scene connection
+        shell: bash
+        env:
+          BUNDLE_ID: ${{ steps.launch.outputs.bundle-id }}
+          SIMULATOR_UDID: ${{ steps.launch.outputs.simulator-udid }}
+        run: |
+          set -euo pipefail
+          scene_log="$RUNNER_TEMP/rn-scene-callback.log"
+          xcrun simctl spawn "$SIMULATOR_UDID" log show \
+            --last 2m \
+            --style compact \
+            --predicate "process == '$APP_NAME' AND eventMessage CONTAINS 'CIO_RN_SCENE_WILL_CONNECT'" \
+            > "$scene_log"
+          grep -Fq 'CIO_RN_SCENE_WILL_CONNECT' "$scene_log"
+
+      - name: Upload validation logs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: react-native-0.88-scene-validation-logs
+          path: ${{ runner.temp }}/rn-scene-*.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/react-native-scene-validation.yml
+++ b/.github/workflows/react-native-scene-validation.yml
@@ -103,7 +103,6 @@ jobs:
           /usr/libexec/PlistBuddy -c 'Add :CFBundleURLTypes:0 dict' "$plist"
           /usr/libexec/PlistBuddy -c 'Add :CFBundleURLTypes:0:CFBundleURLSchemes array' "$plist"
           /usr/libexec/PlistBuddy -c 'Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string cio-rn-scene-validation' "$plist"
-          /usr/libexec/PlistBuddy -c 'Add :CFBundleURLTypes:0:CFBundleURLSchemes:1 string cio-live-activity' "$plist"
 
           cd "$host"
           bundle install
@@ -148,39 +147,6 @@ jobs:
           expected-ios-major: '27'
           survival-seconds: '30'
           log-path: ${{ runner.temp }}/rn-scene-launch.log
-
-      - name: Cold launch from a Live Activity URL
-        shell: bash
-        env:
-          SIMULATOR_UDID: ${{ steps.warm-launch.outputs.simulator-udid }}
-        run: |
-          set -euo pipefail
-          app_path="$RUNNER_TEMP/rn-scene-derived-data/Build/Products/Release-iphonesimulator/$APP_NAME.app"
-          bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app_path/Info.plist")"
-          executable="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app_path/Info.plist")"
-
-          xcrun simctl boot "$SIMULATOR_UDID" >/dev/null 2>&1 || true
-          xcrun simctl bootstatus "$SIMULATOR_UDID" -b
-          xcrun simctl install "$SIMULATOR_UDID" "$app_path"
-          trap 'xcrun simctl terminate "$SIMULATOR_UDID" "$bundle_id" >/dev/null 2>&1 || true; xcrun simctl uninstall "$SIMULATOR_UDID" "$bundle_id" >/dev/null 2>&1 || true' EXIT
-
-          tracking_url='cio-live-activity://open?cio_delivery_id=scene-validation&cio_redirect=cio-rn-scene-validation%3A%2F%2Fcold'
-          xcrun simctl openurl "$SIMULATOR_UDID" "$tracking_url"
-          sleep 30
-
-          process_status="$(/bin/ps -axo state=,comm= | /usr/bin/awk \
-            -v device="/Devices/$SIMULATOR_UDID/" \
-            -v suffix="/$executable" \
-            'index($0, device) && substr($0, length($0) - length(suffix) + 1) == suffix { print }')"
-          if [[ -z "$process_status" || "$process_status" == *$'\n'* ]]; then
-            echo "::error::cold-launched scene host did not remain alive"
-            exit 1
-          fi
-          read -r process_state _ <<< "$process_status"
-          if [[ "$process_state" != [RSIU]* ]]; then
-            echo "::error::cold-launched scene host is not runnable: $process_status"
-            exit 1
-          fi
 
       - name: Upload validation logs
         if: always()

--- a/.github/workflows/react-native-scene-validation.yml
+++ b/.github/workflows/react-native-scene-validation.yml
@@ -98,6 +98,11 @@ jobs:
           /usr/libexec/PlistBuddy -c 'Add :UIApplicationSceneManifest:UISceneConfigurations:UIWindowSceneSessionRoleApplication:0:UISceneConfigurationName string Default Configuration' "$plist"
           # shellcheck disable=SC2016
           /usr/libexec/PlistBuddy -c 'Add :UIApplicationSceneManifest:UISceneConfigurations:UIWindowSceneSessionRoleApplication:0:UISceneDelegateClassName string $(PRODUCT_MODULE_NAME).SceneDelegate' "$plist"
+          /usr/libexec/PlistBuddy -c 'Delete :CFBundleURLTypes' "$plist" >/dev/null 2>&1 || true
+          /usr/libexec/PlistBuddy -c 'Add :CFBundleURLTypes array' "$plist"
+          /usr/libexec/PlistBuddy -c 'Add :CFBundleURLTypes:0 dict' "$plist"
+          /usr/libexec/PlistBuddy -c 'Add :CFBundleURLTypes:0:CFBundleURLSchemes array' "$plist"
+          /usr/libexec/PlistBuddy -c 'Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string cio-rn-scene-validation' "$plist"
 
           cd "$host"
           bundle install

--- a/.github/workflows/react-native-scene-validation.yml
+++ b/.github/workflows/react-native-scene-validation.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   APP_NAME: CioRnSceneHost
   REACT_NATIVE_CLI_VERSION: 20.2.0
-  REACT_NATIVE_TEMPLATE_VERSION: 0.83.0-nightly-2026724-ed3802b
+  REACT_NATIVE_TEMPLATE_VERSION: 0.87.0
   REACT_NATIVE_VERSION: 0.88.0-nightly-20260823-0c7f63a4e
 
 jobs:
@@ -119,6 +119,21 @@ jobs:
             -derivedDataPath "$RUNNER_TEMP/rn-scene-derived-data" \
             CODE_SIGNING_ALLOWED=NO \
             build 2>&1 | tee "$RUNNER_TEMP/rn-scene-build.log"
+
+      - name: Validate built scene manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          plist="$RUNNER_TEMP/rn-scene-derived-data/Build/Products/Release-iphonesimulator/$APP_NAME.app/Info.plist"
+          test -f "$plist"
+          scene_class="$(/usr/libexec/PlistBuddy \
+            -c 'Print :UIApplicationSceneManifest:UISceneConfigurations:UIWindowSceneSessionRoleApplication:0:UISceneDelegateClassName' \
+            "$plist")"
+          # shellcheck disable=SC2016
+          if [[ "$scene_class" != '$(PRODUCT_MODULE_NAME).SceneDelegate' ]]; then
+            echo "::error::unexpected built scene delegate class: $scene_class"
+            exit 1
+          fi
 
       - name: Install and launch scene host
         uses: customerio/mobile-ci-tools/github-actions/ios/launch-simulator-app/v1@main

--- a/.github/workflows/react-native-scene-validation.yml
+++ b/.github/workflows/react-native-scene-validation.yml
@@ -54,7 +54,13 @@ jobs:
             --version "$REACT_NATIVE_VERSION" \
             --skip-install
           cd "$APP_NAME"
+          npm pkg set "dependencies.react-native=$REACT_NATIVE_VERSION"
           npm install
+          installed_version="$(node -p "require('react-native/package.json').version")"
+          if [[ "$installed_version" != "$REACT_NATIVE_VERSION" ]]; then
+            echo "::error::expected react-native $REACT_NATIVE_VERSION, installed $installed_version"
+            exit 1
+          fi
           npm install "${{ steps.wrapper.outputs.path }}"
 
       - name: Apply upstream scene host shape
@@ -86,7 +92,7 @@ jobs:
       - name: Build scene host
         shell: bash
         run: |
-          set -o pipefail
+          set -euo pipefail
           host="$RUNNER_TEMP/$APP_NAME"
           xcodebuild \
             -workspace "$host/ios/$APP_NAME.xcworkspace" \
@@ -101,7 +107,7 @@ jobs:
       - name: Install and launch scene host
         uses: customerio/mobile-ci-tools/github-actions/ios/launch-simulator-app/v1@main
         with:
-          app-path: ${{ runner.temp }}/rn-scene-derived-data/Build/Products/Release-iphonesimulator/CioRnSceneHost.app
+          app-path: ${{ runner.temp }}/rn-scene-derived-data/Build/Products/Release-iphonesimulator/${{ env.APP_NAME }}.app
           expected-ios-major: '27'
           survival-seconds: '10'
           log-path: ${{ runner.temp }}/rn-scene-launch.log

--- a/.github/workflows/react-native-scene-validation.yml
+++ b/.github/workflows/react-native-scene-validation.yml
@@ -158,7 +158,6 @@ jobs:
           app_path="$RUNNER_TEMP/rn-scene-derived-data/Build/Products/Release-iphonesimulator/$APP_NAME.app"
           bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app_path/Info.plist")"
           executable="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app_path/Info.plist")"
-          log_path="$RUNNER_TEMP/rn-scene-cold-launch.log"
 
           xcrun simctl boot "$SIMULATOR_UDID" >/dev/null 2>&1 || true
           xcrun simctl bootstatus "$SIMULATOR_UDID" -b
@@ -168,11 +167,6 @@ jobs:
           tracking_url='cio-live-activity://open?cio_delivery_id=scene-validation&cio_redirect=cio-rn-scene-validation%3A%2F%2Fcold'
           xcrun simctl openurl "$SIMULATOR_UDID" "$tracking_url"
           sleep 30
-
-          xcrun simctl spawn "$SIMULATOR_UDID" log show \
-            --last 45s \
-            --style compact \
-            --predicate "process == '$executable'" > "$log_path" 2>&1 || true
 
           process_status="$(/bin/ps -axo state=,comm= | /usr/bin/awk \
             -v device="/Devices/$SIMULATOR_UDID/" \

--- a/.github/workflows/react-native-scene-validation.yml
+++ b/.github/workflows/react-native-scene-validation.yml
@@ -129,8 +129,7 @@ jobs:
           scene_class="$(/usr/libexec/PlistBuddy \
             -c 'Print :UIApplicationSceneManifest:UISceneConfigurations:UIWindowSceneSessionRoleApplication:0:UISceneDelegateClassName' \
             "$plist")"
-          # shellcheck disable=SC2016
-          if [[ "$scene_class" != '$(PRODUCT_MODULE_NAME).SceneDelegate' ]]; then
+          if [[ "$scene_class" != "$APP_NAME.SceneDelegate" ]]; then
             echo "::error::unexpected built scene delegate class: $scene_class"
             exit 1
           fi


### PR DESCRIPTION
## Test only, do not merge

Validates production #641 against an exact React Native 0.88 nightly scene host on the Xcode 27 runner.

The workflow pins the CLI, compatible stable template, React Native package, and companion `@react-native/*` packages. It installs the autolinked wrapper plus APN and Live Activities subspecs, keeps the real `CioAppDelegateWrapper`, uploads both lockfiles, and validates the built scene manifest.

The behavioral check requires an SDK-triggered warm URL to reach React Native Linking exactly once. The scene host also compiles and calls the production cold connection-options helper, but the simulator does not provide a terminated `simctl openurl` through `connectionOptions.urlContexts`. A real cold Live Activity tap therefore remains in the physical-device matrix rather than being claimed here.

This is simulator evidence only. After the hosted evidence and independent review are recorded, close this PR without merging.