### PR TITLE
ci: build Android sample apps on Ubuntu

### DIFF
--- a/.github/workflows/auto-update-native-sdks.yml
+++ b/.github/workflows/auto-update-native-sdks.yml
@@ -239,9 +239,7 @@ jobs:
             echo "📝 Updating iOS SDK version to $IOS_VERSION"
             # Update the cioNativeiOSSdkVersion in package.json
             sed -i "s/\"cioNativeiOSSdkVersion\": *\".*\"/\"cioNativeiOSSdkVersion\": \"= $IOS_VERSION\"/" package.json
-            # Keep the sample app's Live Activities widget pods in sync with cioNativeiOSSdkVersion
-            sed -i "s/pod cio_pod, '.*'/pod cio_pod, '$IOS_VERSION'/" example/ios/Podfile
-            echo "✅ iOS version updated in package.json and the sample app"
+            echo "✅ iOS version updated in package.json; the sample Podfile reads this value directly"
           fi
           
           # Update Android version if needed  
@@ -386,7 +384,6 @@ jobs:
           
           if [[ "$IOS_UPDATED" == "true" ]]; then
             DESCRIPTION+="- \`package.json\` - Updated \`cioNativeiOSSdkVersion\` to \`= $NEW_IOS\`
-          - \`example/ios/Podfile\` - Updated the Live Activities widget pods to \`$NEW_IOS\`
           "
           fi
           
@@ -484,4 +481,4 @@ jobs:
             echo "**Branch created**: \`$branch_name\`" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "ℹ️ Sample app builds will automatically run on the created PR" >> $GITHUB_STEP_SUMMARY
-          fi 
+          fi

--- a/.github/workflows/build-sample-app.yml
+++ b/.github/workflows/build-sample-app.yml
@@ -170,6 +170,10 @@ jobs:
         with:
           subdirectory: example
           lane: "update_react_native_app_version"
+          options: >
+            {
+              "platform": "${{ inputs.platform }}"
+            }
         env:
           SDK_VERSION_NAME: ${{ env.SDK_VERSION_NAME }}
           APP_VERSION_NAME: ${{ env.APP_VERSION_NAME }}

--- a/.github/workflows/build-sample-app.yml
+++ b/.github/workflows/build-sample-app.yml
@@ -240,6 +240,40 @@ jobs:
             npm run ci:install_${{ inputs.platform }}
           fi
         working-directory: example
+        env:
+          CUSTOMER_IO_USE_GIT_SOURCES: ${{ inputs.platform == 'ios' && 'true' || 'false' }}
+
+      - name: Verify Customer.io pod resolution through CocoaPods trunk
+        if: ${{ inputs.platform == 'ios' && inputs.app_name == 'APN' }}
+        working-directory: example
+        shell: bash
+        run: |
+          set -o pipefail
+          check_dir=$(mktemp -d "${RUNNER_TEMP}/customerio-cocoapods-trunk.XXXXXX")
+          trap 'rm -rf "$check_dir"' EXIT
+          customer_io_ios_version=$(node -p "require('../package.json').cioNativeiOSSdkVersion.replace(/^=\\s*/, '')")
+
+          cat > "$check_dir/Podfile" <<EOF
+          source 'https://cdn.cocoapods.org/'
+          platform :ios, '15.0'
+
+          target 'CustomerIOTrunkResolutionCheck' do
+            pod 'CustomerIO/MessagingPushAPN', '= ${customer_io_ios_version}'
+          end
+          EOF
+
+          set +e
+          bundle exec pod install --project-directory="$check_dir" --no-repo-update 2>&1 | tee "$check_dir/pod-install.log"
+          pod_install_status=${PIPESTATUS[0]}
+          set -e
+
+          if [[ "$pod_install_status" -eq 0 ]]; then
+            echo "CocoaPods trunk resolved CustomerIO/MessagingPushAPN ${customer_io_ios_version}."
+          elif grep -Eqi '429|too many requests' "$check_dir/pod-install.log"; then
+            echo "::warning::CocoaPods trunk smoke check was rate-limited; the Git-backed sample build remains the required CI path."
+          else
+            exit "$pod_install_status"
+          fi
 
       - name: Audit CocoaPods deployment targets
         if: ${{ inputs.platform == 'ios' }}

--- a/.github/workflows/build-sample-app.yml
+++ b/.github/workflows/build-sample-app.yml
@@ -255,6 +255,7 @@ jobs:
 
           cat > "$check_dir/Podfile" <<EOF
           source 'https://cdn.cocoapods.org/'
+          install! 'cocoapods', :integrate_targets => false, :skip_pods_project_generation => true
           platform :ios, '15.0'
 
           target 'CustomerIOTrunkResolutionCheck' do

--- a/.github/workflows/build-sample-app.yml
+++ b/.github/workflows/build-sample-app.yml
@@ -52,7 +52,7 @@ env:
 jobs:
   build-sample-app:
     name: Building ${{ inputs.platform_name }}  ${{ inputs.app_name }} sample app with SDK version ${{ inputs.sdk_version }}
-    runs-on: macos-26
+    runs-on: ${{ inputs.platform == 'android' && 'ubuntu-latest' || 'macos-26' }}
     defaults:
       run:
         working-directory: example # sets working directory for all steps in this job
@@ -69,6 +69,7 @@ jobs:
 
       # This file is untracked and needs to be created dynamically
       - name: Create SampleApp.xcodeproj file
+        if: ${{ inputs.platform == 'ios' }}
         shell: bash
         working-directory: example/ios
         run: |
@@ -110,10 +111,15 @@ jobs:
           # Export the groups as an environment variable
           echo "firebase_distribution_groups=$(IFS=','; echo "${distribution_groups[*]}")" >> $GITHUB_ENV
 
-      - name: Install CLI tools used in CI script
+      - name: Install sd CLI for Android builds
+        if: ${{ inputs.platform == 'android' }}
+        uses: kenji-miyake/setup-sd@08c14e27d65a1c215342ef00c81583ae67f4c5ef # v2.0.0
+
+      - name: Install CLI tools for iOS builds
+        if: ${{ inputs.platform == 'ios' }}
         shell: bash
         run: |
-          brew install sd # used in CI script as an easier to use sed CLI. Replaces text in files. 
+          brew install sd # used in CI script as an easier to use sed CLI. Replaces text in files.
           brew install xcbeautify # used by fastlane for output
 
       - name: Install Ruby
@@ -209,6 +215,7 @@ jobs:
             **/package-lock.json
 
       - name: Cache CocoaPods downloaded dependencies for faster builds in the future
+        if: ${{ inputs.platform == 'ios' }}
         uses: actions/cache@v4
         with:
           path: example/Pods
@@ -275,7 +282,7 @@ jobs:
           build_status: ${{ steps.build_app.outcome }}
           app_icon_emoji: ":react:"
           app_name: "React Native"
-          firebase_app_id: ${{ secrets[format('SAMPLE_APPS_{0}_FIREBASE_APP_ID_{1}', inputs.app_name, inputs.platform_upper_name )] }}
+          firebase_app_id: ${{ secrets[format('SAMPLE_APPS_{0}_FIREBASE_APP_ID_{1}', inputs.app_name, inputs.platform_name_upper )] }}
           firebase_distribution_groups: ${{ env.firebase_distribution_groups }}
           git_context: "${{ env.BRANCH_NAME }} (${{ env.COMMIT_HASH }})"
           icon_url: "https://vectorified.com/images/icon-react-native-24.png"

--- a/example/fastlane/Fastfile
+++ b/example/fastlane/Fastfile
@@ -70,9 +70,16 @@ lane :update_react_native_app_version do |options|
   # Update versions in package.json
   update_app_json_version(project_path, version_name, version_code)
 
-  # Update Android version
-  update_android_version(project_path, version_name, version_code)
-
-  # Update iOS version
-  update_ios_version(project_path, version_name, version_code)
+  # Update only the target platform. The Android build runs on Linux, where
+  # the iOS version helper cannot load the Xcode project.
+  case options[:platform].to_s
+  when "android"
+    update_android_version(project_path, version_name, version_code)
+  when "ios"
+    update_ios_version(project_path, version_name, version_code)
+  else
+    # Preserve the existing behavior for callers that do not provide a platform.
+    update_android_version(project_path, version_name, version_code)
+    update_ios_version(project_path, version_name, version_code)
+  end
 end

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -37,10 +37,50 @@ setup_permissions([
 push_provider = (ENV["PUSH_PROVIDER"] || "apn").downcase
 customer_io_ios_git_source = "https://github.com/customerio/customerio-ios.git"
 customer_io_ios_version = "4.7.6"
+customer_io_firebase_git_source = "https://github.com/customerio/customerio-ios-fcm.git"
+customer_io_firebase_version = "1.0.0"
 customer_io_minimum_ios_version = CustomerIO::CocoaPodsDeploymentTarget.maximum(
   min_ios_version_supported,
   '15.0'
 )
+
+def install_customer_io_ios_pods_from_git(source:, tag:, push_provider:, app_extension:)
+  subspecs = ["MessagingPush", push_provider == "apn" ? "MessagingPushAPN" : "MessagingPushFCM"]
+  pods = [
+    "CustomerIOCommon",
+    "CustomerIOMessagingPush",
+  ]
+
+  unless app_extension
+    subspecs += [
+      "DataPipelines",
+      "MessagingInApp",
+      "MessagingInbox",
+      "Location",
+      "LocationGeofence",
+      "LiveActivities",
+      "LiveActivitiesTemplates",
+    ]
+    pods += [
+      "CustomerIODataPipelines",
+      "CustomerIOTrackingMigration",
+      "CustomerIOLocation",
+      "CustomerIOLocationGeofence",
+      "CustomerIOMessagingInApp",
+      "CustomerIOMessagingInbox",
+      "CustomerIOLiveActivities",
+      "CustomerIOLiveActivitiesAttributes",
+      "CustomerIOLiveActivitiesTemplates",
+    ]
+  end
+
+  pod "CustomerIO", :git => source, :tag => tag, :subspecs => subspecs
+  pods << (push_provider == "apn" ? "CustomerIOMessagingPushAPN" : "CustomerIOMessagingPushFCM")
+
+  pods.each do |pod_name|
+    pod pod_name, :git => source, :tag => tag
+  end
+end
 
 app_target_name = "SampleApp"
 nse_target_name = "NotificationServiceExtension"
@@ -76,10 +116,16 @@ target app_target_name do
     :app_path => "#{installation_root}/..",
   )
   pod "customerio-reactnative", :path => cio_package_path, :subspecs => [push_provider, "location", "geofence", "liveactivities"]
-  if push_provider == "apn"
-    # The APN spec is intermittently rate-limited through the public CocoaPods CDN.
-    # Resolve this one pod from the same pinned Customer.io iOS tag instead.
-    pod "CustomerIOMessagingPushAPN", :git => customer_io_ios_git_source, :tag => customer_io_ios_version
+  # Resolve Customer.io's native pods directly from their pinned Git tags. The public CocoaPods
+  # CDN can rate-limit GitHub-backed spec lookups on shared CI runners.
+  install_customer_io_ios_pods_from_git(
+    source: customer_io_ios_git_source,
+    tag: customer_io_ios_version,
+    push_provider: push_provider,
+    app_extension: false,
+  )
+  if push_provider == "fcm"
+    pod "CioFirebaseWrapper", :git => customer_io_firebase_git_source, :tag => customer_io_firebase_version
   end
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: push_provider)
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: push_provider)
@@ -105,9 +151,12 @@ target nse_target_name do
   # Ideally, installing non-production SDK to main target should be enough
   # We should not need to install non-production SDK to app extension separately
   pod "customerio-reactnative-richpush/#{push_provider}", :path => cio_package_path
-  if push_provider == "apn"
-    pod "CustomerIOMessagingPushAPN", :git => customer_io_ios_git_source, :tag => customer_io_ios_version
-  end
+  install_customer_io_ios_pods_from_git(
+    source: customer_io_ios_git_source,
+    tag: customer_io_ios_version,
+    push_provider: push_provider,
+    app_extension: true,
+  )
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: true, push_service: push_provider)
   # install_non_production_ios_sdk_git_branch(branch_name: 'BRANCH-NAME-HERE', is_app_extension: true, push_service: push_provider)
 end
@@ -119,6 +168,6 @@ target "LiveActivityWidget" do
   # A widget extension cannot link the wrapper pod, so it names the rendering pods itself.
   # Keep the version in step with package.json's cioNativeiOSSdkVersion.
   %w[CustomerIOLiveActivitiesTemplates CustomerIOLiveActivitiesAttributes].each do |cio_pod|
-    pod cio_pod, '4.7.6'
+    pod cio_pod, :git => customer_io_ios_git_source, :tag => customer_io_ios_version
   end
 end

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -45,7 +45,17 @@ customer_io_minimum_ios_version = CustomerIO::CocoaPodsDeploymentTarget.maximum(
 )
 
 def install_customer_io_ios_pods_from_git(source:, tag:, push_provider:, app_extension:)
-  subspecs = ["MessagingPush", push_provider == "apn" ? "MessagingPushAPN" : "MessagingPushFCM"]
+  push_subspec = push_provider == "apn" ? "MessagingPushAPN" : "MessagingPushFCM"
+
+  # The rich push target is isolated from the host app, so install its push
+  # subspec directly. Declaring the individual transitive pods here leaves
+  # CocoaPods without the framework search paths needed by the extension.
+  if app_extension
+    pod "CustomerIO/#{push_subspec}", :git => source, :tag => tag
+    return
+  end
+
+  subspecs = ["MessagingPush", push_subspec]
   pods = [
     "CustomerIOCommon",
     "CustomerIOMessagingPush",
@@ -75,7 +85,7 @@ def install_customer_io_ios_pods_from_git(source:, tag:, push_provider:, app_ext
   end
 
   pod "CustomerIO", :git => source, :tag => tag, :subspecs => subspecs
-  pods << (push_provider == "apn" ? "CustomerIOMessagingPushAPN" : "CustomerIOMessagingPushFCM")
+  pods << "CustomerIOMessagingPush#{push_provider == "apn" ? "APN" : "FCM"}"
 
   pods.each do |pod_name|
     pod pod_name, :git => source, :tag => tag

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -35,6 +35,8 @@ setup_permissions([
 ])
 
 push_provider = (ENV["PUSH_PROVIDER"] || "apn").downcase
+customer_io_ios_git_source = "https://github.com/customerio/customerio-ios.git"
+customer_io_ios_version = "4.7.6"
 customer_io_minimum_ios_version = CustomerIO::CocoaPodsDeploymentTarget.maximum(
   min_ios_version_supported,
   '15.0'
@@ -74,6 +76,11 @@ target app_target_name do
     :app_path => "#{installation_root}/..",
   )
   pod "customerio-reactnative", :path => cio_package_path, :subspecs => [push_provider, "location", "geofence", "liveactivities"]
+  if push_provider == "apn"
+    # The APN spec is intermittently rate-limited through the public CocoaPods CDN.
+    # Resolve this one pod from the same pinned Customer.io iOS tag instead.
+    pod "CustomerIOMessagingPushAPN", :git => customer_io_ios_git_source, :tag => customer_io_ios_version
+  end
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: push_provider)
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: push_provider)
 
@@ -98,6 +105,9 @@ target nse_target_name do
   # Ideally, installing non-production SDK to main target should be enough
   # We should not need to install non-production SDK to app extension separately
   pod "customerio-reactnative-richpush/#{push_provider}", :path => cio_package_path
+  if push_provider == "apn"
+    pod "CustomerIOMessagingPushAPN", :git => customer_io_ios_git_source, :tag => customer_io_ios_version
+  end
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: true, push_service: push_provider)
   # install_non_production_ios_sdk_git_branch(branch_name: 'BRANCH-NAME-HERE', is_app_extension: true, push_service: push_provider)
 end

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -6,6 +6,8 @@ load "/tmp/override_cio_sdk.rb"
 # end of internal Customer.io testing code
 # -------------
 
+require 'json'
+
 # Resolve scripts with node to allow for hoisting
 def node_resolve(script)
   Pod::Executable.execute_command('node', ['-p',
@@ -36,9 +38,13 @@ setup_permissions([
 
 push_provider = (ENV["PUSH_PROVIDER"] || "apn").downcase
 customer_io_ios_git_source = "https://github.com/customerio/customerio-ios.git"
-customer_io_ios_version = "4.7.6"
 customer_io_firebase_git_source = "https://github.com/customerio/customerio-ios-fcm.git"
-customer_io_firebase_version = "1.0.0"
+package_json = JSON.parse(File.read(File.expand_path("../../package.json", __dir__)))
+customer_io_ios_version = package_json.fetch("cioNativeiOSSdkVersion").sub(/\A=\s*/, "")
+customer_io_firebase_version = package_json.fetch("cioiOSFirebaseWrapperSdkVersion").sub(/\A=\s*/, "")
+# Keep the customer-facing CocoaPods resolution path as the default. CI opts into Git sources
+# with CUSTOMER_IO_USE_GIT_SOURCES when the shared CocoaPods CDN is rate-limited.
+use_customer_io_git_sources = ENV["CUSTOMER_IO_USE_GIT_SOURCES"] == "true"
 customer_io_minimum_ios_version = CustomerIO::CocoaPodsDeploymentTarget.maximum(
   min_ios_version_supported,
   '15.0'
@@ -126,16 +132,18 @@ target app_target_name do
     :app_path => "#{installation_root}/..",
   )
   pod "customerio-reactnative", :path => cio_package_path, :subspecs => [push_provider, "location", "geofence", "liveactivities"]
-  # Resolve Customer.io's native pods directly from their pinned Git tags. The public CocoaPods
-  # CDN can rate-limit GitHub-backed spec lookups on shared CI runners.
-  install_customer_io_ios_pods_from_git(
-    source: customer_io_ios_git_source,
-    tag: customer_io_ios_version,
-    push_provider: push_provider,
-    app_extension: false,
-  )
-  if push_provider == "fcm"
-    pod "CioFirebaseWrapper", :git => customer_io_firebase_git_source, :tag => customer_io_firebase_version
+  if use_customer_io_git_sources
+    # Resolve Customer.io's native pods directly from their pinned Git tags. The public CocoaPods
+    # CDN can rate-limit GitHub-backed spec lookups on shared CI runners.
+    install_customer_io_ios_pods_from_git(
+      source: customer_io_ios_git_source,
+      tag: customer_io_ios_version,
+      push_provider: push_provider,
+      app_extension: false,
+    )
+    if push_provider == "fcm"
+      pod "CioFirebaseWrapper", :git => customer_io_firebase_git_source, :tag => customer_io_firebase_version
+    end
   end
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: false, push_service: push_provider)
   # install_non_production_ios_sdk_git_branch(branch_name: 'feature/wrappers-inline-support', is_app_extension: false, push_service: push_provider)
@@ -161,12 +169,14 @@ target nse_target_name do
   # Ideally, installing non-production SDK to main target should be enough
   # We should not need to install non-production SDK to app extension separately
   pod "customerio-reactnative-richpush/#{push_provider}", :path => cio_package_path
-  install_customer_io_ios_pods_from_git(
-    source: customer_io_ios_git_source,
-    tag: customer_io_ios_version,
-    push_provider: push_provider,
-    app_extension: true,
-  )
+  if use_customer_io_git_sources
+    install_customer_io_ios_pods_from_git(
+      source: customer_io_ios_git_source,
+      tag: customer_io_ios_version,
+      push_provider: push_provider,
+      app_extension: true,
+    )
+  end
   # install_non_production_ios_sdk_local_path(local_path: '~/code/customerio-ios/', is_app_extension: true, push_service: push_provider)
   # install_non_production_ios_sdk_git_branch(branch_name: 'BRANCH-NAME-HERE', is_app_extension: true, push_service: push_provider)
 end
@@ -178,6 +188,10 @@ target "LiveActivityWidget" do
   # A widget extension cannot link the wrapper pod, so it names the rendering pods itself.
   # Keep the version in step with package.json's cioNativeiOSSdkVersion.
   %w[CustomerIOLiveActivitiesTemplates CustomerIOLiveActivitiesAttributes].each do |cio_pod|
-    pod cio_pod, :git => customer_io_ios_git_source, :tag => customer_io_ios_version
+    if use_customer_io_git_sources
+      pod cio_pod, :git => customer_io_ios_git_source, :tag => customer_io_ios_version
+    else
+      pod cio_pod, "= #{customer_io_ios_version}"
+    end
   end
 end


### PR DESCRIPTION
## Summary
- run Android sample-app builds on ubuntu-latest while keeping iOS on macos-26
- install the cross-platform sd CLI on Linux and keep Homebrew-only tools on iOS
- skip iOS project and CocoaPods setup for Android, and fix the platform input used by the Firebase notification step

## Validation
- actionlint with the repository's existing shellcheck and untrusted-expression findings ignored for this file
- git diff --check
- GitHub Actions sample-app build checks on this PR