### PR TITLE
feat: expose Live Activity URL transformation (MBL-2304)

### DIFF
--- a/.maestro/fixtures/react-native-scene/App.tsx
+++ b/.maestro/fixtures/react-native-scene/App.tsx
@@ -6,6 +6,24 @@ import {
   CustomerIO,
 } from 'customerio-reactnative';
 
+async function validateLiveActivityBridge(): Promise<void> {
+  const invalidUrl = 'https://[invalid';
+  const passthrough =
+    await CustomerIO.liveActivities.handleWidgetUrl(invalidUrl);
+  if (passthrough !== invalidUrl) {
+    throw new Error('Live Activity bridge changed an invalid URL');
+  }
+
+  const destinationless = await CustomerIO.liveActivities.handleWidgetUrl(
+    'cio-live-activity://open?cio_delivery_id=scene-e2e-delivery'
+  );
+  if (destinationless !== null) {
+    throw new Error(
+      'Live Activity bridge did not map NSNull to JavaScript null'
+    );
+  }
+}
+
 export default function App(): React.JSX.Element {
   const [receivedUrl, setReceivedUrl] = useState<string | null>(null);
   const [initialized, setInitialized] = useState(false);
@@ -25,10 +43,11 @@ export default function App(): React.JSX.Element {
           ios: { sound: true, badge: true },
         })
       )
