### PR TITLE
chore: pin semantic-release plugin versions

### DIFF
--- a/.github/workflows/deploy-sdk.yml
+++ b/.github/workflows/deploy-sdk.yml
@@ -41,14 +41,18 @@ jobs:
         uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4.2.0
         id: semantic-release
         with:
-          # Both pinned deliberately. The conventionalcommits 10.x line renders through
-          # @conventional-changelog/template, which needs conventional-changelog-writer@9;
+          # Every version here is pinned deliberately. The conventionalcommits 10.x line renders
+          # through @conventional-changelog/template, which needs conventional-changelog-writer@9;
           # every released semantic-release resolves writer@8, so 10.x cannot render here.
+          #
+          # Dependabot cannot see these versions: the `github-actions` ecosystem only resolves
+          # `uses:` refs, and no ecosystem parses `extra_plugins`. An unpinned entry silently
+          # floats to whatever is `latest` at release time, so bump these by hand.
           semantic_version: 25.0.9
           extra_plugins: |
             conventional-changelog-conventionalcommits@9.3.1
-            @semantic-release/github
-            @semantic-release/exec
+            @semantic-release/github@12.0.9
+            @semantic-release/exec@7.1.0
         env:
           # Needs to push git commits to repo. Needs write access.
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
## Problem

`deploy-sdk.yml` passes an `extra_plugins` list to `cycjimmy/semantic-release-action`. Unpinned entries there are installed at `latest` **at release time**, so the release pipeline's behaviour changes without any commit to this repo. That has already broken releases twice:

- **[Run 32482771165](https://github.com/customerio/customerio-reactnative/actions/runs/32482771165) (Aug 21)** — failed in `generateNotes`, before any tag was cut: `Missing helper: conventional-changelog-conventionalcommits requires conventional-changelog-writer@9 or newer`. The unpinned preset had floated into the incompatible 10.x line. Fixed by db93d2d (#639); 6.6.3 released cleanly ~40 minutes later, no version burned.
- **[Run 30559203085](https://github.com/customerio/customerio-reactnative/actions/runs/30559203085) (Jul 30)** — the tag job succeeded and *then* `Deploy to npm` failed at "Install npm 11.5.1+ for OIDC support" with `EBADENGINE ... npm@12.0.2 Required: node ^22 || ^24 || >=26, Actual: node v20.20.2` — same class of defect (`npm install -g npm@latest` under a pinned Node 20). Fixed by 7c6f6cd (#626) and 21feea4 (#635).

Both incidents are already fixed. What remained is that #639 pinned only `semantic_version` and the changelog preset — `@semantic-release/github` and `@semantic-release/exec` were still unpinned, leaving the same failure mode live.

## What changed

Pinned the two remaining floating entries to the versions the workflow already resolves today, matching the style of the existing preset pin:

| Plugin | Before | After |
| --- | --- | --- |
| `@semantic-release/github` | unpinned (`latest`) | `12.0.9` |
| `@semantic-release/exec` | unpinned (`latest`) | `7.1.0` |

Both are the current `latest` on npm and both predate the most recent successful release run ([33205068114](https://github.com/customerio/customerio-reactnative/actions/runs/33205068114), 6.10.0, Aug 28), so this pins to what CI is already installing — no behaviour change, just determinism. Peer ranges (`semantic-release: >=24.1.0`) are satisfied by the pinned `semantic_version: 25.0.9`.

`@semantic-release/changelog` and `@semantic-release/git` are also used by `.releaserc.json` but are **not** listed here — they are bundled by `cycjimmy/semantic-release-action` itself, which is already SHA-pinned, so they are deterministic.

## Dependabot blind spot

`.github/dependabot.yml` watches only `github-actions`, which resolves `uses:` refs and nothing else. No Dependabot ecosystem parses `extra_plugins`, so these versions are invisible to automated updates and will go stale with no PR.

I did **not** change `dependabot.yml`: there is no configuration that would actually cover these strings (adding an `npm` ecosystem would open PRs for the SDK's own dependency tree and still would not read the workflow). Instead the constraint is recorded as a comment next to the pins so the next person bumps them deliberately.

## Out of scope

- The orphan `6.6.0` tag (npm jumps 6.5.2 → 6.6.1) is intentionally left alone.
- The post-release sample-app job is unchanged. This repo is the healthy reference for MBL-2324 — it takes an `sdk_version` input rather than using `git describe`, and that behaviour is deliberately preserved.

Fixes MBL-2324