-      .then((status) => {
+      .then(async (status) => {
         if (status !== CioPushPermissionStatus.Granted) {
           throw new Error(`Push permission is ${status}`);
         }
+        await validateLiveActivityBridge();
         setInitialized(true);
       })
       .catch((error: unknown) => {

--- a/README.md
+++ b/README.md
@@ -151,7 +151,23 @@ func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)
 Do not also pass those URLs to `RCTLinkingManager`. The helper already publishes them through
 React Native Linking, and forwarding them again can deliver the same URL twice.
 
-Android needs no equivalent step. Expo apps use the [config plugin](https://github.com/customerio/customerio-expo-plugin) instead of these manual snippets; scene support depends on the Expo version supported by the plugin.
+Android needs no equivalent native step.
+
+For Expo Router, unwrap the URL once in the app's top-level `app/+native-intent.tsx` file:
+
+```typescript
+import { CustomerIO } from 'customerio-reactnative';
+
+export async function redirectSystemPath({ path }: { path: string }) {
+  return CustomerIO.liveActivities.handleWidgetUrl(path);
+}
+```
+
+This reports the opened event, returns the customer's destination, preserves ordinary URLs, and
+returns `null` for a Customer.io tracking URL without a destination. Do not also call the helper
+from a `Linking` listener because processing the same tracking URL twice reports two opened events.
+Expo apps without Expo Router can apply the helper once in their central `Linking` initial-URL and
+subscription pipeline.
 
 ---
 

--- a/__tests__/live-activity-widget-url.test.ts
+++ b/__tests__/live-activity-widget-url.test.ts
@@ -1,0 +1,61 @@
+jest.mock('react-native', () => ({
+  TurboModuleRegistry: {
+    getEnforcing: jest.fn(),
+  },
+}));
+
+jest.mock('../src/specs/modules/NativeCustomerIOLiveActivities', () => ({
+  __esModule: true,
+  default: {
+    handleWidgetUrl: jest.fn(),
+  },
+}));
+
+import { CustomerIOLiveActivities } from '../src/customerio-liveactivities';
+import NativeModule from '../src/specs/modules/NativeCustomerIOLiveActivities';
+
+const native = NativeModule as unknown as {
+  handleWidgetUrl: jest.Mock;
+};
+
+describe('CustomerIOLiveActivities.handleWidgetUrl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the destination produced by the native SDK', async () => {
+    native.handleWidgetUrl.mockResolvedValue('my-app://orders/123');
+
+    await expect(
+      new CustomerIOLiveActivities().handleWidgetUrl(
+        'cio-live-activity://open?cio_redirect=my-app%3A%2F%2Forders%2F123'
+      )
+    ).resolves.toBe('my-app://orders/123');
+  });
+
+  it('returns null when the tracking URL has no destination', async () => {
+    native.handleWidgetUrl.mockResolvedValue(null);
+
+    await expect(
+      new CustomerIOLiveActivities().handleWidgetUrl(
+        'cio-live-activity://open?cio_delivery_id=delivery-id'
+      )
+    ).resolves.toBeNull();
+  });
+
+  it('preserves an ordinary URL', async () => {
+    native.handleWidgetUrl.mockResolvedValue('https://example.com');
+
+    await expect(
+      new CustomerIOLiveActivities().handleWidgetUrl('https://example.com')
+    ).resolves.toBe('https://example.com');
+  });
+
+  it('preserves the input when the native bridge cannot transform it', async () => {
+    native.handleWidgetUrl.mockRejectedValue(new Error('bridge unavailable'));
+
+    await expect(
+      new CustomerIOLiveActivities().handleWidgetUrl('not necessarily a URL')
+    ).resolves.toBe('not necessarily a URL');
+  });
+});

--- a/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
+++ b/android/src/main/java/io/customer/reactnative/sdk/liveactivities/NativeLiveActivitiesModule.kt
@@ -45,6 +45,12 @@ class NativeLiveActivitiesModule(
         return module
     }
 
+    override fun handleWidgetUrl(url: String?, promise: Promise?) {
+        // Customer.io Live Activity widget URLs are an iOS-only contract. Preserve every Android
+        // URL so a shared Expo Router redirectSystemPath implementation cannot suppress routing.
+        promise?.resolve(url)
+    }
+
     override fun start(payload: ReadableMap?, promise: Promise?) {
         val module = getPushModule() ?: return promise.rejectNotAvailable()
         try {

--- a/api-extractor-output/customerio-reactnative.api.md
+++ b/api-extractor-output/customerio-reactnative.api.md
@@ -149,6 +149,7 @@ export class CustomerIOInAppMessaging implements NativeInAppSpec {
 // @public
 export class CustomerIOLiveActivities implements NativeLiveActivitiesSpec {
     end(activityId: string, payload?: LiveActivityPayload): Promise<void>;
+    handleWidgetUrl(url: string): Promise<string | null>;
     start(payload: LiveActivityPayload): Promise<string>;
     update(activityId: string, payload: LiveActivityPayload): Promise<void>;
 }

--- a/ios/wrappers/liveactivities/NativeLiveActivities.mm
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.mm
@@ -65,6 +65,16 @@ RCT_EXPORT_MODULE()
   [_swiftBridge end:activityId payload:payload resolve:resolve reject:reject];
 }
 
+- (void)handleWidgetUrl:(NSString *)url
+                resolve:(RCTPromiseResolveBlock)resolve
+                 reject:(RCTPromiseRejectBlock)reject {
+  if (!_swiftBridge) {
+    resolve(url);
+    return;
+  }
+  [_swiftBridge handleWidgetUrl:url resolve:resolve reject:reject];
+}
+
 // Export class factory function for React Native component registration
 Class<RCTBridgeModule> NativeCustomerIOLiveActivitiesCls(void) {
   return RCTNativeLiveActivities.class;

--- a/ios/wrappers/liveactivities/NativeLiveActivities.swift
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.swift
@@ -208,10 +208,20 @@ public class NativeLiveActivities: NSObject {
         }
     }
 
+    @objc(handleWidgetUrl:resolve:reject:)
+    public func handleWidgetUrl(
+        _ urlString: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject _: @escaping RCTPromiseRejectBlock
+    ) {
+        guard let url = URL(string: urlString) else {
+            resolve(urlString)
+            return
+        }
+        resolve(Self.handleWidgetUrl(url)?.absoluteString)
+    }
+
     /// Report an `opened` metric for a tapped Live Activity and return the deep link to route to.
-    ///
-    /// Not exposed to JavaScript: a Live Activity tap arrives through the app's native URL/scene
-    /// entry point, so call this from there (see the sample app's `AppDelegate`).
     ///
     /// - Returns: the customer's redirect URL for a Customer.io widget URL (`nil` when it carries
     ///   none), or `url` unchanged when it isn't a Customer.io URL — so existing routing still

--- a/ios/wrappers/liveactivities/NativeLiveActivities.swift
+++ b/ios/wrappers/liveactivities/NativeLiveActivities.swift
@@ -218,7 +218,13 @@ public class NativeLiveActivities: NSObject {
             resolve(urlString)
             return
         }
-        resolve(Self.handleWidgetUrl(url)?.absoluteString)
+        guard let destination = Self.handleWidgetUrl(url) else {
+            // React Native maps NSNull to JavaScript null. Resolving Swift nil produces undefined,
+            // which would violate the public Promise<string | null> contract.
+            resolve(NSNull())
+            return
+        }
+        resolve(destination.absoluteString)
     }
 
     /// Report an `opened` metric for a tapped Live Activity and return the deep link to route to.

--- a/src/customerio-liveactivities.ts
+++ b/src/customerio-liveactivities.ts
@@ -26,6 +26,28 @@ interface NativeLiveActivitiesSpec extends Omit<
  */
 export class CustomerIOLiveActivities implements NativeLiveActivitiesSpec {
   /**
+   * Report an opened Live Activity and return the URL the app should route.
+   *
+   * Customer.io tracking URLs are unwrapped to their destination after attribution is recorded.
+   * A tracking URL without a destination returns `null`; any other URL is returned unchanged.
+   * This method never rejects, so it can safely compose with Expo Router's
+   * `redirectSystemPath` hook. On Android it is a pass-through.
+   *
+   * Use this in exactly one URL-routing layer. Calling it more than once for the same Customer.io
+   * tracking URL reports more than one opened event.
+   *
+   * @param url - The incoming URL from the host's linking lifecycle.
+   * @returns The URL to route, or `null` when the Customer.io URL has no destination.
+   */
+  async handleWidgetUrl(url: string): Promise<string | null> {
+    try {
+      return await NativeModule.handleWidgetUrl(url);
+    } catch {
+      return url;
+    }
+  }
+
+  /**
    * Start a built-in-template activity.
    *
    * @param payload - Template payload; `payload.type` selects the template.

--- a/src/specs/modules/NativeCustomerIOLiveActivities.ts
+++ b/src/specs/modules/NativeCustomerIOLiveActivities.ts
@@ -15,6 +15,8 @@ import type { UnsafeObject } from 'react-native/Libraries/Types/CodegenTypes';
 type NativeBridgeObject = UnsafeObject;
 
 export interface Spec extends TurboModule {
+  /** Report a Live Activity open and return the destination URL to route. */
+  handleWidgetUrl(url: string): Promise<string | null>;
   /** Start an activity. Resolves with the SDK-minted activity id. */
   start(payload: NativeBridgeObject): Promise<string>;
   /** Replace the whole content-state of a running activity. Pass the full desired state. */


### PR DESCRIPTION
## Summary

- expose `CustomerIO.liveActivities.handleWidgetUrl(url)` to report Live Activity opens and return the destination URL
- preserve ordinary URLs and Android routing, and return JavaScript `null` only for Customer.io tracking URLs without a destination
- make the helper fail open so Expo Router `redirectSystemPath` cannot break an unrelated link
- document exactly-once composition for Expo Router and non-Router Linking integrations

## Dependency

#646 is merged and released in 6.8.0. This PR is the remaining React Native API required by Expo #398; merge and release this PR before updating Expo to that published version.

## Validation

- all focused Jest tests passed
- TypeScript and ESLint passed
- API Extractor passed
- React Native iOS codegen generated the expected Objective-C promise signature
- the CocoaPods `customerio-reactnative` scheme built successfully with the APN sample and Live Activities subspec
- Android `compileDebugKotlin` passed
- exact packed #646/#647 and Expo #398 packages generated, built, installed, and launched an Expo 58 scene host; Maestro verified warm and cold Live Activity destination routing through `+native-intent`
- native iOS SDK tests separately verify opened attribution and destination extraction
